### PR TITLE
ci: use GITHUB_TOKEN for Release Please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   release-image:
     needs: release-please

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -113,10 +113,8 @@ normal releases. Use a `Release-As: X.Y.Z` commit footer only when intentionally
 overriding Release Please's next version.
 
 Repository administrators must allow GitHub Actions to create pull requests for
-the Release Please workflow. If CI checks must run on Release Please-generated
-pull requests, create a repository secret named `RELEASE_PLEASE_TOKEN` containing
-a fine-grained personal access token or GitHub App token with permission to
-write contents and pull requests.
+the Release Please workflow. The workflow uses the built-in `GITHUB_TOKEN` with
+repository write permissions.
 
 ## License and Notice Files
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
+import json
 import shutil
 import subprocess
+import tomllib
 
 import pytest
 
@@ -346,6 +348,7 @@ def test_release_image_traceability_metadata_is_documented() -> None:
 def test_release_please_automation_is_configured() -> None:
     config = (ROOT_DIR / "release-please-config.json").read_text()
     manifest = (ROOT_DIR / ".release-please-manifest.json").read_text()
+    pyproject = (ROOT_DIR / "pyproject.toml").read_text()
     workflow = (ROOT_DIR / ".github/workflows/release-please.yml").read_text()
     pr_title = (ROOT_DIR / ".github/workflows/pr-title.yml").read_text()
     pr_template = (ROOT_DIR / ".github/pull_request_template.md").read_text()
@@ -356,7 +359,7 @@ def test_release_please_automation_is_configured() -> None:
     assert '"release-type": "python"' in config
     assert '"package-name": "relaytv"' in config
     assert '"bootstrap-sha": "0c270faaccf1361416538a6230758b6bbe69bc17"' in config
-    assert '".": "0.1.0"' in manifest
+    assert json.loads(manifest)["."] == tomllib.loads(pyproject)["project"]["version"]
     assert "googleapis/release-please-action@v4" in workflow
     assert "contents: write" in workflow
     assert "pull-requests: write" in workflow

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -361,7 +361,8 @@ def test_release_please_automation_is_configured() -> None:
     assert "contents: write" in workflow
     assert "pull-requests: write" in workflow
     assert "packages: write" in workflow
-    assert "secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN" in workflow
+    assert "token: ${{ secrets.GITHUB_TOKEN }}" in workflow
+    assert "RELEASE_PLEASE_TOKEN" not in workflow
     assert "ghcr.io/${{ github.repository }}:${{ needs.release-please.outputs.tag_name }}" in workflow
     assert "Conventional Commit PR title" in pr_title
     assert "User impact:" in pr_template
@@ -369,7 +370,7 @@ def test_release_please_automation_is_configured() -> None:
     assert "Release Please owns version bumps" in agents
     assert "Release notes are maintained by Release Please." in changelog
     assert "Automated Release Flow" in release_doc
-    assert "RELEASE_PLEASE_TOKEN" in release_doc
+    assert "built-in `GITHUB_TOKEN`" in release_doc
 
 
 def test_api_docs_include_app_info_endpoint() -> None:


### PR DESCRIPTION
## Summary

- Removes the optional `RELEASE_PLEASE_TOKEN` path from the Release Please workflow.
- Documents that Release Please uses the built-in `GITHUB_TOKEN`.
- Updates smoke coverage so an invalid repo secret cannot silently become part of the expected workflow contract.

## Changelog

Type: ci

User impact: none

Operator/deployment impact: Release Please no longer fails if a stale or invalid `RELEASE_PLEASE_TOKEN` repo secret exists.

Breaking change: no

## Tests

- `PYTHONPATH=app pytest -q tests/test_smoke.py`
- GitHub workflow YAML parsed with PyYAML
