### PR TITLE
fix: persist interrupted close state across reloads

### DIFF
--- a/app/relaytv_app/routes.py
+++ b/app/relaytv_app/routes.py
@@ -2634,13 +2634,13 @@ def _stop_current_for_idle_or_desktop() -> bool:
 @router.post("/now_playing/clear")
 def clear_now_playing():
     """Discard current now-playing item; advance queue or return to idle/desktop."""
+    _discard_interrupted_playback_state("now_playing_clear")
     with state.QUEUE_LOCK:
         has_queue = bool(state.QUEUE)
     if has_queue:
         return next_track()
 
     state.AUTO_NEXT_SUPPRESS_UNTIL = time.time() + 3600 * 24
-    _discard_interrupted_playback_state("now_playing_clear")
     with player.MPV_LOCK:
         stopped_in_place = _stop_current_for_idle_or_desktop()
     state.set_now_playing(None)

--- a/app/relaytv_app/state.py
+++ b/app/relaytv_app/state.py
@@ -290,6 +290,15 @@ def _persistable_queue_item(item: dict) -> dict | None:
         if resolved_at > 0.0:
             out["_resolved_at"] = resolved_at
 
+    if item.get("_relaytv_interrupt_preserved") is True:
+        out["_relaytv_interrupt_preserved"] = True
+        try:
+            preserved_at = int(item.get("_relaytv_interrupt_preserved_at") or 0)
+        except Exception:
+            preserved_at = 0
+        if preserved_at >= 0:
+            out["_relaytv_interrupt_preserved_at"] = preserved_at
+
     thumb = _sanitize_thumb_for_persist(item)
     if thumb:
         out["thumbnail"] = thumb

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1662,6 +1662,12 @@ def test_close_uses_overlay_not_qt_shell_for_idle_notifications_on_x11(monkeypat
 
 def test_clear_now_playing_advances_queue_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[str, bool]] = []
+    routes._TEMP_PLAYBACK_STACK.clear()
+    routes._TEMP_PLAYBACK_STACK.append({
+        'id': 'frame-1',
+        'resume': True,
+        'snapshot': {'now_playing': {'url': 'https://example.com/interrupted.mp4'}},
+    })
 
     monkeypatch.setattr(routes.state, 'QUEUE', [{'url': 'https://example.com/next.mp4'}], raising=False)
     monkeypatch.setattr(
@@ -1674,12 +1680,16 @@ def test_clear_now_playing_advances_queue_when_available(monkeypatch: pytest.Mon
         },
     )
 
-    out = routes.clear_now_playing()
+    try:
+        out = routes.clear_now_playing()
 
-    assert out['status'] == 'playing_next'
-    assert out['now_playing']['title'] == 'Next'
-    assert 'method' not in out
-    assert calls == [('next', True)]
+        assert out['status'] == 'playing_next'
+        assert out['now_playing']['title'] == 'Next'
+        assert 'method' not in out
+        assert calls == [('next', True)]
+        assert routes._TEMP_PLAYBACK_STACK == []
+    finally:
+        routes._TEMP_PLAYBACK_STACK.clear()
 
 
 def test_clear_now_playing_returns_to_idle_without_preserving_current(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1923,6 +1933,26 @@ def test_preserve_current_marks_interrupt_queue_entry(monkeypatch: pytest.Monkey
     assert preserved['resume_pos'] == 37.0
     assert routes.state.QUEUE == [preserved]
     assert persisted[-1]['queue'] == [preserved]
+
+
+def test_persisted_queue_item_keeps_interrupt_preserved_marker() -> None:
+    item = {
+        'url': 'https://example.com/interrupted.mp4',
+        'title': 'Interrupted',
+        'resume_pos': 37.0,
+        '_relaytv_interrupt_preserved': True,
+        '_relaytv_interrupt_preserved_at': 1234,
+    }
+
+    persisted = routes.state._persistable_queue_item(item)
+    loaded = routes.state._load_persisted_queue_item(item)
+
+    assert persisted is not None
+    assert persisted['_relaytv_interrupt_preserved'] is True
+    assert persisted['_relaytv_interrupt_preserved_at'] == 1234
+    assert loaded is not None
+    assert loaded['_relaytv_interrupt_preserved'] is True
+    assert loaded['_relaytv_interrupt_preserved_at'] == 1234
 
 
 def test_interrupt_preserved_queue_item_is_not_mpv_primed() -> None:


### PR DESCRIPTION
## Summary
- preserve interrupted-close queue markers when queue items are persisted and reloaded
- discard temporary playback restore frames before /now_playing/clear advances to queued playback
- add smoke regressions for queue reload persistence and queued clear behavior

## User impact
Prevents a closed/interrupted stream from being preloaded or restored again after queue reloads, restarts, or queued clear flows.

## Operator/deployment impact
None.

## Breaking changes
None.

## Tests run
- PYTHONPATH=app pytest -q tests/test_smoke.py
- python3 -m compileall app/relaytv_app/state.py app/relaytv_app/routes.py
- git diff --check