### PR TITLE
ci: publish release after image push

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
       minor: ${{ steps.release.outputs.minor }}
       sha: ${{ steps.release.outputs.sha }}
     steps:
-      - name: Create or publish release
+      - name: Create or update release pull request, or create draft release
         id: release
         uses: googleapis/release-please-action@v4
         with:
@@ -32,7 +32,7 @@ jobs:
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - uses: actions/checkout@v6
@@ -75,3 +75,8 @@ jobs:
             RELAYTV_IMAGE_CREATED=${{ steps.created.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Publish GitHub Release after image push
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ needs.release-please.outputs.tag_name }}" --draft=false

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -11,8 +11,8 @@ The public image is:
 ghcr.io/mcgeezy/relaytv:latest
 ```
 
-The immutable release image is built by the Release Please workflow after a
-GitHub Release is published. Routine `main` branch CI builds publish the
+The immutable release image is built by the Release Please workflow before a
+GitHub Release is made public. Routine `main` branch CI builds publish the
 `ghcr.io/mcgeezy/relaytv:main` tag for branch validation and do not overwrite
 the release `latest` tag. The Dockerfile pins its base image by digest:
 
@@ -90,7 +90,7 @@ This repository was bootstrapped from the current `0.1.0` source baseline, so
 the first Release Please run starts changelog collection at the configured
 `bootstrap-sha` instead of importing the entire pre-automation history.
 
-When the release pull request is merged, Release Please creates the GitHub
+When the release pull request is merged, Release Please creates a draft GitHub
 Release and source tag, for example `v0.2.0`. The release workflow then builds
 and publishes immutable GHCR image tags:
 
@@ -100,6 +100,10 @@ ghcr.io/mcgeezy/relaytv:0.2.0
 ghcr.io/mcgeezy/relaytv:0.2
 ghcr.io/mcgeezy/relaytv:latest
 ```
+
+Only after the image push succeeds does the workflow publish the draft GitHub
+Release. If the image build or push fails, the release remains a draft so users
+do not see a public GitHub Release before matching GHCR images are available.
 
 The container image also exposes the release build metadata to the running app
 through `RELAYTV_IMAGE_VERSION`, `RELAYTV_IMAGE_REVISION`,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,9 @@
       "package-name": "relaytv",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
-      "include-v-in-tag": true
+      "include-v-in-tag": true,
+      "draft": true,
+      "force-tag-creation": true
     }
   }
 }

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -360,6 +360,8 @@ def test_release_please_automation_is_configured() -> None:
     assert '"release-type": "python"' in config
     assert '"package-name": "relaytv"' in config
     assert '"bootstrap-sha": "0c270faaccf1361416538a6230758b6bbe69bc17"' in config
+    assert '"draft": true' in config
+    assert '"force-tag-creation": true' in config
     assert json.loads(manifest)["."] == tomllib.loads(pyproject)["project"]["version"]
     assert "googleapis/release-please-action@v4" in workflow
     assert "contents: write" in workflow
@@ -368,6 +370,9 @@ def test_release_please_automation_is_configured() -> None:
     assert "token: ${{ secrets.GITHUB_TOKEN }}" in workflow
     assert "RELEASE_PLEASE_TOKEN" not in workflow
     assert "ghcr.io/${{ github.repository }}:${{ needs.release-please.outputs.tag_name }}" in workflow
+    assert "Publish GitHub Release after image push" in workflow
+    assert 'gh release edit "${{ needs.release-please.outputs.tag_name }}" --draft=false' in workflow
+    assert workflow.index("Publish release Docker image") < workflow.index("Publish GitHub Release after image push")
     assert "Conventional Commit PR title" in pr_title
     assert "User impact:" in pr_template
     assert "Operator/deployment impact:" in pr_template
@@ -375,6 +380,7 @@ def test_release_please_automation_is_configured() -> None:
     assert "Release notes are maintained by Release Please." in changelog
     assert "Automated Release Flow" in release_doc
     assert "built-in `GITHUB_TOKEN`" in release_doc
+    assert "Only after the image push succeeds" in release_doc
 
 
 def test_api_docs_include_app_info_endpoint() -> None:


### PR DESCRIPTION
## Summary

- configure Release Please to create draft releases while still creating the tag immediately
- publish GHCR release images before making the GitHub Release public
- undraft the GitHub Release only after the Docker build/push step succeeds
- document the image-before-release ordering and guard it in smoke tests

## User Impact

Users should not see a public GitHub Release before matching `latest`, versioned, and immutable GHCR image tags are available.

## Operator / Deployment Impact

The `release-image` job now needs `contents: write` so it can publish the draft GitHub Release after images are pushed. No new secrets are required; this continues using the built-in `GITHUB_TOKEN`.

## Breaking Changes

None.

## Tests Run

- `python3 -m json.tool release-please-config.json`
- `git diff --check`
- `PYTHONPATH=app pytest -q tests/test_smoke.py`