### PR TITLE
fix: keep idle toasts available without dashboard

### DIFF
--- a/app/relaytv_app/overlay_app.py
+++ b/app/relaytv_app/overlay_app.py
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: GPL-3.0-only
 """
-RelayTV X11 Overlay App (transparent always-on-top browser window)
+RelayTV X11 Overlay App (transparent always-on-top browser window).
 
-This is intentionally small and dependency-light: GTK + WebKitGTK.
-
-Runs ONLY on X11. On Wayland or DRM/KMS, RelayTV should fall back to mpv OSD.
+GTK/WebKitGTK is preferred when installed. Qt WebEngine is used as a fallback
+because the RelayTV image already ships the Qt stack for the shell UI.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
+import platform
+import shlex
 import sys
 
 from .debug import get_logger
@@ -21,14 +22,114 @@ logger = get_logger("overlay")
 def _eprint(*a: object) -> None:
     logger.info(" ".join(str(part) for part in a))
 
-def main(argv: list[str] | None = None) -> int:
-    argv = list(sys.argv[1:] if argv is None else argv)
+def _env_choice(name: str) -> bool | None:
+    v = os.getenv(name)
+    if v is None:
+        return None
+    text = v.strip().lower()
+    if text in ("1", "true", "yes", "on"):
+        return True
+    if text in ("0", "false", "no", "off"):
+        return False
+    return None
 
-    ap = argparse.ArgumentParser(description="RelayTV X11 Overlay (WebKitGTK)")
-    ap.add_argument("--url", default=os.getenv("RELAYTV_OVERLAY_URL", "http://127.0.0.1:8787/x11/overlay"))
-    ap.add_argument("--click-through", action="store_true", default=os.getenv("RELAYTV_OVERLAY_CLICKTHROUGH", "0").strip().lower() in ("1","true","yes","on"))
-    args = ap.parse_args(argv)
+def _append_env_flags(name: str, flags: list[str]) -> None:
+    current = (os.getenv(name) or "").strip()
+    try:
+        parts = shlex.split(current) if current else []
+    except Exception:
+        parts = current.split() if current else []
+    changed = False
+    for flag in flags:
+        if flag not in parts:
+            parts.append(flag)
+            changed = True
+    if changed or not current:
+        os.environ[name] = " ".join(parts).strip()
 
+def _qt_overlay_software_mode_enabled() -> bool:
+    override = _env_choice("RELAYTV_QT_OVERLAY_SOFTWARE")
+    if override is not None:
+        return bool(override)
+    arch = (platform.machine() or "").strip().lower()
+    return arch in ("aarch64", "arm64", "armv7l", "armv6l")
+
+def _run_qt_overlay(url: str, *, click_through: bool) -> int:
+    if _qt_overlay_software_mode_enabled():
+        _append_env_flags(
+            "QTWEBENGINE_CHROMIUM_FLAGS",
+            [
+                "--disable-gpu",
+                "--disable-gpu-compositing",
+                "--disable-gpu-rasterization",
+                "--disable-zero-copy",
+            ],
+        )
+
+    try:
+        from PySide6.QtCore import Qt, QTimer, QUrl
+        from PySide6.QtWidgets import QApplication, QMainWindow
+        from PySide6.QtWebEngineCore import QWebEngineProfile, QWebEngineSettings
+        from PySide6.QtWebEngineWidgets import QWebEngineView
+    except Exception as e:
+        _eprint("RelayTV overlay Qt fallback requires PySide6 QtWebEngine.")
+        _eprint("Error:", e)
+        return 2
+
+    app = QApplication([sys.argv[0]])
+    win = QMainWindow()
+    win.setWindowTitle("RelayTV Overlay")
+    win.setWindowFlags(
+        Qt.FramelessWindowHint
+        | Qt.WindowStaysOnTopHint
+        | Qt.Tool
+        | Qt.X11BypassWindowManagerHint
+    )
+    win.setAttribute(Qt.WA_TranslucentBackground, True)
+    win.setAttribute(Qt.WA_ShowWithoutActivating, True)
+    if click_through:
+        win.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+    win.setStyleSheet("background: transparent;")
+
+    view = QWebEngineView(win)
+    view.setAttribute(Qt.WA_TranslucentBackground, True)
+    if click_through:
+        view.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+    view.setStyleSheet("background: transparent;")
+    view.page().setBackgroundColor(Qt.transparent)
+    try:
+        profile = view.page().profile()
+        profile.setHttpCacheType(QWebEngineProfile.NoCache)
+        profile.setPersistentCookiesPolicy(QWebEngineProfile.NoPersistentCookies)
+    except Exception:
+        pass
+    try:
+        settings = view.settings()
+        settings.setAttribute(QWebEngineSettings.JavascriptEnabled, True)
+        settings.setAttribute(QWebEngineSettings.LocalStorageEnabled, False)
+        settings.setAttribute(QWebEngineSettings.ErrorPageEnabled, False)
+    except Exception:
+        pass
+    win.setCentralWidget(view)
+
+    def _layout() -> None:
+        screen = app.primaryScreen()
+        if screen is not None:
+            win.setGeometry(screen.geometry())
+        view.setGeometry(win.rect())
+        win.showFullScreen()
+        win.raise_()
+
+    QTimer.singleShot(0, _layout)
+    keep_above = QTimer()
+    keep_above.setInterval(2000)
+    keep_above.timeout.connect(_layout)
+    keep_above.start()
+
+    view.load(QUrl(url))
+    return int(app.exec())
+
+def _run_gtk_overlay(url: str, *, click_through: bool) -> int:
     try:
         import gi
         gi.require_version("Gtk", "3.0")
@@ -41,11 +142,9 @@ def main(argv: list[str] | None = None) -> int:
 
         from gi.repository import Gtk, WebKit2, GLib, Gdk
     except Exception as e:
-        _eprint("RelayTV overlay requires GTK3 + WebKitGTK (PyGObject).")
-        _eprint("Install (Ubuntu 24.04+ / newer Debian): apt-get install -y python3-gi gir1.2-gtk-3.0 gir1.2-webkit2-4.1")
-        _eprint("Install (older Debian/Ubuntu): apt-get install -y python3-gi gir1.2-gtk-3.0 gir1.2-webkit2-4.0")
-        _eprint("Error:", e)
-        return 2
+        _eprint("GTK/WebKitGTK overlay backend unavailable; trying Qt WebEngine fallback.")
+        _eprint("GTK error:", e)
+        return _run_qt_overlay(url, click_through=click_through)
 
     # Must be on X11 for the always-on-top transparent overlay semantics we rely on.
     if os.getenv("XDG_SESSION_TYPE", "").strip().lower() == "wayland":
@@ -116,7 +215,7 @@ def main(argv: list[str] | None = None) -> int:
     # Optional click-through: make the window input-transparent to mouse events.
     # This only works on X11 and requires an X11 window to exist (after realize).
     def _enable_click_through():
-        if not args.click_through:
+        if not click_through:
             return
         try:
             gdk_win = win.get_window()
@@ -133,11 +232,22 @@ def main(argv: list[str] | None = None) -> int:
     # Close behavior
     win.connect("destroy", lambda *_: Gtk.main_quit())
 
-    view.load_uri(args.url)
+    view.load_uri(url)
 
     win.show_all()
     Gtk.main()
     return 0
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    ap = argparse.ArgumentParser(description="RelayTV X11 Overlay (WebKitGTK)")
+    ap.add_argument("--url", default=os.getenv("RELAYTV_OVERLAY_URL", "http://127.0.0.1:8787/x11/overlay"))
+    click_through_default = os.getenv("RELAYTV_OVERLAY_CLICKTHROUGH", "1").strip().lower() in ("1","true","yes","on")
+    ap.add_argument("--click-through", action="store_true", default=click_through_default)
+    args = ap.parse_args(argv)
+
+    return _run_gtk_overlay(args.url, click_through=args.click_through)
 
 
 if __name__ == "__main__":

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -45,6 +45,51 @@ def _idle_dashboard_enabled() -> bool:
     return True
 
 
+def _idle_notifications_enabled() -> bool:
+    try:
+        settings = state.get_settings() if hasattr(state, "get_settings") else {}
+    except Exception:
+        settings = {}
+    if isinstance(settings, dict) and settings.get("idle_notifications_enabled") is False:
+        return False
+    raw = (os.getenv("RELAYTV_IDLE_NOTIFICATIONS_ENABLED") or "").strip().lower()
+    if raw in ("0", "false", "no", "off"):
+        return False
+    return True
+
+
+def idle_notifications_enabled() -> bool:
+    return _idle_notifications_enabled()
+
+
+def _x11_idle_notifications_available() -> bool:
+    if not _idle_notifications_enabled():
+        return False
+    try:
+        from . import x11_overlay
+        return bool(x11_overlay.overlay_enabled() and x11_overlay.x11_session())
+    except Exception:
+        return False
+
+
+def _idle_qt_shell_enabled(*, allow_notification_fallback: bool = False) -> bool:
+    if _idle_dashboard_enabled():
+        return True
+    if not _idle_notifications_enabled():
+        return False
+    if allow_notification_fallback:
+        return True
+    return not _x11_idle_notifications_available()
+
+
+def _idle_visual_surface_enabled() -> bool:
+    return bool(_idle_dashboard_enabled() or _idle_notifications_enabled())
+
+
+def idle_visual_surface_enabled() -> bool:
+    return _idle_visual_surface_enabled()
+
+
 def _native_sidecar_health_snapshot(require_qt_shell: bool = False):
     """Legacy compatibility shim retained for dev-branch tests.
 
@@ -1033,11 +1078,11 @@ def _start_qt_external_mpv(
     return subprocess.Popen(args)
 
 
-def ensure_qt_shell_idle(*, force: bool = False) -> None:
+def ensure_qt_shell_idle(*, force: bool = False, allow_notification_fallback: bool = False) -> None:
     """Ensure Qt shell is running in idle-overlay mode for qt backend."""
     if not _qt_shell_backend_enabled():
         return
-    if not _idle_dashboard_enabled():
+    if not _idle_qt_shell_enabled(allow_notification_fallback=allow_notification_fallback):
         return
     qpa_platform = (os.getenv("QT_QPA_PLATFORM") or "").strip().lower()
     headless_qpa = qpa_platform in ("offscreen", "vnc", "minimal")
@@ -2084,10 +2129,10 @@ def stop_mpv(*, restart_splash: bool = True):
 
 
 def stop_playback_keep_qt_shell() -> bool:
-    """Stop current media while keeping the Qt shell alive for idle overlay."""
+    """Stop current media while keeping Qt shell alive for idle UI/toasts."""
     if not _qt_shell_backend_enabled():
         return False
-    if not _idle_dashboard_enabled():
+    if not _idle_qt_shell_enabled():
         return False
     _persist_runtime_volume_before_stop()
     try:
@@ -4195,7 +4240,7 @@ def _handle_playback_idle_no_queue() -> None:
     settle_sec = max(1.0, min(30.0, settle_sec))
     _NATURAL_IDLE_RESET_UNTIL = time.time() + settle_sec
     if _qt_shell_backend_enabled():
-        if not _idle_dashboard_enabled():
+        if not _idle_qt_shell_enabled():
             try:
                 stop_mpv(restart_splash=False)
             except Exception:

--- a/app/relaytv_app/routes.py
+++ b/app/relaytv_app/routes.py
@@ -26,7 +26,7 @@ import tempfile
 import urllib.request
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-from . import state, resolver, player, devices, discovery_mdns, video_profile, upload_store
+from . import state, resolver, player, devices, discovery_mdns, video_profile, upload_store, x11_overlay
 from .integrations import jellyfin_receiver
 from .debug import debug_log, get_logger
 from .thumb_cache import THUMB_DIR, ensure_cached_sync, attach_local_thumbnail, thumb_id, local_rel_path
@@ -739,6 +739,7 @@ def _notification_capabilities() -> dict:
     return {
         "visual_runtime_mode": visual_runtime_mode,
         "notification_strategy": strategy,
+        "idle_notifications_enabled": _idle_notifications_enabled_for_player(),
         "notifications_available": available,
         "notifications_reason": reason,
         "overlay_subscribers": max(0, int(subscribers)),
@@ -2424,6 +2425,7 @@ class SettingsReq(BaseModel):
     tv_auto_resume_on_return: str | None = None
     volume: float | None = None
     idle_dashboard_enabled: bool | None = None
+    idle_notifications_enabled: bool | None = None
     idle_qr_enabled: bool | None = None
     idle_qr_size: int | None = None
     idle_panels: dict[str, dict] | None = None
@@ -2599,14 +2601,15 @@ def next_track():
 
 def _stop_current_for_idle_or_desktop() -> bool:
     keep_qt_shell = bool(
-        _idle_dashboard_enabled_for_player()
+        _idle_visual_surface_enabled_for_player()
         and getattr(player, "_qt_shell_backend_enabled", lambda: False)()
     )
     if keep_qt_shell:
         stopped_in_place = bool(getattr(player, "stop_playback_keep_qt_shell", lambda: False)())
         if stopped_in_place:
             return True
-    player.stop_mpv(restart_splash=_idle_dashboard_enabled_for_player())
+    player.stop_mpv(restart_splash=_idle_visual_surface_enabled_for_player())
+    _ensure_notification_surface(wait_for_subscriber=False)
     return False
 
 
@@ -2915,6 +2918,7 @@ def overlay(req: OverlayReq):
     if not text:
         raise HTTPException(status_code=400, detail="text or image_url is required")
     duration_ms = max(250, int(float(req.duration) * 1000.0))
+    _ensure_notification_surface(wait_for_subscriber=True)
     # In visual runtimes we use overlay toasts only.
     # In headless runtime, notifications are unavailable.
     x11_overlay_mode = _x11_mode_notifications()
@@ -6049,6 +6053,70 @@ def _idle_dashboard_enabled_for_player() -> bool:
         return True
 
 
+def _idle_notifications_enabled_for_player() -> bool:
+    try:
+        return bool(getattr(player, "idle_notifications_enabled", lambda: True)())
+    except Exception:
+        return True
+
+
+def _idle_visual_surface_enabled_for_player() -> bool:
+    try:
+        return bool(getattr(player, "idle_visual_surface_enabled", lambda: True)())
+    except Exception:
+        return _idle_dashboard_enabled_for_player() or _idle_notifications_enabled_for_player()
+
+
+def _ensure_notification_surface(*, wait_for_subscriber: bool = False) -> None:
+    if not _idle_notifications_enabled_for_player():
+        return
+    try:
+        x11_overlay.start_overlay()
+    except Exception:
+        pass
+    try:
+        if not x11_overlay.overlay_running() and bool(getattr(player, "_qt_shell_backend_enabled", lambda: False)()):
+            player.ensure_qt_shell_idle(force=True, allow_notification_fallback=True)
+    except Exception:
+        pass
+    if not wait_for_subscriber:
+        return
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        try:
+            if len(_X11_OVERLAY_SUBS) > 0:
+                return
+        except Exception:
+            pass
+        try:
+            if bool(getattr(player, "_qt_shell_running", lambda: False)()):
+                return
+        except Exception:
+            pass
+        time.sleep(0.05)
+
+
+def _sync_idle_visual_surfaces_after_settings() -> None:
+    try:
+        playing = bool(player.is_playing())
+    except Exception:
+        playing = False
+    if playing:
+        return
+    if not _idle_notifications_enabled_for_player():
+        try:
+            x11_overlay.stop_overlay()
+        except Exception:
+            pass
+    if _idle_visual_surface_enabled_for_player():
+        _ensure_notification_surface(wait_for_subscriber=False)
+    else:
+        try:
+            player.stop_mpv(restart_splash=False)
+        except Exception:
+            pass
+
+
 def _jellyfin_progress_snapshot() -> dict | None:
     now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
     if not now:
@@ -7546,7 +7614,7 @@ def close():
     state.set_session_state("closed" if preserve_resume else "idle")
     keep_qt_shell = bool(
         preserve_resume
-        and _idle_dashboard_enabled_for_player()
+        and _idle_visual_surface_enabled_for_player()
         and getattr(player, "_qt_shell_backend_enabled", lambda: False)()
     )
     stopped_in_place = False
@@ -7555,7 +7623,8 @@ def close():
             stopped_in_place = bool(getattr(player, "stop_playback_keep_qt_shell", lambda: False)())
     if not stopped_in_place:
         with player.MPV_LOCK:
-            player.stop_mpv(restart_splash=_idle_dashboard_enabled_for_player())
+            player.stop_mpv(restart_splash=_idle_visual_surface_enabled_for_player())
+        _ensure_notification_surface(wait_for_subscriber=False)
 
     if preserve_resume:
         player.update_history_progress(
@@ -7817,6 +7886,7 @@ def _playback_state_fast_snapshot() -> dict[str, object]:
     payload: dict[str, object] = {
         "state": sess,
         "idle_dashboard_enabled": bool((state.get_settings() if hasattr(state, "get_settings") else {}).get("idle_dashboard_enabled", True)),
+        "idle_notifications_enabled": bool((state.get_settings() if hasattr(state, "get_settings") else {}).get("idle_notifications_enabled", True)),
         "playing": bool(playing),
         "paused": bool(paused),
         "has_now_playing": has_now_playing,
@@ -8140,6 +8210,7 @@ def _status_payload() -> dict[str, object]:
         "state": sess,
         "device_name": str(settings_snapshot.get("device_name") or "RelayTV"),
         "idle_dashboard_enabled": bool(settings_snapshot.get("idle_dashboard_enabled", True)),
+        "idle_notifications_enabled": bool(settings_snapshot.get("idle_notifications_enabled", True)),
         "mdns_advertising": bool(mdns.get("active")),
         "mdns_service_type": str(mdns.get("service_type") or ""),
         "jellyfin_enabled": jf_enabled,
@@ -8324,6 +8395,7 @@ def _settings_for_client(raw: dict | None) -> dict:
     out["youtube_use_invidious"] = bool(out.get("youtube_use_invidious"))
     out["youtube_invidious_base"] = str(out.get("youtube_invidious_base") or "").strip()
     out["idle_dashboard_enabled"] = bool(out.get("idle_dashboard_enabled", True))
+    out["idle_notifications_enabled"] = bool(out.get("idle_notifications_enabled", True))
     return out
 
 
@@ -8783,6 +8855,8 @@ def update_settings(req: SettingsReq):
         os.environ["RELAYTV_SUB_LANG"] = str(updated.get("sub_lang") or "")
     if "idle_dashboard_enabled" in requested_keys and updated.get("idle_dashboard_enabled") is not None:
         os.environ["RELAYTV_IDLE_DASHBOARD_ENABLED"] = "1" if bool(updated.get("idle_dashboard_enabled")) else "0"
+    if "idle_notifications_enabled" in requested_keys and updated.get("idle_notifications_enabled") is not None:
+        os.environ["RELAYTV_IDLE_NOTIFICATIONS_ENABLED"] = "1" if bool(updated.get("idle_notifications_enabled")) else "0"
     if "idle_qr_enabled" in requested_keys and updated.get("idle_qr_enabled") is not None:
         os.environ["RELAYTV_IDLE_QR_ENABLED"] = "1" if bool(updated.get("idle_qr_enabled")) else "0"
     if "idle_qr_size" in requested_keys and updated.get("idle_qr_size") is not None:
@@ -8909,6 +8983,13 @@ def update_settings(req: SettingsReq):
                 live_apply_failed.append("jellyfin_user_id")
     if "jellyfin_playback_mode" in requested_keys and "jellyfin_playback_mode" not in live_applied:
         live_applied.append("jellyfin_playback_mode")
+    if requested_keys.intersection({"idle_dashboard_enabled", "idle_notifications_enabled"}):
+        idle_keys = sorted(requested_keys.intersection({"idle_dashboard_enabled", "idle_notifications_enabled"}))
+        try:
+            _sync_idle_visual_surfaces_after_settings()
+            live_applied.extend(k for k in idle_keys if k not in live_applied)
+        except Exception:
+            live_apply_failed.extend(k for k in idle_keys if k not in live_apply_failed)
 
     now = None
     apply_performed = False
@@ -15347,6 +15428,7 @@ async function loadSettingsUi(){
   const ytCookiesState = document.getElementById('setYtCookiesState');
   const subs = document.getElementById('setSubs');
   const idleDashboardEnabled = document.getElementById('setIdleDashboardEnabled');
+  const idleNotificationsEnabled = document.getElementById('setIdleNotificationsEnabled');
   const idleQrEnabled = document.getElementById('setIdleQrEnabled');
   const idleQrSize = document.getElementById('setIdleQrSize');
   const idleQrSizeVal = document.getElementById('setIdleQrSizeVal');
@@ -15464,6 +15546,7 @@ async function loadSettingsUi(){
     subs.value = (cur.sub_lang || '');
   }
   if (idleDashboardEnabled) idleDashboardEnabled.checked = (cur.idle_dashboard_enabled !== false);
+  if (idleNotificationsEnabled) idleNotificationsEnabled.checked = (cur.idle_notifications_enabled !== false);
   if (idleQrEnabled) idleQrEnabled.checked = (cur.idle_qr_enabled !== false);
   if (idleQrSize) {
     const size = Number(cur.idle_qr_size);
@@ -15717,6 +15800,7 @@ function bindSettingsUi(){
     const ytInvidiousBase = (document.getElementById('setYtInvidiousBase')?.value || '').trim();
     const subs = document.getElementById('setSubs')?.value || '';
     const idleDashboardEnabled = document.getElementById('setIdleDashboardEnabled')?.checked !== false;
+    const idleNotificationsEnabled = document.getElementById('setIdleNotificationsEnabled')?.checked !== false;
     const idleQrEnabled = !!document.getElementById('setIdleQrEnabled')?.checked;
     const idleQrSize = Number(document.getElementById('setIdleQrSize')?.value || '168');
     const idleQrSizeSafe = Number.isFinite(idleQrSize) ? Math.max(96, Math.min(280, Math.round(idleQrSize))) : 168;
@@ -15760,6 +15844,7 @@ function bindSettingsUi(){
       youtube_invidious_base: ytInvidiousBase,
       sub_lang: subs,
       idle_dashboard_enabled: idleDashboardEnabled,
+      idle_notifications_enabled: idleNotificationsEnabled,
       idle_qr_enabled: idleQrEnabled,
       idle_qr_size: idleQrSizeSafe,
       idle_panels: collectIdlePanelSettings(),
@@ -15957,6 +16042,16 @@ window.addEventListener('DOMContentLoaded', () => {
           </div>
           <label class="toggleSwitch" for="setIdleDashboardEnabled" title="Show idle dashboard between plays">
             <input type="checkbox" id="setIdleDashboardEnabled" />
+            <span class="toggleTrack" aria-hidden="true"></span>
+          </label>
+        </div>
+        <div class="toggleRow">
+          <div class="toggleCopy">
+            <div class="toggleTitle">Show toast notifications while idle</div>
+            <div class="toggleHint">Keep a lightweight notification surface available when nothing is playing.</div>
+          </div>
+          <label class="toggleSwitch" for="setIdleNotificationsEnabled" title="Show toast notifications while idle">
+            <input type="checkbox" id="setIdleNotificationsEnabled" />
             <span class="toggleTrack" aria-hidden="true"></span>
           </label>
         </div>

--- a/app/relaytv_app/state.py
+++ b/app/relaytv_app/state.py
@@ -936,6 +936,7 @@ def _default_settings() -> dict:
         "tv_auto_resume_on_return": "0",
         "volume": default_volume,
         "idle_dashboard_enabled": _env_bool("RELAYTV_IDLE_DASHBOARD_ENABLED", True),
+        "idle_notifications_enabled": _env_bool("RELAYTV_IDLE_NOTIFICATIONS_ENABLED", True),
         "idle_qr_enabled": _env_bool("RELAYTV_IDLE_QR_ENABLED", True),
         "idle_qr_size": _normalize_idle_qr_size(os.getenv("RELAYTV_IDLE_QR_SIZE", "168"), 168),
         "idle_panels": _default_idle_panels(),
@@ -973,6 +974,7 @@ def load_settings() -> None:
     defaults["youtube_invidious_base"] = _normalize_invidious_base(defaults.get("youtube_invidious_base"))
     defaults["volume"] = _normalize_volume(defaults.get("volume"), defaults.get("volume", 100.0))
     defaults["idle_dashboard_enabled"] = bool(defaults.get("idle_dashboard_enabled"))
+    defaults["idle_notifications_enabled"] = bool(defaults.get("idle_notifications_enabled", True))
     defaults["idle_qr_size"] = _normalize_idle_qr_size(defaults.get("idle_qr_size"), 168)
     defaults["idle_panels"] = _normalize_idle_panels(defaults.get("idle_panels"))
     defaults["weather"] = _normalize_weather_settings(defaults.get("weather"))
@@ -1010,6 +1012,7 @@ def update_settings(patch: dict) -> dict:
         "tv_auto_resume_on_return",
         "volume",
         "idle_dashboard_enabled",
+        "idle_notifications_enabled",
         "idle_qr_enabled",
         "idle_qr_size",
         "idle_panels",
@@ -1048,6 +1051,8 @@ def update_settings(patch: dict) -> dict:
         clean["volume"] = _normalize_volume(clean.get("volume"), 100.0)
     if "idle_dashboard_enabled" in clean:
         clean["idle_dashboard_enabled"] = bool(clean.get("idle_dashboard_enabled"))
+    if "idle_notifications_enabled" in clean:
+        clean["idle_notifications_enabled"] = bool(clean.get("idle_notifications_enabled"))
     if "idle_qr_enabled" in clean:
         clean["idle_qr_enabled"] = bool(clean.get("idle_qr_enabled"))
     if "idle_qr_size" in clean:

--- a/app/relaytv_app/x11_overlay.py
+++ b/app/relaytv_app/x11_overlay.py
@@ -16,18 +16,56 @@ import os
 import subprocess
 import sys
 import threading
+from pathlib import Path
 from typing import Optional
 
 _OVERLAY_LOCK = threading.Lock()
 _OVERLAY_PROC: Optional[subprocess.Popen] = None
 
+def _xauthority_file(env: dict[str, str]) -> str | None:
+    path = env.get("XAUTHORITY")
+    if path and Path(path).is_file():
+        return path
+    runtime_dir = env.get("XDG_RUNTIME_DIR")
+    if not runtime_dir:
+        return None
+    try:
+        candidates = sorted(
+            Path(runtime_dir).glob(".mutter-Xwaylandauth.*"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except Exception:
+        return None
+    for candidate in candidates:
+        try:
+            if candidate.is_file():
+                return str(candidate)
+        except Exception:
+            continue
+    return None
+
 def x11_session() -> bool:
-    if os.getenv("XDG_SESSION_TYPE", "").strip().lower() == "wayland":
-        return False
+    # DISPLAY is the useful signal here: on Wayland hosts the container may
+    # still have Xwayland available, which gives us the click-through overlay
+    # semantics we need without keeping the Qt shell's black window alive.
     return bool(os.getenv("DISPLAY"))
 
 def overlay_enabled() -> bool:
-    return os.getenv("RELAYTV_X11_OVERLAY", "0").strip().lower() in ("1", "true", "yes", "on")
+    explicit = os.getenv("RELAYTV_X11_OVERLAY")
+    if explicit is not None and explicit.strip().lower() in ("1", "true", "yes", "on"):
+        return True
+    raw = (os.getenv("RELAYTV_IDLE_NOTIFICATIONS_ENABLED") or "").strip().lower()
+    if raw in ("0", "false", "no", "off"):
+        return False
+    try:
+        from . import state
+        settings = state.get_settings() if hasattr(state, "get_settings") else {}
+        if isinstance(settings, dict) and settings.get("idle_notifications_enabled") is False:
+            return False
+    except Exception:
+        pass
+    return True
 
 def overlay_running() -> bool:
     global _OVERLAY_PROC
@@ -42,11 +80,28 @@ def start_overlay() -> None:
         if overlay_running():
             return
         try:
+            env = os.environ.copy()
+            env.setdefault("RELAYTV_OVERLAY_CLICKTHROUGH", "1")
+            # The main Qt shell may run on Wayland, but this overlay relies on
+            # X11/Xwayland semantics for transparent, click-through desktop use.
+            if env.get("DISPLAY"):
+                env["QT_QPA_PLATFORM"] = "xcb"
+                env["XDG_SESSION_TYPE"] = "x11"
+                env.pop("WAYLAND_DISPLAY", None)
+                xauthority = _xauthority_file(env)
+                if xauthority:
+                    env["XAUTHORITY"] = xauthority
+            log_path = Path(env.get("RELAYTV_OVERLAY_LOG", "/tmp/relaytv-overlay.log"))
+            try:
+                log_handle = log_path.open("ab")
+            except Exception:
+                log_handle = subprocess.DEVNULL
             # Prefer module execution so it works in editable installs and within the package.
             _OVERLAY_PROC = subprocess.Popen(
                 [sys.executable, "-m", "relaytv_app.overlay_app"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=log_handle,
+                env=env,
             )
         except Exception:
             _OVERLAY_PROC = None

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -45,6 +45,7 @@ def test_ui_smoke() -> None:
     assert 'id="nowSubLangBtn"' in response.text
     assert 'id="aboutBtn"' in response.text
     assert 'id="aboutBackdrop"' in response.text
+    assert 'id="setIdleNotificationsEnabled"' in response.text
     assert 'id="aboutGithubLink"' in response.text
     assert 'id="aboutVersionValue"' in response.text
     assert 'id="aboutRevisionValue"' in response.text
@@ -852,6 +853,107 @@ def test_overlay_playback_visibility_prefers_session_and_transition_signals() ->
     assert "root.style.setProperty(name, `${Math.round(Number(base) * scale)}px`);" in response.text
 
 
+def test_x11_overlay_enabled_by_idle_notifications_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    from relaytv_app import x11_overlay
+
+    monkeypatch.delenv("RELAYTV_X11_OVERLAY", raising=False)
+    monkeypatch.delenv("RELAYTV_IDLE_NOTIFICATIONS_ENABLED", raising=False)
+    monkeypatch.setattr(routes.state, "get_settings", lambda: {"idle_notifications_enabled": True})
+
+    assert x11_overlay.overlay_enabled() is True
+
+
+def test_x11_overlay_can_be_disabled_with_idle_notifications_setting(monkeypatch: pytest.MonkeyPatch) -> None:
+    from relaytv_app import x11_overlay
+
+    monkeypatch.delenv("RELAYTV_X11_OVERLAY", raising=False)
+    monkeypatch.setenv("RELAYTV_IDLE_NOTIFICATIONS_ENABLED", "0")
+    monkeypatch.setattr(routes.state, "get_settings", lambda: {"idle_notifications_enabled": True})
+
+    assert x11_overlay.overlay_enabled() is False
+
+
+def test_x11_overlay_click_through_defaults_on() -> None:
+    text = (ROOT_DIR / "app/relaytv_app/overlay_app.py").read_text()
+    assert 'os.getenv("RELAYTV_OVERLAY_CLICKTHROUGH", "1")' in text
+
+
+def test_x11_overlay_uses_qt_fallback_when_gtk_unavailable() -> None:
+    text = (ROOT_DIR / "app/relaytv_app/overlay_app.py").read_text()
+    assert "GTK/WebKitGTK overlay backend unavailable; trying Qt WebEngine fallback." in text
+    assert "from PySide6.QtWebEngineWidgets import QWebEngineView" in text
+    assert "Qt.WA_TransparentForMouseEvents" in text
+    assert "view.page().setBackgroundColor(Qt.transparent)" in text
+    assert "RELAYTV_QT_OVERLAY_SOFTWARE" in text
+    assert "--disable-gpu-compositing" in text
+
+
+def test_x11_overlay_launch_forces_xcb_with_clickthrough(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from relaytv_app import x11_overlay
+
+    calls: list[dict] = []
+
+    class DummyProc:
+        def poll(self):
+            return None
+
+    def fake_popen(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        return DummyProc()
+
+    monkeypatch.setattr(x11_overlay, "_OVERLAY_PROC", None)
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.setenv("QT_QPA_PLATFORM", "wayland")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.setenv("RELAYTV_OVERLAY_LOG", str(tmp_path / "overlay.log"))
+
+    x11_overlay.start_overlay()
+
+    assert len(calls) == 1
+    env = calls[0]["kwargs"]["env"]
+    assert env["QT_QPA_PLATFORM"] == "xcb"
+    assert env["XDG_SESSION_TYPE"] == "x11"
+    assert env["RELAYTV_OVERLAY_CLICKTHROUGH"] == "1"
+    assert "WAYLAND_DISPLAY" not in env
+
+    x11_overlay._OVERLAY_PROC = None
+
+
+def test_x11_overlay_launch_repairs_stale_xauthority(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from relaytv_app import x11_overlay
+
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+    stale_xauthority = tmp_path / ".Xauthority"
+    stale_xauthority.mkdir()
+    valid_xauthority = runtime_dir / ".mutter-Xwaylandauth.TEST"
+    valid_xauthority.write_text("auth")
+    calls: list[dict] = []
+
+    class DummyProc:
+        def poll(self):
+            return None
+
+    def fake_popen(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        return DummyProc()
+
+    monkeypatch.setattr(x11_overlay, "_OVERLAY_PROC", None)
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setenv("XAUTHORITY", str(stale_xauthority))
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
+    monkeypatch.setenv("RELAYTV_OVERLAY_LOG", str(tmp_path / "overlay.log"))
+
+    x11_overlay.start_overlay()
+
+    assert calls[0]["kwargs"]["env"]["XAUTHORITY"] == str(valid_xauthority)
+
+    x11_overlay._OVERLAY_PROC = None
+
+
 def test_pwa_brand_banner_png_asset_resolves_with_logo_fallback() -> None:
     app = create_app(testing=True)
     client = TestClient(app)
@@ -1162,12 +1264,26 @@ def test_natural_queue_end_keeps_qt_shell_alive_before_idle_overlay(monkeypatch:
     assert player._NATURAL_IDLE_RESET_UNTIL == 1002.0
 
 
-def test_natural_queue_end_stops_qt_shell_when_idle_dashboard_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_natural_queue_end_keeps_qt_shell_for_idle_notifications_without_x11(monkeypatch: pytest.MonkeyPatch) -> None:
     stop_calls: list[bool] = []
     ensure_calls: list[bool] = []
 
+    class ImmediateTimer:
+        daemon = False
+
+        def __init__(self, delay, callback):
+            self.delay = delay
+            self.callback = callback
+
+        def cancel(self):
+            pass
+
+        def start(self):
+            self.callback()
+
     monkeypatch.setenv("RELAYTV_NATURAL_IDLE_SETTLE_SEC", "2")
     monkeypatch.setattr(player.time, "time", lambda: 1500.0)
+    monkeypatch.setattr(player, "_NATURAL_IDLE_ENSURE_TIMER", None, raising=False)
     monkeypatch.setattr(player, "_emit_jellyfin_stopped_from_now", lambda now: None)
     monkeypatch.setattr(player.state, "NOW_PLAYING", {"title": "Ended"}, raising=False)
     monkeypatch.setattr(player.state, "SESSION_STATE", "playing", raising=False)
@@ -1176,14 +1292,39 @@ def test_natural_queue_end_stops_qt_shell_when_idle_dashboard_disabled(monkeypat
     monkeypatch.setattr(player.state, "set_session_position", lambda value: None)
     monkeypatch.setattr(player, "_qt_shell_backend_enabled", lambda: True)
     monkeypatch.setattr(player, "_idle_dashboard_enabled", lambda: False)
+    monkeypatch.setattr(player, "_idle_notifications_enabled", lambda: True)
+    monkeypatch.setattr(player, "_x11_idle_notifications_available", lambda: False)
     monkeypatch.setattr(player, "stop_mpv", lambda restart_splash=True: stop_calls.append(bool(restart_splash)))
     monkeypatch.setattr(player, "ensure_qt_shell_idle", lambda force=False: ensure_calls.append(bool(force)))
+    monkeypatch.setattr(player.threading, "Timer", ImmediateTimer)
+
+    player._handle_playback_idle_no_queue()
+
+    assert stop_calls == []
+    assert ensure_calls == [False]
+    assert player._NATURAL_IDLE_RESET_UNTIL == 1502.0
+
+
+def test_natural_queue_end_stops_qt_shell_when_idle_visual_surface_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    stop_calls: list[bool] = []
+
+    monkeypatch.setenv("RELAYTV_NATURAL_IDLE_SETTLE_SEC", "2")
+    monkeypatch.setattr(player.time, "time", lambda: 1600.0)
+    monkeypatch.setattr(player, "_emit_jellyfin_stopped_from_now", lambda now: None)
+    monkeypatch.setattr(player.state, "NOW_PLAYING", {"title": "Ended"}, raising=False)
+    monkeypatch.setattr(player.state, "SESSION_STATE", "playing", raising=False)
+    monkeypatch.setattr(player.state, "set_now_playing", lambda value: None)
+    monkeypatch.setattr(player.state, "set_session_state", lambda value: None)
+    monkeypatch.setattr(player.state, "set_session_position", lambda value: None)
+    monkeypatch.setattr(player, "_qt_shell_backend_enabled", lambda: True)
+    monkeypatch.setattr(player, "_idle_dashboard_enabled", lambda: False)
+    monkeypatch.setattr(player, "_idle_notifications_enabled", lambda: False)
+    monkeypatch.setattr(player, "stop_mpv", lambda restart_splash=True: stop_calls.append(bool(restart_splash)))
 
     player._handle_playback_idle_no_queue()
 
     assert stop_calls == [False]
-    assert ensure_calls == []
-    assert player._NATURAL_IDLE_RESET_UNTIL == 1502.0
+    assert player._NATURAL_IDLE_RESET_UNTIL == 1602.0
 
 
 def test_natural_queue_end_starts_splash_for_non_qt_backend(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1367,17 +1508,21 @@ def test_close_preserves_now_playing_and_keeps_qt_shell_when_idle_enabled(monkey
     assert now_values[-1]['resume_pos'] == 12.5
 
 
-def test_close_tears_down_qt_shell_when_idle_dashboard_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_close_uses_overlay_not_qt_shell_for_idle_notifications_on_x11(monkeypatch: pytest.MonkeyPatch) -> None:
     stop_shell_calls: list[bool] = []
     stop_mpv_calls: list[bool] = []
+    ensure_surface_calls: list[bool] = []
 
     monkeypatch.setattr(routes.player, 'is_playing', lambda: True)
     monkeypatch.setattr(routes.player, 'native_qt_playback_explicitly_ended', lambda: False)
     monkeypatch.setattr(routes.player, '_idle_dashboard_enabled', lambda: False)
+    monkeypatch.setattr(routes.player, 'idle_notifications_enabled', lambda: True)
+    monkeypatch.setattr(routes.player, 'idle_visual_surface_enabled', lambda: True)
     monkeypatch.setattr(routes.player, '_qt_shell_backend_enabled', lambda: True)
     monkeypatch.setattr(routes.player, 'mpv_get', lambda prop: 12.5 if prop == 'time-pos' else 99.0)
-    monkeypatch.setattr(routes.player, 'stop_playback_keep_qt_shell', lambda: stop_shell_calls.append(True) or True)
+    monkeypatch.setattr(routes.player, 'stop_playback_keep_qt_shell', lambda: stop_shell_calls.append(True) or False)
     monkeypatch.setattr(routes.player, 'stop_mpv', lambda restart_splash=True: stop_mpv_calls.append(bool(restart_splash)))
+    monkeypatch.setattr(routes, '_ensure_notification_surface', lambda wait_for_subscriber=False: ensure_surface_calls.append(bool(wait_for_subscriber)))
     monkeypatch.setattr(routes, '_jellyfin_emit_stopped_hint', lambda pos, dur: None)
     monkeypatch.setattr(routes.state, 'NOW_PLAYING', {'title': 'Clip', 'url': 'https://example.com/video.mp4'}, raising=False)
     monkeypatch.setattr(routes.state, 'set_now_playing', lambda value: None)
@@ -1388,8 +1533,9 @@ def test_close_tears_down_qt_shell_when_idle_dashboard_disabled(monkeypatch: pyt
 
     assert out['status'] == 'closed'
     assert out['kept_player_shell'] is False
-    assert stop_shell_calls == []
-    assert stop_mpv_calls == [False]
+    assert stop_shell_calls == [True]
+    assert stop_mpv_calls == [True]
+    assert ensure_surface_calls == [False]
 
 
 def test_clear_now_playing_advances_queue_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1440,9 +1586,10 @@ def test_clear_now_playing_returns_to_idle_without_preserving_current(monkeypatc
     assert stop_mpv_calls == []
 
 
-def test_clear_now_playing_tears_down_when_idle_dashboard_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_clear_now_playing_uses_overlay_not_qt_shell_for_idle_notifications_on_x11(monkeypatch: pytest.MonkeyPatch) -> None:
     stop_shell_calls: list[bool] = []
     stop_mpv_calls: list[bool] = []
+    ensure_surface_calls: list[bool] = []
 
     monkeypatch.setattr(routes.state, 'QUEUE', [], raising=False)
     monkeypatch.setattr(routes.state, 'NOW_PLAYING', {'title': 'Current'}, raising=False)
@@ -1451,15 +1598,19 @@ def test_clear_now_playing_tears_down_when_idle_dashboard_disabled(monkeypatch: 
     monkeypatch.setattr(routes.state, 'set_session_state', lambda value: None)
     monkeypatch.setattr(routes.state, 'persist_queue', lambda: None)
     monkeypatch.setattr(routes.player, '_idle_dashboard_enabled', lambda: False)
+    monkeypatch.setattr(routes.player, 'idle_notifications_enabled', lambda: True)
+    monkeypatch.setattr(routes.player, 'idle_visual_surface_enabled', lambda: True)
     monkeypatch.setattr(routes.player, '_qt_shell_backend_enabled', lambda: True)
-    monkeypatch.setattr(routes.player, 'stop_playback_keep_qt_shell', lambda: stop_shell_calls.append(True) or True)
+    monkeypatch.setattr(routes.player, 'stop_playback_keep_qt_shell', lambda: stop_shell_calls.append(True) or False)
     monkeypatch.setattr(routes.player, 'stop_mpv', lambda restart_splash=True: stop_mpv_calls.append(bool(restart_splash)))
+    monkeypatch.setattr(routes, '_ensure_notification_surface', lambda wait_for_subscriber=False: ensure_surface_calls.append(bool(wait_for_subscriber)))
 
     out = routes.clear_now_playing()
 
     assert out == {'status': 'cleared', 'resume_available': False, 'kept_player_shell': False}
-    assert stop_shell_calls == []
-    assert stop_mpv_calls == [False]
+    assert stop_shell_calls == [True]
+    assert stop_mpv_calls == [True]
+    assert ensure_surface_calls == [False]
 
 
 def test_status_keeps_idle_non_playing_during_natural_idle_hold(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- keep idle toast notifications available when the idle dashboard is disabled and nothing is playing
- use a transparent, click-through X11/Xwayland overlay instead of preserving the Qt shell black window for idle notifications
- add a Qt WebEngine fallback for the standalone overlay when GTK/WebKitGTK (`gi`) is not installed
- repair stale `XAUTHORITY` values by discovering a valid Mutter Xwayland auth file under `XDG_RUNTIME_DIR`
- add overlay launch logging at `/tmp/relaytv-overlay.log` for future diagnosis

## User Impact

Desktop remains visible and usable when the idle dashboard is disabled, while RelayTV can still show toast notifications while the app is running.

## Operator / Deployment Impact

No new default image dependency is required. The default image already ships PySide6/Qt WebEngine for the Qt shell, and GTK/WebKitGTK remains an optional overlay backend via the existing build arg.

Existing running containers need a rebuilt image or refreshed app files plus restart to persist the fix.

## Root Cause

The default container did not include PyGObject/WebKitGTK, so the X11 overlay process exited before subscribing to `/x11/overlay/events`. Toast requests could return OK but had no overlay subscriber. In the live container, the configured `/tmp/.Xauthority` was also stale, preventing the Qt/XCB fallback from authenticating with Xwayland until the launcher repaired it.

## Breaking Changes

None.

## Tests Run

- `git diff --check`
- `python3 -m compileall app/relaytv_app/overlay_app.py app/relaytv_app/x11_overlay.py`
- `PYTHONPATH=app pytest -q tests/test_smoke.py`