### PR TITLE
feat: start resumed playback at saved position

### DIFF
--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -761,7 +761,7 @@ def _stop_qt_shell() -> None:
         QT_SHELL_PROC = None
 
 
-def _start_qt_shell(stream_url: str | None = None, audio_url: str | None = None) -> bool:
+def _start_qt_shell(stream_url: str | None = None, audio_url: str | None = None, start_pos: float | None = None) -> bool:
     global QT_SHELL_PROC
     settings = getattr(state, "get_settings", lambda: {})()
     shell_module = (os.getenv("RELAYTV_QT_SHELL_MODULE") or "relaytv_app.qt_shell_app").strip()
@@ -806,6 +806,9 @@ def _start_qt_shell(stream_url: str | None = None, audio_url: str | None = None)
     stream = (stream_url or "").strip()
     if stream:
         args += ["--stream", stream]
+    start_value = _mpv_start_option_value(start_pos)
+    if start_value:
+        args += ["--start", start_value]
     if ytdl_format:
         args += ["--ytdl-format", ytdl_format]
     if ytdl_raw_options:
@@ -971,10 +974,11 @@ def _build_qt_external_mpv_args(
     audio_url: str | None,
     *,
     fallback_to_x11: bool = False,
+    start_pos: float | None = None,
 ) -> list[str]:
     # Start from the standard app-managed args, then append external runtime
     # renderer hints. Keep first-wins semantics for singleton options.
-    args = _build_mpv_args(stream_url, audio_url, "x11")
+    args = _build_mpv_args(stream_url, audio_url, "x11", start_pos=start_pos)
     base = _strip_mpv_renderer_args(args[:-1])
     extra = _qt_external_mpv_mode_args(fallback_to_x11=fallback_to_x11)
     out = base + extra + [stream_url]
@@ -1005,9 +1009,10 @@ def _start_qt_external_mpv(
     *,
     fallback_to_x11: bool = False,
     fallback_reason: str = "",
+    start_pos: float | None = None,
 ) -> subprocess.Popen:
     _stop_qt_shell()
-    args = _build_qt_external_mpv_args(stream_url, audio_url, fallback_to_x11=fallback_to_x11)
+    args = _build_qt_external_mpv_args(stream_url, audio_url, fallback_to_x11=fallback_to_x11, start_pos=start_pos)
     mode_args = _qt_external_mpv_mode_args(fallback_to_x11=fallback_to_x11)
     _set_qt_external_runtime_state(
         fallback_to_x11=fallback_to_x11,
@@ -1282,6 +1287,7 @@ def _first_wins_dedupe(args: list[str]) -> list[str]:
         "--osd-playing-msg",
         "--term-playing-msg",
         "--ytdl-format",
+        "--start",
     )
     seen: set[str] = set()
     out: list[str] = []
@@ -1299,6 +1305,23 @@ def _first_wins_dedupe(args: list[str]) -> list[str]:
         seen.add(key)
         out.append(a)
     return out
+
+
+def _normalize_start_pos(start_pos: float | None) -> float | None:
+    try:
+        pos = float(start_pos) if start_pos is not None else None
+    except Exception:
+        return None
+    if pos is None or pos <= 0.0:
+        return None
+    return pos
+
+
+def _mpv_start_option_value(start_pos: float | None) -> str | None:
+    pos = _normalize_start_pos(start_pos)
+    if pos is None:
+        return None
+    return f"{pos:.3f}".rstrip("0").rstrip(".")
 
 
 def _effective_ytdl_format(settings: dict | None = None, provider: str | None = None) -> str:
@@ -1699,7 +1722,7 @@ def _qt_shell_runtime_write_control(payload: dict[str, Any]) -> dict[str, Any]:
     return {"error": "success", "request_id": request_id}
 
 
-def _qt_shell_runtime_load_stream(stream_url: str, audio_url: str | None = None) -> dict[str, Any]:
+def _qt_shell_runtime_load_stream(stream_url: str, audio_url: str | None = None, start_pos: float | None = None) -> dict[str, Any]:
     stream = str(stream_url or "").strip()
     if not stream:
         return {"error": "invalid_command"}
@@ -1711,6 +1734,9 @@ def _qt_shell_runtime_load_stream(stream_url: str, audio_url: str | None = None)
     audio = str(audio_url or "").strip() if isinstance(audio_url, str) else ""
     if audio:
         payload["audio"] = audio
+    pos = _normalize_start_pos(start_pos)
+    if pos is not None:
+        payload["start_pos"] = pos
     return _qt_shell_runtime_finalize_control_result(
         _qt_shell_runtime_write_control(payload),
         timeout_sec=max(1.5, _qt_shell_runtime_control_wait_sec()),
@@ -2175,7 +2201,7 @@ def _x11_mode_active(selected_mode: str | None = None) -> bool:
     return _has_x11_display()
 
 
-def _build_mpv_args(stream_url: str, audio_url: str | None, mode: str) -> list[str]:
+def _build_mpv_args(stream_url: str, audio_url: str | None, mode: str, start_pos: float | None = None) -> list[str]:
     """Build mpv command line with minimal app-managed options.
 
     Keep mpv mostly default-driven and only set options required for RelayTV
@@ -2225,6 +2251,10 @@ def _build_mpv_args(stream_url: str, audio_url: str | None, mode: str) -> list[s
 
     if audio_url:
         mpv_args.append(f"--audio-file={audio_url}")
+
+    start_value = _mpv_start_option_value(start_pos)
+    if start_value:
+        mpv_args.append(f"--start={start_value}")
 
     # In X11 sessions, route notifications through RelayTV's overlay and
     # suppress mpv playback banners/messages that can appear on every file start.
@@ -2432,7 +2462,7 @@ def _apply_startup_mpv_runtime_settings() -> None:
         pass
 
 
-def _load_stream_in_existing_mpv(stream_url: str, audio_url: str | None = None) -> bool:
+def _load_stream_in_existing_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | None = None) -> bool:
     """Try seamless in-process stream replacement on an already-running mpv."""
     if not _env_bool("RELAYTV_MPV_SEAMLESS_REPLACE", True):
         return False
@@ -2505,13 +2535,22 @@ def _load_stream_in_existing_mpv(stream_url: str, audio_url: str | None = None) 
 
     if _qt_shell_runtime_accepts_mpv_commands():
         try:
-            resp = _qt_shell_runtime_load_stream(stream_url, audio_url)
+            if _normalize_start_pos(start_pos) is not None:
+                resp = _qt_shell_runtime_load_stream(stream_url, audio_url, start_pos=start_pos)
+            else:
+                resp = _qt_shell_runtime_load_stream(stream_url, audio_url)
         except Exception:
             return False
     else:
         cmd: list[object] = ["loadfile", str(stream_url), "replace"]
+        start_value = _mpv_start_option_value(start_pos)
         if audio_url:
-            cmd.extend(["-1", f"audio-files-append={str(audio_url)}"])
+            option_value = f"audio-files-append={str(audio_url)}"
+            if start_value and "," not in option_value:
+                option_value = f"start={start_value},{option_value}"
+            cmd.extend(["-1", option_value])
+        elif start_value:
+            cmd.extend(["-1", f"start={start_value}"])
         try:
             resp = mpv_command(cmd)
         except Exception:
@@ -2524,7 +2563,7 @@ def _load_stream_in_existing_mpv(stream_url: str, audio_url: str | None = None) 
     return True
 
 
-def start_mpv(stream_url: str, audio_url: str | None = None):
+def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | None = None):
     """Start mpv fullscreen with an IPC socket so we can control it.
 
     Video mode:
@@ -2559,6 +2598,7 @@ def start_mpv(stream_url: str, audio_url: str | None = None):
                 audio_url=audio_url,
                 fallback_to_x11=False,
                 fallback_reason="",
+                start_pos=start_pos,
             )
             if not wait_for_ipc_ready(timeout=startup_timeout):
                 raise HTTPException(status_code=500, detail="qt external mpv started but IPC not ready")
@@ -2574,6 +2614,7 @@ def start_mpv(stream_url: str, audio_url: str | None = None):
                         audio_url=audio_url,
                         fallback_to_x11=True,
                         fallback_reason="video_unhealthy",
+                        start_pos=start_pos,
                     )
                     if not wait_for_ipc_ready(timeout=startup_timeout):
                         raise HTTPException(status_code=500, detail="qt external mpv x11 fallback started but IPC not ready")
@@ -2583,7 +2624,7 @@ def start_mpv(stream_url: str, audio_url: str | None = None):
             _recover_audio_output_if_needed(settings)
             return
 
-        _start_qt_shell(stream_url, audio_url=audio_url)
+        _start_qt_shell(stream_url, audio_url=audio_url, start_pos=start_pos)
         if not wait_for_ipc_ready(timeout=startup_timeout):
             raise HTTPException(status_code=500, detail="qt shell started but mpv IPC not ready")
         _apply_startup_mpv_runtime_settings()
@@ -2591,7 +2632,7 @@ def start_mpv(stream_url: str, audio_url: str | None = None):
         return
 
     def _spawn(mode_to_use: str) -> subprocess.Popen:
-        args = _build_mpv_args(stream_url, audio_url, mode_to_use)
+        args = _build_mpv_args(stream_url, audio_url, mode_to_use, start_pos=start_pos)
         if debug:
             logger.info("starting_mpv mode=%s args=%s", mode_to_use, " ".join(shlex.quote(a) for a in args))
         return subprocess.Popen(args)
@@ -3826,6 +3867,11 @@ def _consume_mpv_queued_next_if_started(
             now_item["jellyfin_media_source_id"] = consumed.get("jellyfin_media_source_id")
         if consumed.get("history_id"):
             now_item["history_id"] = consumed.get("history_id")
+        if consumed.get("_resolved_source_url") == url and consumed.get("_resolved_stream"):
+            now_item["_resolved_source_url"] = consumed.get("_resolved_source_url")
+            now_item["_resolved_stream"] = consumed.get("_resolved_stream")
+            now_item["_resolved_audio"] = consumed.get("_resolved_audio") or ""
+            now_item["_resolved_at"] = consumed.get("_resolved_at") or time.time()
 
     try:
         pos = props.get("time-pos")
@@ -3870,6 +3916,16 @@ def _add_history_entry(now: dict) -> None:
     for key in ("channel", "jellyfin_item_id", "jellyfin_media_source_id", "thumbnail", "thumbnail_local"):
         if now.get(key):
             entry[key] = now[key]
+    if now.get("_resolved_source_url") == now.get("url") and now.get("_resolved_stream"):
+        entry["_resolved_source_url"] = now.get("_resolved_source_url")
+        entry["_resolved_stream"] = now.get("_resolved_stream")
+        entry["_resolved_audio"] = now.get("_resolved_audio") or ""
+        try:
+            resolved_at = float(now.get("_resolved_at") or 0.0)
+        except Exception:
+            resolved_at = 0.0
+        if resolved_at > 0.0:
+            entry["_resolved_at"] = resolved_at
     state.history_add(entry)
 
 
@@ -4020,13 +4076,14 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
 
     debug_log("player", f"resolved_stream={stream!r} audio={audio!r}")
 
+    resume_start_pos = _normalize_start_pos(start_pos)
     with MPV_LOCK:
         t_mpv = time.monotonic()
         # Resolver work can outlast the initial transition window. Refresh it
         # immediately before the playback handoff so background idle workers do
         # not collapse the session while the reused runtime is loading media.
         _mark_playback_transition()
-        reused_runtime = _load_stream_in_existing_mpv(stream, audio_url=audio)
+        reused_runtime = _load_stream_in_existing_mpv(stream, audio_url=audio, start_pos=resume_start_pos)
         if (not reused_runtime) and _qt_shell_backend_enabled():
             # ARM hosts can expose a brief control-gap at EOF; retry a couple
             # of times before escalating to full player restart.
@@ -4042,7 +4099,7 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
             delay_sec = max(0.01, min(1.0, delay_sec))
             for _ in range(retries):
                 time.sleep(delay_sec)
-                reused_runtime = _load_stream_in_existing_mpv(stream, audio_url=audio)
+                reused_runtime = _load_stream_in_existing_mpv(stream, audio_url=audio, start_pos=resume_start_pos)
                 if reused_runtime:
                     break
         if reused_runtime:
@@ -4050,16 +4107,14 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
             # transitions from idle surface to the newly loaded stream.
             _mark_playback_transition()
         if not reused_runtime:
-            start_mpv(stream, audio_url=audio)
+            start_mpv(stream, audio_url=audio, start_pos=resume_start_pos)
         debug_log(
             "player",
             f"{'seamless_replace' if reused_runtime else 'start_mpv'} finished in "
             f"{int((time.monotonic() - t_mpv) * 1000)}ms",
         )
 
-    # If resuming, seek after mpv starts (IPC can take a moment).
-    if start_pos is not None:
-        mpv_seek_absolute_with_retry(start_pos)
+    if resume_start_pos is not None:
         try:
             mpv_set("pause", False)
         except Exception:
@@ -4083,6 +4138,15 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
         **({"jellyfin_stream_mode": item.get("jellyfin_stream_mode")} if item.get("jellyfin_stream_mode") else {}),
         **({"jellyfin_stream_reason": item.get("jellyfin_stream_reason")} if item.get("jellyfin_stream_reason") else {}),
     }
+    if stream and stream != raw:
+        now["_resolved_source_url"] = raw
+        now["_resolved_stream"] = stream
+        now["_resolved_audio"] = audio or ""
+        try:
+            resolved_at = float(item.get("_resolved_at") or time.time()) if isinstance(item, dict) else time.time()
+        except Exception:
+            resolved_at = time.time()
+        now["_resolved_at"] = resolved_at
     # Keep last resume position on the now_playing dict for close/resume UX.
     if start_pos is not None:
         try:

--- a/app/relaytv_app/qt_shell_app.py
+++ b/app/relaytv_app/qt_shell_app.py
@@ -453,6 +453,7 @@ def _first_wins_dedupe(args: list[str]) -> list[str]:
         "--script-opts",
         "--ytdl-format",
         "--ytdl-raw-options",
+        "--start",
     )
     seen: set[str] = set()
     out: list[str] = []
@@ -476,6 +477,7 @@ def _build_mpv_args(
     stream: str,
     wid: int,
     audio: str | None = None,
+    start_pos: float | None = None,
     ipc_path: str | None = None,
     audio_device: str | None = None,
     sub_lang: str | None = None,
@@ -517,6 +519,13 @@ def _build_mpv_args(
         args.append(f"--input-ipc-server={ipc_path}")
     if audio:
         args.append(f"--audio-file={audio}")
+    try:
+        pos = float(start_pos) if start_pos is not None else None
+    except Exception:
+        pos = None
+    if pos is not None and pos > 0.0:
+        start_value = f"{pos:.3f}".rstrip("0").rstrip(".")
+        args.append(f"--start={start_value}")
     if audio_device:
         args.append(f"--audio-device={audio_device}")
     if sub_lang:
@@ -768,13 +777,22 @@ class _QtLibMpvPlayer:
             raise RuntimeError("command list empty")
         self._command(*items)
 
-    def load_stream(self, stream: str, audio: str | None = None) -> None:
+    def load_stream(self, stream: str, audio: str | None = None, start_pos: float | None = None) -> None:
         s = str(stream or "").strip()
         if not s:
             raise RuntimeError("stream required")
         a = str(audio or "").strip() if isinstance(audio, str) else ""
+        try:
+            pos = float(start_pos) if start_pos is not None else None
+        except Exception:
+            pos = None
+        options: list[str] = []
+        if pos is not None and pos > 0.0:
+            options.append(f"start={f'{pos:.3f}'.rstrip('0').rstrip('.')}")
         if a:
-            self._command("loadfile", s, "replace", "-1", f"audio-files-append={a}")
+            options.append(f"audio-files-append={a}")
+        if options:
+            self._command("loadfile", s, "replace", "-1", ",".join(options))
             return
         self._command("loadfile", s, "replace")
 
@@ -1007,6 +1025,7 @@ class _QtLibMpvPlayer:
         *,
         stream: str,
         audio: str | None,
+        start_pos: float | None,
         ipc_path: str | None,
         audio_device: str | None,
         sub_lang: str | None,
@@ -1212,6 +1231,7 @@ def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="RelayTV Qt shell (experimental)")
     ap.add_argument("--stream", default="")
     ap.add_argument("--audio", default="")
+    ap.add_argument("--start", type=float, default=None)
     ap.add_argument("--ipc-path", default=os.getenv("MPV_IPC_PATH", "/tmp/mpv.sock"))
     ap.add_argument("--audio-device", default="")
     ap.add_argument("--sub-lang", default="")
@@ -2060,6 +2080,7 @@ def main(argv: list[str] | None = None) -> int:
             libmpv_player.start(
                 stream=stream,
                 audio=((args.audio or "").strip() or None),
+                start_pos=args.start,
                 ipc_path=(ipc_path or None),
                 audio_device=((args.audio_device or "").strip() or None),
                 sub_lang=((args.sub_lang or "").strip() or None),
@@ -2690,6 +2711,7 @@ def main(argv: list[str] | None = None) -> int:
     if use_libmpv and libmpv_player is not None and stream:
         initial_stream = stream
         initial_audio = (args.audio or None)
+        initial_start = args.start
         initial_load_attempts = {"n": 0}
 
         def _load_initial_libmpv_stream() -> None:
@@ -2702,7 +2724,7 @@ def main(argv: list[str] | None = None) -> int:
                         QTimer.singleShot(50, _load_initial_libmpv_stream)
                         return
                     raise RuntimeError("libmpv render context not ready")
-                libmpv_player.load_stream(initial_stream, initial_audio)
+                libmpv_player.load_stream(initial_stream, initial_audio, initial_start)
                 _sync_idle_visibility()
                 _nudge_overlay_stack()
             except Exception as exc:
@@ -2766,7 +2788,7 @@ def main(argv: list[str] | None = None) -> int:
             except Exception:
                 pass
 
-    def _spawn_subprocess_mpv(stream_url: str, audio_url: str | None = None) -> None:
+    def _spawn_subprocess_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | None = None) -> None:
         nonlocal mpv_proc
         if not stream_url:
             raise RuntimeError("stream_empty")
@@ -2785,6 +2807,7 @@ def main(argv: list[str] | None = None) -> int:
                 stream_url,
                 wid=wid,
                 audio=(audio_url or None),
+                start_pos=start_pos,
                 ipc_path=(ipc_path or None),
                 audio_device=((args.audio_device or "").strip() or None),
                 sub_lang=((args.sub_lang or "").strip() or None),
@@ -2804,7 +2827,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if (not use_libmpv) and stream:
         try:
-            _spawn_subprocess_mpv(stream, (args.audio or None))
+            _spawn_subprocess_mpv(stream, (args.audio or None), args.start)
         except Exception as e:
             _eprint("Failed to start embedded mpv:", e)
             return 3
@@ -2877,17 +2900,23 @@ def main(argv: list[str] | None = None) -> int:
             elif action == "load_stream":
                 stream_url = str(payload.get("stream") or "").strip()
                 audio_url = (str(payload.get("audio") or "").strip() or None)
+                start_pos = _optional_float(payload.get("start_pos"))
                 if libmpv_player is not None:
-                    libmpv_player.load_stream(stream_url, audio_url)
+                    libmpv_player.load_stream(stream_url, audio_url, start_pos)
                 else:
                     if not _subprocess_mpv_running():
-                        _spawn_subprocess_mpv(stream_url, audio_url)
+                        _spawn_subprocess_mpv(stream_url, audio_url, start_pos)
                         if not _wait_for_subprocess_mpv_ipc():
                             raise RuntimeError("mpv_ipc_unavailable")
                     else:
                         command: list[object] = ["loadfile", stream_url, "replace"]
+                        options: list[str] = []
+                        if start_pos is not None and start_pos > 0.0:
+                            options.append(f"start={f'{start_pos:.3f}'.rstrip('0').rstrip('.')}")
                         if audio_url:
-                            command.extend(["-1", f"audio-files-append={audio_url}"])
+                            options.append(f"audio-files-append={audio_url}")
+                        if options:
+                            command.extend(["-1", ",".join(options)])
                         result = _subprocess_mpv_ipc_request(command)
                         if result.get("error") != "success":
                             raise RuntimeError(str(result.get("error") or "mpv_loadfile_failed"))

--- a/app/relaytv_app/routes.py
+++ b/app/relaytv_app/routes.py
@@ -418,6 +418,10 @@ class PlayNowReq(BaseModel):
     thumbnail: str | None = None
     resume_pos: float | None = None
     history_id: str | None = None
+    resolved_source_url: str | None = None
+    resolved_stream: str | None = None
+    resolved_audio: str | None = None
+    resolved_at: float | None = None
 
 
 class PlayTemporaryReq(BaseModel):
@@ -2696,6 +2700,10 @@ def history_play(req: HistoryPlayReq):
         resume_pos = float(raw_resume) if raw_resume is not None else None
     except Exception:
         resume_pos = None
+    try:
+        resolved_at = float(it.get("_resolved_at")) if it.get("_resolved_at") is not None else None
+    except Exception:
+        resolved_at = None
     return play_now(PlayNowReq(
         url=url.strip(),
         preserve_current=True,
@@ -2704,6 +2712,10 @@ def history_play(req: HistoryPlayReq):
         thumbnail=str(it.get("thumbnail") or "").strip() or None,
         resume_pos=resume_pos,
         history_id=str(it.get("history_id") or "").strip() or None,
+        resolved_source_url=str(it.get("_resolved_source_url") or "").strip() or None,
+        resolved_stream=str(it.get("_resolved_stream") or "").strip() or None,
+        resolved_audio=str(it.get("_resolved_audio") or "").strip() or None,
+        resolved_at=resolved_at,
     ))
 
 
@@ -2754,6 +2766,21 @@ def _preserve_current_to_queue_front() -> dict | None:
         preserved["jellyfin_media_source_id"] = now.get("jellyfin_media_source_id")
     if isinstance(now.get("history_id"), str) and now.get("history_id"):
         preserved["history_id"] = now.get("history_id")
+    resolved_stream = str(now.get("_resolved_stream") or "").strip()
+    if not resolved_stream:
+        now_stream = str(now.get("stream") or "").strip()
+        if now_stream and now_stream != url.strip():
+            resolved_stream = now_stream
+    if resolved_stream:
+        preserved["_resolved_source_url"] = url.strip()
+        preserved["_resolved_stream"] = resolved_stream
+        resolved_audio = str(now.get("_resolved_audio") or now.get("audio") or "").strip()
+        if resolved_audio:
+            preserved["_resolved_audio"] = resolved_audio
+        try:
+            preserved["_resolved_at"] = float(now.get("_resolved_at") or time.time())
+        except Exception:
+            preserved["_resolved_at"] = time.time()
     if pos_f is not None:
         preserved["resume_pos"] = pos_f
     player.update_history_progress(now, position_sec=pos_f, duration_sec=dur, force=True)
@@ -2782,7 +2809,13 @@ def play_now(req: PlayNowReq):
     if req.preserve_current and req.preserve_to == "queue_front" and req.resume_current:
         preserved = _preserve_current_to_queue_front()
 
-    if req.title or req.thumbnail or req.resume_pos is not None or req.history_id:
+    if (
+        req.title
+        or req.thumbnail
+        or req.resume_pos is not None
+        or req.history_id
+        or req.resolved_stream
+    ):
         item = {"url": req.url}
         if req.title:
             item["title"] = req.title
@@ -2790,6 +2823,13 @@ def play_now(req: PlayNowReq):
             item["thumbnail"] = req.thumbnail
         if req.history_id:
             item["history_id"] = req.history_id
+        if req.resolved_stream:
+            item["_resolved_source_url"] = (req.resolved_source_url or req.url or "").strip()
+            item["_resolved_stream"] = req.resolved_stream.strip()
+            if req.resolved_audio:
+                item["_resolved_audio"] = req.resolved_audio.strip()
+            if req.resolved_at is not None:
+                item["_resolved_at"] = req.resolved_at
         now = player.play_item(
             item,
             use_resolver=True,
@@ -7326,6 +7366,11 @@ def playback_play():
         pos = now.get("resume_pos")
         if pos is None:
             pos = getattr(state, "SESSION_POSITION", None)
+        start_pos = None
+        try:
+            start_pos = player._normalize_start_pos(float(pos)) if pos is not None else None
+        except Exception:
+            start_pos = None
         state.AUTO_NEXT_SUPPRESS_UNTIL = time.time() + 2.0
 
         if isinstance(stream, str) and stream.strip():
@@ -7333,14 +7378,8 @@ def playback_play():
             with player.MPV_LOCK:
                 stream_url = stream.strip()
                 audio_url = audio.strip() if isinstance(audio, str) and audio.strip() else None
-                if not player._load_stream_in_existing_mpv(stream_url, audio_url=audio_url):
-                    player.start_mpv(stream_url, audio_url=audio_url)
-            # Seek after start
-            if pos is not None:
-                try:
-                    player.mpv_seek_absolute_with_retry(float(pos), tries=25, delay=0.12)
-                except Exception:
-                    pass
+                if not player._load_stream_in_existing_mpv(stream_url, audio_url=audio_url, start_pos=start_pos):
+                    player.start_mpv(stream_url, audio_url=audio_url, start_pos=start_pos)
             try:
                 resume_result = _control_result_or_raise(player.mpv_set_result("pause", False), action="resume_session")
             except Exception:
@@ -7566,6 +7605,14 @@ def resume_session():
     # Reuse resolved stream/audio from NOW_PLAYING to avoid re-resolving.
     stream = now.get("stream")
     audio = now.get("audio")
+    pos = now.get("resume_pos")
+    if pos is None:
+        pos = getattr(state, "SESSION_POSITION", None)
+    start_pos = None
+    try:
+        start_pos = player._normalize_start_pos(float(pos)) if pos is not None else None
+    except Exception:
+        start_pos = None
 
     if not isinstance(stream, str) or not stream.strip():
         # Fallback: re-resolve if missing
@@ -7575,14 +7622,14 @@ def resume_session():
             cec=False,
             clear_queue=False,
             mode="resume",
-            start_pos=(float(now.get("resume_pos")) if now.get("resume_pos") is not None else getattr(state, "SESSION_POSITION", None)),
+            start_pos=start_pos,
         )
     else:
         with player.MPV_LOCK:
             stream_url = stream.strip()
             audio_url = audio.strip() if isinstance(audio, str) and audio.strip() else None
-            if not player._load_stream_in_existing_mpv(stream_url, audio_url=audio_url):
-                player.start_mpv(stream_url, audio_url=audio_url)
+            if not player._load_stream_in_existing_mpv(stream_url, audio_url=audio_url, start_pos=start_pos):
+                player.start_mpv(stream_url, audio_url=audio_url, start_pos=start_pos)
         resumed = dict(now)
         resumed["started"] = int(time.time())
         resumed["mode"] = "resume"
@@ -7591,16 +7638,7 @@ def resume_session():
         state.set_session_state("playing")
 
     resume_result: dict[str, object] | None = None
-    # Seek to last known position
-    pos = now.get("resume_pos")
-    if pos is None:
-        pos = getattr(state, "SESSION_POSITION", None)
-    if pos is not None:
-        try:
-            player.mpv_seek_absolute_with_retry(float(pos), tries=25, delay=0.12)
-        except Exception:
-            pass
-
+    if start_pos is not None:
         try:
             resume_result = _control_result_or_raise(player.mpv_set_result("pause", False), action="resume_session")
         except Exception:

--- a/app/relaytv_app/state.py
+++ b/app/relaytv_app/state.py
@@ -275,6 +275,21 @@ def _persistable_queue_item(item: dict) -> dict | None:
         except Exception:
             pass
 
+    resolved_source = str(item.get("_resolved_source_url") or "").strip()
+    resolved_stream = str(item.get("_resolved_stream") or "").strip()
+    if resolved_source == url and resolved_stream:
+        out["_resolved_source_url"] = resolved_source
+        out["_resolved_stream"] = resolved_stream
+        resolved_audio = str(item.get("_resolved_audio") or "").strip()
+        if resolved_audio:
+            out["_resolved_audio"] = resolved_audio
+        try:
+            resolved_at = float(item.get("_resolved_at") or 0.0)
+        except Exception:
+            resolved_at = 0.0
+        if resolved_at > 0.0:
+            out["_resolved_at"] = resolved_at
+
     thumb = _sanitize_thumb_for_persist(item)
     if thumb:
         out["thumbnail"] = thumb

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1571,6 +1571,137 @@ def test_playback_toggle_resumes_paused_session_without_reloading(monkeypatch: p
     assert calls == [('pause', False)]
 
 
+def test_mpv_start_args_include_resume_start_position(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(player.state, 'get_settings', lambda: {'volume': 75})
+    monkeypatch.setattr(player, '_effective_audio_device', lambda settings=None: '')
+    monkeypatch.setattr(player, '_x11_mode_active', lambda selected_mode=None: False)
+    monkeypatch.setattr(player, '_x11_overlay_enabled', lambda: False)
+    monkeypatch.setattr(player, '_provider_hint_for_stream', lambda *_a, **_k: 'generic')
+    monkeypatch.setattr(player, '_should_force_ytdl_off', lambda *_a, **_k: False)
+    monkeypatch.setattr(player, '_effective_ytdl_format', lambda *_a, **_k: '')
+
+    args = player._build_mpv_args('https://example.com/video.mp4', None, 'x11', start_pos=42.5)
+
+    assert '--start=42.5' in args
+    assert args[-1] == 'https://example.com/video.mp4'
+
+
+def test_resume_session_starts_resolved_stream_at_resume_position(monkeypatch: pytest.MonkeyPatch) -> None:
+    load_calls: list[dict[str, object]] = []
+    start_calls: list[dict[str, object]] = []
+    seek_calls: list[object] = []
+
+    monkeypatch.setattr(routes.state, 'SESSION_STATE', 'closed', raising=False)
+    monkeypatch.setattr(
+        routes.state,
+        'NOW_PLAYING',
+        {
+            'url': 'https://youtube.com/watch?v=abc',
+            'stream': 'https://video.example/resolved.mp4',
+            'audio': 'https://audio.example/resolved.m4a',
+            'resume_pos': 42.5,
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(routes.state, 'SESSION_POSITION', 42.5, raising=False)
+    monkeypatch.setattr(routes.state, 'set_now_playing', lambda value: setattr(routes.state, 'NOW_PLAYING', value))
+    monkeypatch.setattr(routes.state, 'set_session_state', lambda value: setattr(routes.state, 'SESSION_STATE', value))
+    monkeypatch.setattr(
+        routes.player,
+        '_load_stream_in_existing_mpv',
+        lambda stream_url, audio_url=None, start_pos=None: load_calls.append(
+            {'stream': stream_url, 'audio': audio_url, 'start_pos': start_pos}
+        ) or False,
+    )
+    monkeypatch.setattr(
+        routes.player,
+        'start_mpv',
+        lambda stream_url, audio_url=None, start_pos=None: start_calls.append(
+            {'stream': stream_url, 'audio': audio_url, 'start_pos': start_pos}
+        ),
+    )
+    monkeypatch.setattr(routes.player, 'mpv_seek_absolute_with_retry', lambda *a, **k: seek_calls.append((a, k)))
+    monkeypatch.setattr(routes.player, 'mpv_set_result', lambda prop, value: {'error': 'success'})
+
+    out = routes.resume_session()
+
+    assert out['status'] == 'resumed'
+    assert load_calls == [{'stream': 'https://video.example/resolved.mp4', 'audio': 'https://audio.example/resolved.m4a', 'start_pos': 42.5}]
+    assert start_calls == [{'stream': 'https://video.example/resolved.mp4', 'audio': 'https://audio.example/resolved.m4a', 'start_pos': 42.5}]
+    assert seek_calls == []
+
+
+def test_play_item_reuses_fresh_resolved_stream_without_ytdlp(monkeypatch: pytest.MonkeyPatch) -> None:
+    start_calls: list[dict[str, object]] = []
+    now_values: list[dict] = []
+
+    monkeypatch.setattr(player, 'update_history_progress', lambda *a, **k: None)
+    monkeypatch.setattr(player, '_mark_playback_transition', lambda *a, **k: None)
+    monkeypatch.setattr(player, 'cec_auto_on_switch', lambda cec: False)
+    monkeypatch.setattr(player, '_load_stream_in_existing_mpv', lambda *a, **k: False)
+    monkeypatch.setattr(
+        player,
+        'start_mpv',
+        lambda stream_url, audio_url=None, start_pos=None: start_calls.append(
+            {'stream': stream_url, 'audio': audio_url, 'start_pos': start_pos}
+        ),
+    )
+    monkeypatch.setattr(player, 'mpv_set', lambda *a, **k: None)
+    monkeypatch.setattr(player, '_add_history_entry', lambda now: None)
+    monkeypatch.setattr(player, '_prime_mpv_up_next_from_queue', lambda force=False: False)
+    monkeypatch.setattr(player.state, 'NOW_PLAYING', None, raising=False)
+    monkeypatch.setattr(player.state, 'get_tv_state', lambda: {})
+    monkeypatch.setattr(player.state, 'set_now_playing', lambda value: now_values.append(value))
+    monkeypatch.setattr(player.state, 'set_session_state', lambda value: None)
+    monkeypatch.setattr(player.state, 'set_pause_reason', lambda value: None)
+    monkeypatch.setattr(player.state, 'set_session_position', lambda value: None)
+    monkeypatch.setattr(player, 'resolve_streams', lambda url: (_ for _ in ()).throw(AssertionError('yt-dlp should not run')))
+    monkeypatch.setattr(player.time, 'time', lambda: 1000.0)
+
+    now = player.play_item(
+        {
+            'url': 'https://youtube.com/watch?v=abc',
+            'title': 'Cached clip',
+            'provider': 'youtube',
+            'resume_pos': 42.5,
+            '_resolved_source_url': 'https://youtube.com/watch?v=abc',
+            '_resolved_stream': 'https://video.example/resolved.mp4',
+            '_resolved_audio': 'https://audio.example/resolved.m4a',
+            '_resolved_at': 999.0,
+        },
+        use_resolver=True,
+        cec=False,
+        clear_queue=False,
+        mode='resume',
+        start_pos=42.5,
+    )
+
+    assert start_calls == [{'stream': 'https://video.example/resolved.mp4', 'audio': 'https://audio.example/resolved.m4a', 'start_pos': 42.5}]
+    assert now['stream'] == 'https://video.example/resolved.mp4'
+    assert now['_resolved_stream'] == 'https://video.example/resolved.mp4'
+    assert now_values[-1]['_resolved_at'] == 999.0
+
+
+def test_persistable_history_item_keeps_resolved_stream_hint() -> None:
+    item = {
+        'url': 'https://youtube.com/watch?v=abc',
+        'title': 'Cached clip',
+        'provider': 'youtube',
+        'resume_pos': 42.5,
+        '_resolved_source_url': 'https://youtube.com/watch?v=abc',
+        '_resolved_stream': 'https://video.example/resolved.mp4',
+        '_resolved_audio': 'https://audio.example/resolved.m4a',
+        '_resolved_at': 999.0,
+    }
+
+    out = routes.state._persistable_history_item(item)
+
+    assert out['_resolved_source_url'] == item['_resolved_source_url']
+    assert out['_resolved_stream'] == item['_resolved_stream']
+    assert out['_resolved_audio'] == item['_resolved_audio']
+    assert out['_resolved_at'] == 999.0
+
+
 def test_playback_state_keeps_idle_non_playing_during_natural_idle_hold(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(routes.state, 'SESSION_STATE', 'idle', raising=False)
     monkeypatch.setattr(routes.state, 'NOW_PLAYING', None, raising=False)


### PR DESCRIPTION
## Summary

Start resumed playback at the saved position during the initial mpv load instead of starting at 00:00 and issuing a follow-up seek.

This also persists fresh resolved stream hints with now-playing, queue, and history items so restart/session/history resumes can reuse a still-valid direct stream URL instead of repeating yt-dlp resolution.

## User Impact

- Resuming playback should begin directly at the saved timestamp with less visible jumping from 00:00.
- Recent resumes should avoid unnecessary yt-dlp lookups when a fresh resolved stream is already available.

## Operator / Deployment Impact

- No new configuration is required.
- Existing resolved stream TTL behavior still gates reuse, so stale signed URLs fall back to normal resolution.

## Breaking Changes

None.

## Tests

- `PYTHONPATH=app pytest -q tests/test_smoke.py`