### PR TITLE
fix: keep close from replaying interrupted streams

### DIFF
--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -2136,6 +2136,15 @@ def stop_playback_keep_qt_shell() -> bool:
         return False
     _persist_runtime_volume_before_stop()
     try:
+        mpv_command(["playlist-clear"])
+    except Exception:
+        pass
+    try:
+        _clear_mpv_playlist_before_current()
+        _clear_mpv_playlist_after_current()
+    except Exception:
+        pass
+    try:
         result = mpv_command(["stop"])
     except Exception:
         return False
@@ -3412,6 +3421,8 @@ def _reset_mpv_up_next_state() -> None:
 
 def _mpv_up_next_load_target(item: object) -> tuple[list[object], str] | None:
     """Return the mpv loadfile command and armed media URL for queue head."""
+    if isinstance(item, dict) and item.get("_relaytv_interrupt_preserved") is True:
+        return None
     head_url = _queue_item_play_url(item)
     if not head_url:
         return None
@@ -4985,6 +4996,9 @@ def start_session_tracker_worker() -> None:
 def restart_current(apply_mode: str | None = None) -> dict | None:
     """Restart current playback to apply settings. Best-effort."""
     try:
+        sess = str(getattr(state, "SESSION_STATE", "idle") or "idle").strip().lower()
+        if sess not in ("playing", "paused"):
+            return None
         if not state.NOW_PLAYING:
             return None
         inp = (state.NOW_PLAYING.get("input") or state.NOW_PLAYING.get("url") or "").strip()

--- a/app/relaytv_app/routes.py
+++ b/app/relaytv_app/routes.py
@@ -2179,6 +2179,7 @@ _X11_OVERLAY_HTML = r"""<!doctype html>
     function overlayPlaybackVisible(state){
       const j = state || {};
       const sessionState = String(j.state || '').trim().toLowerCase();
+      if (sessionState === 'closed') return false;
       const runtimeState = String(j.playback_runtime_state || '').trim().toLowerCase();
       const qtRuntimeActive = (
         j.native_qt_mpv_runtime_playback_active === true
@@ -2451,6 +2452,23 @@ _TEMP_PLAYBACK_LOCK = threading.Lock()
 _TEMP_PLAYBACK_STACK: list[dict] = []
 
 
+def _discard_temporary_playback(reason: str) -> int:
+    """Discard temporary restore frames after an explicit user stop/close."""
+    with _TEMP_PLAYBACK_LOCK:
+        count = len(_TEMP_PLAYBACK_STACK)
+        _TEMP_PLAYBACK_STACK.clear()
+    if count:
+        try:
+            logger.info("temporary_playback_discarded reason=%s count=%s", reason, count)
+        except Exception:
+            pass
+    return count
+
+
+def _discard_interrupted_playback_state(reason: str) -> None:
+    _discard_temporary_playback(reason)
+
+
 def _capture_current_playback_state() -> dict | None:
     if not player.is_playing() or not isinstance(state.NOW_PLAYING, dict):
         return None
@@ -2622,6 +2640,7 @@ def clear_now_playing():
         return next_track()
 
     state.AUTO_NEXT_SUPPRESS_UNTIL = time.time() + 3600 * 24
+    _discard_interrupted_playback_state("now_playing_clear")
     with player.MPV_LOCK:
         stopped_in_place = _stop_current_for_idle_or_desktop()
     state.set_now_playing(None)
@@ -2755,6 +2774,8 @@ def _preserve_current_to_queue_front() -> dict | None:
         "url": url.strip(),
         "title": now.get("title") or url.strip(),
         "provider": now.get("provider"),
+        "_relaytv_interrupt_preserved": True,
+        "_relaytv_interrupt_preserved_at": int(time.time()),
     }
     if isinstance(now.get("channel"), str) and now.get("channel"):
         preserved["channel"] = now.get("channel")
@@ -7562,6 +7583,7 @@ def close():
     """Close the player but keep session resumable (queue preserved)."""
     # Prevent the autoplay worker from immediately advancing.
     state.AUTO_NEXT_SUPPRESS_UNTIL = time.time() + 3600 * 24  # 24h (reset on resume/play)
+    _discard_interrupted_playback_state("close")
 
     pos = None
     dur = None
@@ -7646,6 +7668,7 @@ def close():
 def clear_resumable_session():
     """Clear retained now-playing/resume state and return to idle."""
     state.AUTO_NEXT_SUPPRESS_UNTIL = time.time() + 3600 * 24
+    _discard_interrupted_playback_state("resume_clear")
     with player.MPV_LOCK:
         player.stop_mpv()
     state.set_now_playing(None)
@@ -7721,6 +7744,7 @@ def stop():
     """User stop with resume support; always return to idle visuals."""
     # Suppress autoplay after an explicit user stop until user starts playback again.
     state.AUTO_NEXT_SUPPRESS_UNTIL = time.time() + 3600 * 24
+    _discard_interrupted_playback_state("stop")
 
     pos = None
     dur = None
@@ -7800,7 +7824,7 @@ def _session_playing_fast() -> tuple[str, bool, bool]:
     has_now_playing = isinstance(getattr(state, "NOW_PLAYING", None), dict)
     queue_length = len(getattr(state, "QUEUE", []) or [])
     natural_idle_hold = bool(getattr(player, "natural_idle_reset_holding", lambda: False)())
-    if explicit_stop_hold and queue_length <= 0 and sess == "closed":
+    if explicit_stop_hold and sess == "closed":
         return sess, False, False
     if explicit_stop_hold and (not has_now_playing) and queue_length <= 0 and sess in ("idle", "closed"):
         return sess, False, False
@@ -7881,7 +7905,7 @@ def _playback_state_fast_snapshot() -> dict[str, object]:
     except Exception:
         explicit_stop_hold = False
     natural_idle_hold = bool(getattr(player, "natural_idle_reset_holding", lambda: False)())
-    closed_stop_hold = explicit_stop_hold and queue_length <= 0 and sess == "closed"
+    closed_stop_hold = explicit_stop_hold and sess == "closed"
     natural_idle_clear_hold = natural_idle_hold and queue_length <= 0 and (not has_now_playing) and sess in ("idle", "closed")
     payload: dict[str, object] = {
         "state": sess,
@@ -8000,9 +8024,13 @@ def _playback_state_fast_snapshot() -> dict[str, object]:
         payload["playing"] = True
         payload["state"] = "paused" if bool(payload.get("paused")) else "playing"
     elif closed_stop_hold:
+        transition_active = False
         payload["playing"] = False
         payload["paused"] = False
         payload["state"] = "closed"
+        payload["native_qt_mpv_runtime_playback_active"] = False
+        payload["native_qt_mpv_runtime_stream_loaded"] = False
+        payload["native_qt_mpv_runtime_playback_started"] = False
     elif natural_idle_clear_hold:
         payload["playing"] = False
         payload["paused"] = False
@@ -8069,7 +8097,7 @@ def _status_payload() -> dict[str, object]:
             transitioning_between_items = True
     except Exception:
         transitioning_between_items = False
-    if explicit_stop_hold and (not q) and str(sess or "idle").strip().lower() == "closed":
+    if explicit_stop_hold and str(sess or "idle").strip().lower() == "closed":
         playing = False
         transitioning_between_items = False
     elif explicit_stop_hold and (not has_now_playing) and (not q) and str(sess or "idle").strip().lower() in ("idle", "closed"):
@@ -8991,10 +9019,12 @@ def update_settings(req: SettingsReq):
         except Exception:
             live_apply_failed.extend(k for k in idle_keys if k not in live_apply_failed)
 
+    sess_for_apply = str(getattr(state, "SESSION_STATE", "idle") or "idle").strip().lower()
+    apply_restart_allowed = bool(apply_now and sess_for_apply in ("playing", "paused") and isinstance(state.NOW_PLAYING, dict))
     now = None
     apply_performed = False
     apply_succeeded = False
-    if apply_now:
+    if apply_restart_allowed:
         if hasattr(player, "restart_current"):
             apply_performed = True
             now = player.restart_current()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -840,6 +840,7 @@ def test_overlay_playback_visibility_prefers_session_and_transition_signals() ->
 
     assert response.status_code == 200
     assert 'function overlayPlaybackVisible(state)' in response.text
+    assert "if (sessionState === 'closed') return false;" in response.text
     assert "j.native_qt_mpv_runtime_stream_loaded === true" in response.text
     assert "j.transition_in_progress === true" in response.text
     assert "return qtRuntimeActive || sessionActive;" in response.text
@@ -1067,6 +1068,46 @@ def test_jellyfin_subtitle_select_can_turn_subtitles_off_in_place(monkeypatch: p
     assert body["current_subtitle_language"] == "off"
     assert captured_now["jellyfin_subtitle_stream_index"] == "-1"
     assert captured_now["jellyfin_subtitle_language"] == "off"
+
+
+def test_settings_apply_now_does_not_restart_closed_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(routes.state, 'SESSION_STATE', 'closed', raising=False)
+    monkeypatch.setattr(
+        routes.state,
+        'NOW_PLAYING',
+        {
+            'url': 'https://example.com/closed.mp4',
+            'title': 'Closed',
+            'closed': True,
+            'resume_pos': 42.0,
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(routes.state, 'get_settings', lambda: {'idle_dashboard_enabled': False})
+    monkeypatch.setattr(
+        routes.state,
+        'update_settings',
+        lambda patch: {'idle_dashboard_enabled': bool(patch.get('idle_dashboard_enabled'))},
+    )
+    monkeypatch.setattr(routes.player, 'is_playing', lambda: True)
+    monkeypatch.setattr(
+        routes.player,
+        'restart_current',
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError('closed session must not restart')),
+    )
+    monkeypatch.setattr(routes, '_sync_idle_visual_surfaces_after_settings', lambda: None)
+
+    app = create_app(testing=True)
+    client = TestClient(app)
+
+    response = client.post('/settings', json={'idle_dashboard_enabled': True, 'apply_now': True})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['ok'] is True
+    assert body['apply_now'] is True
+    assert body['apply_performed'] is False
+    assert body['apply_succeeded'] is False
 
 
 def test_native_idle_weather_layout_normalizes_to_supported_values() -> None:
@@ -1400,7 +1441,7 @@ def test_status_keeps_closed_session_non_playing_during_explicit_stop_hold(monke
     monkeypatch.setattr(routes.os.path, 'exists', lambda p: False)
     monkeypatch.setattr(routes.state, 'SESSION_STATE', 'closed', raising=False)
     monkeypatch.setattr(routes.state, 'NOW_PLAYING', {'title': 'stopped', 'closed': True}, raising=False)
-    monkeypatch.setattr(routes.state, 'QUEUE', [], raising=False)
+    monkeypatch.setattr(routes.state, 'QUEUE', [{'url': 'https://example.com/queued.mp4'}], raising=False)
     monkeypatch.setattr(routes.state, 'AUTO_NEXT_SUPPRESS_UNTIL', routes.time.time() + 3600.0, raising=False)
     monkeypatch.setattr(routes.player, 'mpv_get_many', lambda props: {})
 
@@ -1409,12 +1450,14 @@ def test_status_keeps_closed_session_non_playing_during_explicit_stop_hold(monke
     assert payload['state'] == 'closed'
     assert payload['playing'] is False
     assert payload['resume_available'] is True
+    assert payload['queue_length'] == 1
+    assert payload['transition_in_progress'] is False
 
 
 def test_playback_state_keeps_closed_session_non_playing_during_explicit_stop_hold(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(routes.state, 'SESSION_STATE', 'closed', raising=False)
     monkeypatch.setattr(routes.state, 'NOW_PLAYING', {'title': 'stopped', 'closed': True}, raising=False)
-    monkeypatch.setattr(routes.state, 'QUEUE', [], raising=False)
+    monkeypatch.setattr(routes.state, 'QUEUE', [{'url': 'https://example.com/queued.mp4'}], raising=False)
     monkeypatch.setattr(routes.state, 'AUTO_NEXT_SUPPRESS_UNTIL', routes.time.time() + 3600.0, raising=False)
     monkeypatch.setattr(routes.player, 'playback_transitioning', lambda: False)
     monkeypatch.setattr(
@@ -1441,6 +1484,9 @@ def test_playback_state_keeps_closed_session_non_playing_during_explicit_stop_ho
     assert payload['state'] == 'closed'
     assert payload['playing'] is False
     assert payload['has_now_playing'] is True
+    assert payload['queue_length'] == 1
+    assert payload['transition_in_progress'] is False
+    assert payload['native_qt_mpv_runtime_playback_active'] is False
 
 
 def test_playback_state_uses_mpv_ipc_when_qt_telemetry_is_unselected(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1506,6 +1552,76 @@ def test_close_preserves_now_playing_and_keeps_qt_shell_when_idle_enabled(monkey
     assert session_values == ['closed']
     assert now_values[-1]['closed'] is True
     assert now_values[-1]['resume_pos'] == 12.5
+
+
+def test_close_discards_temporary_restore_stack(monkeypatch: pytest.MonkeyPatch) -> None:
+    routes._TEMP_PLAYBACK_STACK.clear()
+    routes._TEMP_PLAYBACK_STACK.append({
+        'id': 'frame-1',
+        'resume': True,
+        'snapshot': {'now_playing': {'url': 'https://example.com/interrupted.mp4'}},
+    })
+
+    monkeypatch.setattr(routes.player, 'is_playing', lambda: True)
+    monkeypatch.setattr(routes.player, 'native_qt_playback_explicitly_ended', lambda: False)
+    monkeypatch.setattr(routes.player, '_idle_dashboard_enabled', lambda: True)
+    monkeypatch.setattr(routes.player, '_qt_shell_backend_enabled', lambda: True)
+    monkeypatch.setattr(routes.player, 'mpv_get', lambda prop: 12.5 if prop == 'time-pos' else 99.0)
+    monkeypatch.setattr(routes.player, 'stop_playback_keep_qt_shell', lambda: True)
+    monkeypatch.setattr(routes.player, 'stop_mpv', lambda restart_splash=True: None)
+    monkeypatch.setattr(routes, '_restore_playback_state', lambda snapshot: (_ for _ in ()).throw(AssertionError('close must not restore temporary playback')))
+    monkeypatch.setattr(routes, '_jellyfin_emit_stopped_hint', lambda pos, dur: None)
+    monkeypatch.setattr(routes.state, 'NOW_PLAYING', {'title': 'Active', 'url': 'https://example.com/active.mp4'}, raising=False)
+    monkeypatch.setattr(routes.state, 'set_now_playing', lambda value: None)
+    monkeypatch.setattr(routes.state, 'set_session_state', lambda value: None)
+    monkeypatch.setattr(routes.state, 'set_session_position', lambda value: None)
+
+    try:
+        out = routes.close()
+        assert out['status'] == 'closed'
+        assert routes._TEMP_PLAYBACK_STACK == []
+    finally:
+        routes._TEMP_PLAYBACK_STACK.clear()
+
+
+def test_close_preserves_interrupt_queue_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    persisted: list[dict] = []
+    queue_events: list[dict] = []
+    interrupted_queue_item = {
+        'url': 'https://example.com/interrupted.mp4',
+        'title': 'Interrupted',
+        'resume_pos': 37.0,
+        '_relaytv_interrupt_preserved': True,
+    }
+    normal_queue_item = {'url': 'https://example.com/normal.mp4', 'title': 'Normal'}
+
+    monkeypatch.setattr(
+        routes.state,
+        'QUEUE',
+        [interrupted_queue_item, normal_queue_item],
+        raising=False,
+    )
+    monkeypatch.setattr(routes.state, 'persist_queue_payload', lambda payload: persisted.append(dict(payload)))
+    monkeypatch.setattr(routes, '_ui_event_push_queue', lambda event, **payload: queue_events.append({'event': event, **payload}))
+    monkeypatch.setattr(routes.player, 'is_playing', lambda: True)
+    monkeypatch.setattr(routes.player, 'native_qt_playback_explicitly_ended', lambda: False)
+    monkeypatch.setattr(routes.player, '_idle_dashboard_enabled', lambda: True)
+    monkeypatch.setattr(routes.player, '_qt_shell_backend_enabled', lambda: True)
+    monkeypatch.setattr(routes.player, 'mpv_get', lambda prop: 12.5 if prop == 'time-pos' else 99.0)
+    monkeypatch.setattr(routes.player, 'stop_playback_keep_qt_shell', lambda: True)
+    monkeypatch.setattr(routes.player, 'stop_mpv', lambda restart_splash=True: None)
+    monkeypatch.setattr(routes, '_jellyfin_emit_stopped_hint', lambda pos, dur: None)
+    monkeypatch.setattr(routes.state, 'NOW_PLAYING', {'title': 'Active', 'url': 'https://example.com/active.mp4'}, raising=False)
+    monkeypatch.setattr(routes.state, 'set_now_playing', lambda value: None)
+    monkeypatch.setattr(routes.state, 'set_session_state', lambda value: None)
+    monkeypatch.setattr(routes.state, 'set_session_position', lambda value: None)
+
+    out = routes.close()
+
+    assert out['status'] == 'closed'
+    assert routes.state.QUEUE == [interrupted_queue_item, normal_queue_item]
+    assert persisted == []
+    assert queue_events == []
 
 
 def test_close_uses_overlay_not_qt_shell_for_idle_notifications_on_x11(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1780,6 +1896,37 @@ def test_resume_session_starts_resolved_stream_at_resume_position(monkeypatch: p
     assert load_calls == [{'stream': 'https://video.example/resolved.mp4', 'audio': 'https://audio.example/resolved.m4a', 'start_pos': 42.5}]
     assert start_calls == [{'stream': 'https://video.example/resolved.mp4', 'audio': 'https://audio.example/resolved.m4a', 'start_pos': 42.5}]
     assert seek_calls == []
+
+
+def test_preserve_current_marks_interrupt_queue_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    persisted: list[dict] = []
+
+    monkeypatch.setattr(routes.player, 'is_playing', lambda: True)
+    monkeypatch.setattr(routes.player, 'mpv_get', lambda prop: 37.0 if prop == 'time-pos' else 120.0)
+    monkeypatch.setattr(routes.player, 'update_history_progress', lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes.state, 'NOW_PLAYING', {'url': 'https://example.com/interrupted.mp4', 'title': 'Interrupted'}, raising=False)
+    monkeypatch.setattr(routes.state, 'QUEUE', [], raising=False)
+    monkeypatch.setattr(routes.state, 'persist_queue_payload', lambda payload: persisted.append(dict(payload)))
+    monkeypatch.setattr(routes.time, 'time', lambda: 1234.0)
+
+    preserved = routes._preserve_current_to_queue_front()
+
+    assert preserved is not None
+    assert preserved['_relaytv_interrupt_preserved'] is True
+    assert preserved['_relaytv_interrupt_preserved_at'] == 1234
+    assert preserved['resume_pos'] == 37.0
+    assert routes.state.QUEUE == [preserved]
+    assert persisted[-1]['queue'] == [preserved]
+
+
+def test_interrupt_preserved_queue_item_is_not_mpv_primed() -> None:
+    assert player._mpv_up_next_load_target(
+        {
+            'url': 'https://example.com/interrupted.mp4',
+            '_relaytv_interrupt_preserved': True,
+            '_resolved_stream': 'https://cdn.example.com/interrupted.mp4',
+        }
+    ) is None
 
 
 def test_play_item_reuses_fresh_resolved_stream_without_ytdlp(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2105,6 +2252,43 @@ def test_stop_mpv_ignores_invalid_runtime_volume(monkeypatch: pytest.MonkeyPatch
 
     assert 'patch' not in observed
     assert observed['stop_called'] is True
+
+
+def test_stop_playback_keep_qt_shell_clears_mpv_playlist_before_stop(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[object] = []
+
+    monkeypatch.setattr(player, '_qt_shell_backend_enabled', lambda: True)
+    monkeypatch.setattr(player, '_idle_qt_shell_enabled', lambda: True)
+    monkeypatch.setattr(player, '_persist_runtime_volume_before_stop', lambda: calls.append('persist_volume'))
+    monkeypatch.setattr(player, '_clear_mpv_playlist_before_current', lambda: calls.append('clear_before'))
+    monkeypatch.setattr(player, '_clear_mpv_playlist_after_current', lambda: calls.append('clear_after'))
+    monkeypatch.setattr(player, 'mpv_command', lambda cmd: calls.append(list(cmd)) or {'error': 'success'})
+    monkeypatch.setattr(player, '_reset_mpv_up_next_state', lambda: calls.append('reset_up_next'))
+    monkeypatch.setattr(player, '_mpv_cache_update', lambda payload: calls.append(('cache', dict(payload))))
+
+    assert player.stop_playback_keep_qt_shell() is True
+
+    assert calls[:5] == ['persist_volume', ['playlist-clear'], 'clear_before', 'clear_after', ['stop']]
+    assert 'reset_up_next' in calls
+    assert any(isinstance(call, tuple) and call[0] == 'cache' for call in calls)
+
+
+def test_restart_current_ignores_closed_resumable_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'closed', raising=False)
+    monkeypatch.setattr(
+        player.state,
+        'NOW_PLAYING',
+        {
+            'url': 'https://example.com/closed.mp4',
+            'closed': True,
+            'resume_pos': 42.0,
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(player, 'play_item', lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError('closed session must not replay')))
+    monkeypatch.setattr(player, 'stop_mpv', lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError('closed session must not stop/restart runtime')))
+
+    assert player.restart_current() is None
 
 
 def test_idle_qt_shell_can_be_reused_for_stream_load(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- prevent `Close` from replaying streams interrupted by `Play Now`
- keep user-visible queue entries intact after closing active playback
- mark interrupt-preserved queue entries so they are not mpv-primed via `append-play`
- clear mpv's internal playlist before stopping in-place Qt playback
- prevent settings `apply_now` from restarting closed resumable sessions
- keep closed sessions reported as non-playing even when queue entries remain, so the idle dashboard renders instead of a black playback surface

## User Impact

Pressing `Close` after interrupting playback now closes only the active item and returns to idle/dashboard or desktop. The closed item remains resumable, and queued/interrupted items remain available for later playback without auto-starting.

## Operator / Deployment Impact

No configuration or dependency changes. Existing containers need a rebuild/restart to pick up the behavior.

## Root Cause

Interrupted items were preserved as normal queue entries and could be appended into mpv's internal playlist for seamless up-next playback. During explicit close, mpv could fall through to that internal playlist entry. After preserving queue entries correctly, closed-session state also needed to override stale runtime/transition telemetry so the idle dashboard would render while queue items remained.

## Breaking Changes

None.

## Tests Run

- `python3 -m compileall app/relaytv_app/player.py app/relaytv_app/routes.py`
- `PYTHONPATH=app pytest -q tests/test_smoke.py`
- `git diff --check`