### PR TITLE
[codex] Improve TV selection and history progress

### DIFF
--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -10,6 +10,7 @@ import threading
 import tempfile
 import time
 import re
+import uuid
 import platform
 import shutil
 import sys
@@ -28,6 +29,7 @@ logger = get_logger("player")
 
 _NATURAL_IDLE_RESET_UNTIL = 0.0
 _NATURAL_IDLE_ENSURE_TIMER: threading.Timer | None = None
+_HISTORY_PROGRESS_LAST_PERSIST: dict[str, float] = {}
 
 
 def _idle_dashboard_enabled() -> bool:
@@ -3577,6 +3579,11 @@ def advance_queue_playback(
                     logger.warning("queue_rollback_persist_failed source=auto_next_suppressed error=%s", exc)
                 raise QueueAdvanceSuppressedError("auto-next suppressed after dequeue")
 
+            update_history_progress(
+                prev_now,
+                completed=_history_item_completed(prev_now),
+                force=True,
+            )
             _emit_jellyfin_stopped_from_now(prev_now)
             start_pos = next_item.get("resume_pos") if isinstance(next_item, dict) else None
             try:
@@ -3786,6 +3793,7 @@ def _consume_mpv_queued_next_if_started(
             pass
         return False
 
+    update_history_progress(prev_now, completed=_history_item_completed(prev_now), force=True)
     _emit_jellyfin_stopped_from_now(prev_now)
 
     url = _queue_item_play_url(consumed)
@@ -3816,6 +3824,8 @@ def _consume_mpv_queued_next_if_started(
             now_item["jellyfin_item_id"] = consumed.get("jellyfin_item_id")
         if consumed.get("jellyfin_media_source_id"):
             now_item["jellyfin_media_source_id"] = consumed.get("jellyfin_media_source_id")
+        if consumed.get("history_id"):
+            now_item["history_id"] = consumed.get("history_id")
 
     try:
         pos = props.get("time-pos")
@@ -3825,6 +3835,7 @@ def _consume_mpv_queued_next_if_started(
     except Exception:
         pass
 
+    _add_history_entry(now_item)
     state.set_now_playing(now_item)
     state.set_session_state("playing")
     state.set_pause_reason(None)
@@ -3839,8 +3850,91 @@ def _providers_forced_to_resolve() -> set[str]:
     return {p.strip() for p in raw.split(",") if p.strip()}
 
 
+def _add_history_entry(now: dict) -> None:
+    """Attach one durable history record to a playback instance."""
+    history_id = str(now.get("history_id") or "").strip() or uuid.uuid4().hex
+    now["history_id"] = history_id
+    # Resume paths retain the same history record instead of creating a duplicate.
+    if state.history_contains(history_id):
+        state.history_update(history_id, {"completed": False})
+        return
+    entry = {
+        "history_id": history_id,
+        "ts": int(time.time()),
+        "mode": now.get("mode"),
+        "url": now.get("url"),
+        "title": now.get("title"),
+        "provider": now.get("provider"),
+        "resume_pos": max(0.0, float(now.get("resume_pos") or 0.0)),
+    }
+    for key in ("channel", "jellyfin_item_id", "jellyfin_media_source_id", "thumbnail", "thumbnail_local"):
+        if now.get(key):
+            entry[key] = now[key]
+    state.history_add(entry)
+
+
+def update_history_progress(
+    now: dict | None,
+    *,
+    position_sec: float | None = None,
+    duration_sec: float | None = None,
+    completed: bool | None = None,
+    force: bool = False,
+) -> None:
+    """Persist the last resume position for the active playback history entry."""
+    if not isinstance(now, dict):
+        return
+    history_id = str(now.get("history_id") or "").strip()
+    if not history_id:
+        return
+    now_ts = time.monotonic()
+    if not force and completed is None:
+        last_saved = _HISTORY_PROGRESS_LAST_PERSIST.get(history_id, 0.0)
+        if (now_ts - last_saved) < 5.0:
+            return
+    updates: dict[str, object] = {}
+    if completed is True:
+        updates["resume_pos"] = 0.0
+        updates["completed"] = True
+    elif completed is False:
+        updates["completed"] = False
+    else:
+        raw_pos = position_sec if position_sec is not None else now.get("resume_pos")
+        try:
+            pos = float(raw_pos) if raw_pos is not None else None
+            if pos is not None and pos >= 0:
+                updates["resume_pos"] = pos
+        except Exception:
+            pass
+    raw_duration = duration_sec if duration_sec is not None else now.get("duration_sec")
+    try:
+        duration = float(raw_duration) if raw_duration is not None else None
+        if duration is not None and duration > 0:
+            updates["duration_sec"] = duration
+    except Exception:
+        pass
+    if updates:
+        if state.history_update(history_id, updates):
+            _HISTORY_PROGRESS_LAST_PERSIST[history_id] = now_ts
+
+
+def _history_item_completed(now: dict | None) -> bool:
+    """Return true only when playback reached the actual end of a finite item."""
+    if not isinstance(now, dict):
+        return False
+    try:
+        position = float(now.get("resume_pos"))
+        duration = float(now.get("duration_sec"))
+    except Exception:
+        return False
+    if duration <= 0 or position < 0:
+        return False
+    return position >= (duration * 0.98) or (duration - position) <= 10.0
+
+
 def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mode: str, start_pos: float | None = None):
     """Play a queue item dict or a raw shared URL/text."""
+    update_history_progress(state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None, force=True)
     _mark_playback_transition()
     if isinstance(item_or_text, dict):
         item = item_or_text
@@ -3983,6 +4077,7 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
         "thumbnail": item.get("thumbnail"),
         "thumbnail_local": item.get("thumbnail_local"),
         "channel": item.get("channel"),
+        **({"history_id": item.get("history_id")} if item.get("history_id") else {}),
         **({"jellyfin_item_id": item.get("jellyfin_item_id")} if item.get("jellyfin_item_id") else {}),
         **({"jellyfin_media_source_id": item.get("jellyfin_media_source_id")} if item.get("jellyfin_media_source_id") else {}),
         **({"jellyfin_stream_mode": item.get("jellyfin_stream_mode")} if item.get("jellyfin_stream_mode") else {}),
@@ -3995,28 +4090,12 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
         except Exception:
             pass
 
-
+    _add_history_entry(now)
     state.set_now_playing(now)
     state.set_session_state("playing")
     state.set_pause_reason(None)
     state.set_session_position(float(start_pos) if start_pos is not None else 0.0)
 
-
-    # Record play history
-    state.history_add({
-        "ts": int(time.time()),
-        "mode": mode,
-        "url": raw,
-        "title": title,
-        "provider": provider,
-        **({"channel": item.get("channel")} if item.get("channel") else {}),
-        **({"jellyfin_item_id": item.get("jellyfin_item_id")} if item.get("jellyfin_item_id") else {}),
-        **({"jellyfin_media_source_id": item.get("jellyfin_media_source_id")} if item.get("jellyfin_media_source_id") else {}),
-        **({
-            "thumbnail": item.get("thumbnail"),
-            "thumbnail_local": item.get("thumbnail_local"),
-        } if item.get("thumbnail") else {}),
-    })
 
     # Keep exactly one "up next" item primed in mpv so queue handoff avoids
     # stop/start transitions between plays.
@@ -4035,6 +4114,7 @@ def _handle_playback_idle_no_queue() -> None:
     """Transition app/UI state when playback has ended and queue is empty."""
     global _NATURAL_IDLE_RESET_UNTIL, _NATURAL_IDLE_ENSURE_TIMER
     now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
+    update_history_progress(now, completed=_history_item_completed(now), force=True)
     _emit_jellyfin_stopped_from_now(now)
     # Only clear now-playing when not in a user-closed resumable session.
     if getattr(state, "SESSION_STATE", "idle") != "closed":
@@ -4694,7 +4774,7 @@ def _session_tracker_worker() -> None:
         if not _is_playing():
             continue
         try:
-            props = mpv_get_many(["time-pos", "pause", "playlist-pos", "playlist-count", "path", "core-idle", "eof-reached"])
+            props = mpv_get_many(["time-pos", "duration", "pause", "playlist-pos", "playlist-count", "path", "core-idle", "eof-reached"])
             _consume_mpv_queued_next_if_started(props)
             now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
             if not now:
@@ -4708,9 +4788,16 @@ def _session_tracker_worker() -> None:
                 pos_f = float(pos)
                 updated = dict(now)
                 updated["resume_pos"] = pos_f
+                try:
+                    duration_f = float(props.get("duration"))
+                    if duration_f > 0:
+                        updated["duration_sec"] = duration_f
+                except Exception:
+                    pass
                 state.set_now_playing(updated)
                 state.set_session_position(pos_f)
                 state.set_session_state("paused" if paused else "playing")
+                update_history_progress(updated)
             if not paused:
                 state.set_pause_reason(None)
             _prime_mpv_up_next_from_queue()

--- a/app/relaytv_app/routes.py
+++ b/app/relaytv_app/routes.py
@@ -296,6 +296,8 @@ class PlayNowReq(BaseModel):
     reason: str | None = None
     title: str | None = None
     thumbnail: str | None = None
+    resume_pos: float | None = None
+    history_id: str | None = None
 
 
 class PlayTemporaryReq(BaseModel):
@@ -2568,7 +2570,21 @@ def history_play(req: HistoryPlayReq):
     if not isinstance(url, str) or not url.strip():
         raise HTTPException(status_code=400, detail="history item missing url")
 
-    return play_now(PlayNowReq(url=url.strip(), preserve_current=True, reason="history"))
+    resume_pos = None
+    try:
+        raw_resume = it.get("resume_pos")
+        resume_pos = float(raw_resume) if raw_resume is not None else None
+    except Exception:
+        resume_pos = None
+    return play_now(PlayNowReq(
+        url=url.strip(),
+        preserve_current=True,
+        reason="history",
+        title=str(it.get("title") or "").strip() or None,
+        thumbnail=str(it.get("thumbnail") or "").strip() or None,
+        resume_pos=resume_pos,
+        history_id=str(it.get("history_id") or "").strip() or None,
+    ))
 
 
 def _preserve_current_to_queue_front() -> dict | None:
@@ -2581,11 +2597,16 @@ def _preserve_current_to_queue_front() -> dict | None:
 
     # Capture current position safely.
     pos = None
+    dur = None
     with player.MPV_LOCK:
         try:
             pos = player.mpv_get("time-pos")
         except Exception:
             pos = None
+        try:
+            dur = player.mpv_get("duration")
+        except Exception:
+            dur = None
     try:
         pos_f = float(pos) if pos is not None else None
     except Exception:
@@ -2611,8 +2632,11 @@ def _preserve_current_to_queue_front() -> dict | None:
         preserved["jellyfin_item_id"] = now.get("jellyfin_item_id")
     if isinstance(now.get("jellyfin_media_source_id"), str) and now.get("jellyfin_media_source_id"):
         preserved["jellyfin_media_source_id"] = now.get("jellyfin_media_source_id")
+    if isinstance(now.get("history_id"), str) and now.get("history_id"):
+        preserved["history_id"] = now.get("history_id")
     if pos_f is not None:
         preserved["resume_pos"] = pos_f
+    player.update_history_progress(now, position_sec=pos_f, duration_sec=dur, force=True)
 
     with state.QUEUE_LOCK:
         state.QUEUE.insert(0, preserved)
@@ -2638,7 +2662,24 @@ def play_now(req: PlayNowReq):
     if req.preserve_current and req.preserve_to == "queue_front" and req.resume_current:
         preserved = _preserve_current_to_queue_front()
 
-    now = player.play_item(req.url, use_resolver=True, cec=False, clear_queue=False, mode=(req.reason or "play_now"))
+    if req.title or req.thumbnail or req.resume_pos is not None or req.history_id:
+        item = {"url": req.url}
+        if req.title:
+            item["title"] = req.title
+        if req.thumbnail:
+            item["thumbnail"] = req.thumbnail
+        if req.history_id:
+            item["history_id"] = req.history_id
+        now = player.play_item(
+            item,
+            use_resolver=True,
+            cec=False,
+            clear_queue=False,
+            mode=(req.reason or "play_now"),
+            start_pos=req.resume_pos,
+        )
+    else:
+        now = player.play_item(req.url, use_resolver=True, cec=False, clear_queue=False, mode=(req.reason or "play_now"))
     try:
         title = now.get("title") if isinstance(now, dict) else None
         _push_overlay_toast(
@@ -7358,6 +7399,12 @@ def close():
             player.stop_mpv(restart_splash=_idle_dashboard_enabled_for_player())
 
     if preserve_resume:
+        player.update_history_progress(
+            state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None,
+            position_sec=pos,
+            duration_sec=dur,
+            force=True,
+        )
         _jellyfin_emit_stopped_hint(pos, dur)
     return {
         "status": ("closed" if preserve_resume else "idle"),
@@ -7488,6 +7535,12 @@ def stop():
         state.set_session_state("closed")
         with player.MPV_LOCK:
             player.stop_mpv()
+        player.update_history_progress(
+            state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None,
+            position_sec=pos,
+            duration_sec=dur,
+            force=True,
+        )
         _jellyfin_emit_stopped_hint(pos, dur)
         return {"status": "stopped", "resume_available": bool(state.NOW_PLAYING), "position": pos}
 
@@ -9068,6 +9121,23 @@ def ui():
       border-radius: 22px;
       border: 1px solid rgba(255,255,255,.10);
     }
+    .histProgress{
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 5px;
+      z-index: 3;
+      overflow: hidden;
+      background: rgba(15,23,42,.68);
+      pointer-events: none;
+    }
+    .histProgress > span{
+      display: block;
+      height: 100%;
+      background: #38bdf8;
+      box-shadow: 0 0 10px rgba(56,189,248,.80);
+    }
     .histMeta{
       min-width:0;
       flex: 1 1 auto;
@@ -10341,6 +10411,41 @@ def ui():
 .jfRowsPad{ padding-right: 0; }
 .jfRow{ display:grid; gap: 6px; }
 .jfRowTitle{ font-size: 13px; color: var(--muted2); letter-spacing: .02em; text-transform: uppercase; }
+.jfTvSelectionRow{ gap: 0; }
+.jfTvSelectionBar{
+  width: 100%;
+  min-height: 48px;
+  padding: 10px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(120,180,255,.48);
+  background: linear-gradient(180deg, rgba(30, 64, 175, .46), rgba(15, 23, 42, .58));
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+.jfTvSelectionBar:hover{ border-color: rgba(147,197,253,.84); }
+.jfTvSelectionBar:focus-visible{
+  outline: 2px solid rgba(147,197,253,.95);
+  outline-offset: 2px;
+}
+.jfTvSelectionLabel{
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 15px;
+  font-weight: 700;
+}
+.jfTvSelectionHint{
+  flex: 0 0 auto;
+  color: var(--muted2);
+  font-size: 12px;
+  font-weight: 650;
+}
 .jfScroller{
   display:flex;
   gap:10px;
@@ -10702,6 +10807,12 @@ def ui():
     border-color: rgba(37, 99, 235, .48);
     box-shadow: 0 0 0 2px rgba(59, 130, 246, .16), 0 16px 36px rgba(15, 23, 42, .14);
   }
+  .jfTvSelectionBar{
+    border-color: rgba(37,99,235,.32);
+    background: linear-gradient(180deg, rgba(239,246,255,.98), rgba(219,234,254,.88));
+    color: #0f172a;
+  }
+  .jfTvSelectionBar:hover{ border-color: rgba(37,99,235,.56); }
   .jfThumb{
     background: linear-gradient(180deg, rgba(226, 232, 240, .90), rgba(241, 245, 249, .98));
   }
@@ -11968,6 +12079,7 @@ let __jfTvSeriesId = '';
 let __jfTvSeriesTitle = '';
 let __jfTvSeriesThumb = '';
 let __jfTvSeasonNumber = null;
+let __jfTvSeasonChooserExpanded = false;
 let __jfTvViewMode = 'series';
 let __jfLastFocus = null;
 let __jfAlphaIndicatorTimer = 0;
@@ -12288,11 +12400,13 @@ function _jfOpenSeriesDetailFromRich(rich){
   if (!rich) return;
   const rType = String(rich.type || '').trim().toLowerCase();
   if (rType === 'nav_back') {
+    __jfTvSeasonChooserExpanded = false;
     loadJellyfinTvSeries(false);
     return;
   }
   if (rType === 'season') {
     __jfTvSeasonNumber = Number.isFinite(Number(rich.season_number)) ? Number(rich.season_number) : null;
+    __jfTvSeasonChooserExpanded = false;
     loadJellyfinTvSeriesDetail(rich.series_id || __jfTvSeriesId, {
       title: __jfTvSeriesTitle,
       thumbnail: __jfTvSeriesThumb || rich.thumbnail_local || rich.thumbnail || '',
@@ -12301,6 +12415,7 @@ function _jfOpenSeriesDetailFromRich(rich){
     return;
   }
   if (rType === 'series') {
+    __jfTvSeasonChooserExpanded = true;
     loadJellyfinTvSeriesDetail(rich.item_id, {
       title: rich.title,
       thumbnail: rich.thumbnail_local || rich.thumbnail || '',
@@ -12310,6 +12425,18 @@ function _jfOpenSeriesDetailFromRich(rich){
   }
   // Episodes (and any future non-series entries) should open item detail panel.
   loadJellyfinDetail(rich.item_id);
+}
+
+function _jfToggleTvSeasonChooser(){
+  if (__jfBusy || !__jfTvSeriesId) return;
+  __jfTvSeasonChooserExpanded = !__jfTvSeasonChooserExpanded;
+  loadJellyfinTvSeriesDetail(__jfTvSeriesId, {
+    title: __jfTvSeriesTitle,
+    thumbnail: __jfTvSeriesThumb,
+    thumbnail_local: __jfTvSeriesThumb,
+    chooserExpanded: __jfTvSeasonChooserExpanded,
+    focusChooser: true,
+  });
 }
 
 function _jfIsSeriesNavType(rich){
@@ -12811,6 +12938,27 @@ function _jfRenderRows(rows){
     if (hideRowTitle) wrap.classList.add('catalogNoTitle');
     wrap.dataset.rowId = rowId;
 
+    if (rowId === 'tv_selection') {
+      wrap.classList.add('jfTvSelectionRow');
+      const selection = document.createElement('button');
+      selection.type = 'button';
+      selection.className = 'jfTvSelectionBar';
+      selection.setAttribute('data-jf-action', 'toggle_tv_season_chooser');
+      selection.setAttribute('aria-expanded', row.expanded ? 'true' : 'false');
+      selection.setAttribute('aria-label', `${row.title || 'Selected series and season'}. ${row.expanded ? 'Hide' : 'Show'} series and season options.`);
+      const label = document.createElement('span');
+      label.className = 'jfTvSelectionLabel';
+      label.textContent = row.title || 'Selected series and season';
+      const hint = document.createElement('span');
+      hint.className = 'jfTvSelectionHint';
+      hint.textContent = row.expanded ? 'Hide options ▴' : 'Change ▾';
+      selection.appendChild(label);
+      selection.appendChild(hint);
+      wrap.appendChild(selection);
+      hostFrag.appendChild(wrap);
+      return;
+    }
+
     const title = document.createElement('div');
     title.className = 'jfRowTitle';
     title.textContent = row.title || 'Results';
@@ -13065,6 +13213,7 @@ async function loadJellyfinTvSeries(force){
     __jfTvSeriesTitle = '';
     __jfTvSeriesThumb = '';
     __jfTvSeasonNumber = null;
+    __jfTvSeasonChooserExpanded = false;
     __jfTvViewMode = 'series';
     const up = !!(j.connected);
     const reason = String(j.last_error || '').trim();
@@ -13139,6 +13288,7 @@ function _jfLoadActiveTabDefault(force){
   __jfTvSeriesTitle = '';
   __jfTvSeriesThumb = '';
   __jfTvSeasonNumber = null;
+  __jfTvSeasonChooserExpanded = false;
   loadJellyfinTvSeries(!!force);
 }
 
@@ -13152,6 +13302,10 @@ async function loadJellyfinTvSeriesDetail(seriesId, opts){
     ''
   ).trim();
   const refresh = !!(opts && opts.refresh);
+  const chooserExpanded = (opts && typeof opts.chooserExpanded === 'boolean')
+    ? opts.chooserExpanded
+    : __jfTvSeasonChooserExpanded;
+  const focusChooser = !!(opts && opts.focusChooser);
   if (__jfBusy) return;
   __jfBusy = true;
   try {
@@ -13184,19 +13338,32 @@ async function loadJellyfinTvSeriesDetail(seriesId, opts){
       thumbnail: String((s && (s.thumbnail_local || s.thumbnail)) || '').trim(),
       thumbnail_local: String((s && s.thumbnail_local) || '').trim(),
     }));
+    const seasonLabel = Number.isFinite(Number(seasonNum)) ? `Season ${Number(seasonNum)}` : 'No season selected';
     const rows = [
-      {id:'tv_back', title:`${title}`, items:[{item_id:'tv_back', title:'← Back to Series', subtitle:'Return to all series', type:'nav_back', thumbnail: thumb, thumbnail_local: thumb}]},
-      {id:'tv_seasons', title:'Seasons', items: seasonItems},
-      {id:'tv_episodes', title:`Episodes${Number.isFinite(Number(seasonNum)) ? ` · Season ${Number(seasonNum)}` : ''}`, items: episodes},
+      {id:'tv_selection', title:`${title} · ${seasonLabel}`, expanded: chooserExpanded},
     ];
+    if (chooserExpanded) {
+      rows.push(
+        {id:'tv_back', title:`${title}`, items:[{item_id:'tv_back', title:'← Back to Series', subtitle:'Return to all series', type:'nav_back', thumbnail: thumb, thumbnail_local: thumb}]},
+        {id:'tv_seasons', title:'Seasons', items: seasonItems},
+      );
+    }
+    rows.push({id:'tv_episodes', title:`Episodes${Number.isFinite(Number(seasonNum)) ? ` · Season ${Number(seasonNum)}` : ''}`, items: episodes});
     __jfTvSeriesId = sid;
     __jfTvSeriesTitle = title;
     __jfTvSeriesThumb = thumb;
     __jfTvSeasonNumber = Number.isFinite(Number(seasonNum)) ? Number(seasonNum) : null;
+    __jfTvSeasonChooserExpanded = chooserExpanded;
     __jfTvViewMode = 'detail';
     __jfSelectedItemId = Number.isFinite(Number(seasonNum)) ? `season:${sid}:${Number(seasonNum)}` : '';
     _jfRenderRows(rows);
     _jfApplySelectionUi();
+    if (focusChooser) {
+      requestAnimationFrame(() => {
+        const chooser = document.querySelector('#jfRows .jfTvSelectionBar');
+        if (chooser && typeof chooser.focus === 'function') chooser.focus();
+      });
+    }
     _jfSetStatus(`TV · ${title}`, 'ok');
     _jfSyncTabControls();
   } catch (e) {
@@ -13639,6 +13806,13 @@ function bindJellyfinUi(){
       const reconnect = e.target && e.target.closest ? e.target.closest('.jfReconnectInline') : null;
       if (reconnect) {
         reconnectJellyfin();
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+      const chooserToggle = e.target && e.target.closest ? e.target.closest('[data-jf-action="toggle_tv_season_chooser"]') : null;
+      if (chooserToggle) {
+        _jfToggleTvSeasonChooser();
         e.preventDefault();
         e.stopPropagation();
         return;
@@ -14310,6 +14484,18 @@ async function renderHistory(){
       row.appendChild(bg);
     }
 
+    const resumePos = Number(it.resume_pos);
+    const duration = Number(it.duration_sec);
+    const progressRatio = (it.completed === true) ? 0 : (resumePos / duration);
+    if (Number.isFinite(progressRatio) && progressRatio > 0 && progressRatio < 1) {
+      const bar = document.createElement('div');
+      bar.className = 'histProgress';
+      const fill = document.createElement('span');
+      fill.style.width = `${Math.max(0, Math.min(100, progressRatio * 100))}%`;
+      bar.appendChild(fill);
+      row.appendChild(bar);
+    }
+
     const meta = document.createElement('div');
     meta.className = 'histMeta';
 
@@ -14340,6 +14526,17 @@ async function renderHistory(){
     const sub = document.createElement('div');
     sub.className = 'histSub';
     sub.textContent = `${_fmtTs(it.ts)}  •  ${it.mode || ''}`.trim();
+
+    const progress = document.createElement('div');
+    progress.className = 'histSub';
+    if (it.completed === true) {
+      progress.textContent = 'Completed · 00:00';
+    } else {
+      const resumePos = Number(it.resume_pos);
+      progress.textContent = Number.isFinite(resumePos) && resumePos > 0
+        ? `Resume · ${fmtTime(resumePos)}`
+        : 'Resume · 00:00';
+    }
 
     const url = document.createElement('div');
     url.className = 'histSub';
@@ -14374,6 +14571,7 @@ async function renderHistory(){
     meta.appendChild(title);
     meta.appendChild(channel);
     meta.appendChild(sub);
+    meta.appendChild(progress);
     meta.appendChild(url);
     meta.appendChild(btns);
 

--- a/app/relaytv_app/state.py
+++ b/app/relaytv_app/state.py
@@ -245,6 +245,7 @@ def _persistable_queue_item(item: dict) -> dict | None:
     for key in (
         "channel",
         "subtitle",
+        "history_id",
         "jellyfin_item_id",
         "jellyfin_media_source_id",
         "series_name",
@@ -308,6 +309,21 @@ def _persistable_history_item(item: dict) -> dict | None:
     mode = item.get("mode")
     if isinstance(mode, str) and mode.strip():
         out["mode"] = mode.strip()
+    history_id = item.get("history_id")
+    if isinstance(history_id, str) and history_id.strip():
+        out["history_id"] = history_id.strip()
+    for key in ("duration_sec",):
+        value = item.get(key)
+        if value is None:
+            continue
+        try:
+            parsed = float(value)
+            if parsed > 0:
+                out[key] = parsed
+        except Exception:
+            pass
+    if item.get("completed") is True:
+        out["completed"] = True
     return out
 
 
@@ -447,6 +463,37 @@ def _history_add(entry: dict) -> None:
         if HISTORY_LIMIT > 0 and len(HISTORY) > HISTORY_LIMIT:
             del HISTORY[HISTORY_LIMIT:]
     _persist_history()
+
+
+def _history_update(history_id: str, updates: dict) -> bool:
+    """Update one persisted history entry by its playback instance id."""
+    key = str(history_id or "").strip()
+    if not key or not isinstance(updates, dict):
+        return False
+    changed = False
+    with HISTORY_LOCK:
+        for entry in HISTORY:
+            if str(entry.get("history_id") or "").strip() != key:
+                continue
+            # A completed entry intentionally retains its 00:00 position.
+            if entry.get("completed") is True and updates.get("completed") is not False:
+                updates = {k: v for k, v in updates.items() if k not in ("resume_pos", "duration_sec")}
+            for field, value in updates.items():
+                if entry.get(field) != value:
+                    entry[field] = value
+                    changed = True
+            break
+    if changed:
+        _persist_history()
+    return changed
+
+
+def _history_contains(history_id: str) -> bool:
+    key = str(history_id or "").strip()
+    if not key:
+        return False
+    with HISTORY_LOCK:
+        return any(str(entry.get("history_id") or "").strip() == key for entry in HISTORY)
 
 
 def _load_persisted_state() -> None:
@@ -727,6 +774,14 @@ def get_tv_state() -> dict:
 
 def history_add(entry: dict) -> None:
     _history_add(entry)
+
+
+def history_update(history_id: str, updates: dict) -> bool:
+    return _history_update(history_id, updates)
+
+
+def history_contains(history_id: str) -> bool:
+    return _history_contains(history_id)
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
       - /sys:/sys:ro
       - /run/udev:/run/udev:ro
-      # Needed only when running with a host X11 display.
+      # Host desktop sockets required by Wayland and Xwayland Qt runtimes.
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - ${RELAYTV_XAUTHORITY_HOST_PATH:-/dev/null}:/tmp/.Xauthority:ro
       - /run/user/${PUID:-1000}:/run/user/${PUID:-1000}:rw


### PR DESCRIPTION
## What changed

- Collapses the selected TV series and season into an expandable selection bar.
- Stores playback progress in history, resumes entries from their saved position, and renders progress across history tiles.
- Preserves interrupted positions during queue transitions while marking only genuinely completed items as `00:00`.
- Clarifies the display-socket compose mount comment for Wayland/Xwayland runtimes.

## Why

The TV season chooser remained expanded after selection, and history records were created at playback start without retaining later progress. Auto-advance could also incorrectly mark interrupted items as completed.

## Validation

- `PYTHONPATH=app pytest -q` (83 passed)
- Rebuilt and ran the RelayTV container locally.