### PR TITLE
fix: address stale codex review findings

### DIFF
--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -2616,7 +2616,6 @@ def _load_stream_in_existing_mpv(stream_url: str, audio_url: str | None = None, 
 
     # Existing "up-next armed" state points at the old timeline.
     _reset_mpv_up_next_state()
-    _set_mpv_process_start_option_active(False)
     return True
 
 

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -495,6 +495,7 @@ _MPV_UPNEXT_LOCK = threading.Lock()
 _MPV_UPNEXT_ARMED_ID = ""
 _MPV_UPNEXT_ARMED_URL = ""
 _MPV_UPNEXT_ARMED_AT = 0.0
+_MPV_PROCESS_START_OPTION_ACTIVE = False
 _QUEUE_PREFETCH_LOCK = threading.Lock()
 _QUEUE_PREFETCH_INFLIGHT: set[str] = set()
 _QUEUE_METADATA_PREFETCH_LOCK = threading.Lock()
@@ -2113,6 +2114,7 @@ def stop_mpv(*, restart_splash: bool = True):
     _persist_runtime_volume_before_stop()
     _stop_qt_shell()
     _reset_mpv_up_next_state()
+    _set_mpv_process_start_option_active(False)
     if MPV_PROC and MPV_PROC.poll() is None:
         MPV_PROC.terminate()
         try:
@@ -2614,6 +2616,7 @@ def _load_stream_in_existing_mpv(stream_url: str, audio_url: str | None = None, 
 
     # Existing "up-next armed" state points at the old timeline.
     _reset_mpv_up_next_state()
+    _set_mpv_process_start_option_active(False)
     return True
 
 
@@ -2626,6 +2629,7 @@ def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | 
       - RELAYTV_VIDEO_MODE=drm: force DRM/KMS mode.
     """
     global MPV_PROC
+    process_start_option_active = _normalize_start_pos(start_pos) is not None
     # Resolve can take longer than the initial transition window. Refresh it
     # here so watchdogs do not relaunch the idle shell while playback startup
     # is tearing down the idle runtime and spawning the media runtime.
@@ -2656,6 +2660,7 @@ def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | 
             )
             if not wait_for_ipc_ready(timeout=startup_timeout):
                 raise HTTPException(status_code=500, detail="qt external mpv started but IPC not ready")
+            _set_mpv_process_start_option_active(process_start_option_active)
             healthy = _qt_external_video_healthy_with_grace()
             _record_qt_external_video_health(healthy)
             if not healthy:
@@ -2672,6 +2677,7 @@ def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | 
                     )
                     if not wait_for_ipc_ready(timeout=startup_timeout):
                         raise HTTPException(status_code=500, detail="qt external mpv x11 fallback started but IPC not ready")
+                    _set_mpv_process_start_option_active(process_start_option_active)
                 else:
                     _set_qt_external_runtime_reason("video_unhealthy_no_x11")
             _apply_startup_mpv_runtime_settings()
@@ -2681,6 +2687,7 @@ def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | 
         _start_qt_shell(stream_url, audio_url=audio_url, start_pos=start_pos)
         if not wait_for_ipc_ready(timeout=startup_timeout):
             raise HTTPException(status_code=500, detail="qt shell started but mpv IPC not ready")
+        _set_mpv_process_start_option_active(process_start_option_active)
         _apply_startup_mpv_runtime_settings()
         _recover_audio_output_if_needed(settings)
         return
@@ -2695,12 +2702,14 @@ def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | 
         MPV_PROC = _spawn("x11")
         if not wait_for_ipc_ready(timeout=startup_timeout):
             raise HTTPException(status_code=500, detail="mpv started but IPC not ready")
+        _set_mpv_process_start_option_active(process_start_option_active)
         return
 
     if mode == "drm":
         MPV_PROC = _spawn("drm")
         if not wait_for_ipc_ready(timeout=startup_timeout):
             raise HTTPException(status_code=500, detail="mpv started but IPC not ready")
+        _set_mpv_process_start_option_active(process_start_option_active)
         if not _video_output_healthy(timeout=2.0):
             debug_log("player", "DRM mode came up without video output")
             if _drm_no_video_fallback_allowed() and _has_x11_display():
@@ -2709,6 +2718,7 @@ def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | 
                 MPV_PROC = _spawn("x11")
                 if not wait_for_ipc_ready(timeout=startup_timeout):
                     raise HTTPException(status_code=500, detail="mpv x11 fallback started but IPC not ready")
+                _set_mpv_process_start_option_active(process_start_option_active)
         return
 
     # auto: prefer DRM when possible, but fall back to X11 if DRM fails (e.g., desktop holds DRM master)
@@ -2733,6 +2743,9 @@ def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | 
             MPV_PROC = _spawn("x11")
             if not wait_for_ipc_ready(timeout=startup_timeout):
                 raise HTTPException(status_code=500, detail="mpv x11 fallback started but IPC not ready")
+            _set_mpv_process_start_option_active(process_start_option_active)
+
+    _set_mpv_process_start_option_active(process_start_option_active)
 
 
 def wait_for_ipc_ready(timeout: float = 5.0) -> bool:
@@ -3419,8 +3432,16 @@ def _reset_mpv_up_next_state() -> None:
         _MPV_UPNEXT_ARMED_AT = 0.0
 
 
+def _set_mpv_process_start_option_active(active: bool) -> None:
+    global _MPV_PROCESS_START_OPTION_ACTIVE
+    with _MPV_UPNEXT_LOCK:
+        _MPV_PROCESS_START_OPTION_ACTIVE = bool(active)
+
+
 def _mpv_up_next_load_target(item: object) -> tuple[list[object], str] | None:
     """Return the mpv loadfile command and armed media URL for queue head."""
+    if _MPV_PROCESS_START_OPTION_ACTIVE:
+        return None
     if isinstance(item, dict) and item.get("_relaytv_interrupt_preserved") is True:
         return None
     head_url = _queue_item_play_url(item)

--- a/app/relaytv_app/routes.py
+++ b/app/relaytv_app/routes.py
@@ -7942,8 +7942,8 @@ def _playback_state_fast_snapshot() -> dict[str, object]:
         ("mute", "mpv_runtime_mute"),
     )
 
-    def fill_from_mpv_ipc() -> bool:
-        if not (bool(payload.get("playing")) or bool(payload.get("paused"))):
+    def fill_from_mpv_ipc(*, force: bool = False) -> bool:
+        if not force and not (bool(payload.get("playing")) or bool(payload.get("paused"))):
             return False
         try:
             props = player.mpv_get_many(["pause", "volume", "mute", "time-pos", "duration"])
@@ -8019,7 +8019,7 @@ def _playback_state_fast_snapshot() -> dict[str, object]:
     sample_detail = str(qt_runtime.get("mpv_runtime_sample_detail") or "").strip().lower()
     missing_runtime_fields = [field for field, _key in field_map if payload.get(field) is None]
     if (bool(payload.get("playing")) or runtime_playing) and (missing_runtime_fields or sample_detail.startswith("subprocess_runtime")):
-        fill_from_mpv_ipc()
+        fill_from_mpv_ipc(force=runtime_playing)
     if runtime_playing and not closed_stop_hold and not natural_idle_clear_hold:
         payload["playing"] = True
         payload["state"] = "paused" if bool(payload.get("paused")) else "playing"

--- a/app/relaytv_app/x11_overlay.py
+++ b/app/relaytv_app/x11_overlay.py
@@ -23,20 +23,27 @@ _OVERLAY_LOCK = threading.Lock()
 _OVERLAY_PROC: Optional[subprocess.Popen] = None
 
 def _xauthority_file(env: dict[str, str]) -> str | None:
+    candidates: list[Path] = []
     path = env.get("XAUTHORITY")
-    if path and Path(path).is_file():
-        return path
+    if path:
+        try:
+            env_candidate = Path(path)
+            if env_candidate.is_file():
+                candidates.append(env_candidate)
+        except Exception:
+            pass
     runtime_dir = env.get("XDG_RUNTIME_DIR")
-    if not runtime_dir:
+    if runtime_dir:
+        try:
+            candidates.extend(Path(runtime_dir).glob(".mutter-Xwaylandauth.*"))
+        except Exception:
+            pass
+    if not candidates:
         return None
     try:
-        candidates = sorted(
-            Path(runtime_dir).glob(".mutter-Xwaylandauth.*"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
+        candidates = sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True)
     except Exception:
-        return None
+        pass
     for candidate in candidates:
         try:
             if candidate.is_file():
@@ -53,8 +60,12 @@ def x11_session() -> bool:
 
 def overlay_enabled() -> bool:
     explicit = os.getenv("RELAYTV_X11_OVERLAY")
-    if explicit is not None and explicit.strip().lower() in ("1", "true", "yes", "on"):
-        return True
+    if explicit is not None:
+        value = explicit.strip().lower()
+        if value in ("1", "true", "yes", "on"):
+            return True
+        if value in ("0", "false", "no", "off"):
+            return False
     raw = (os.getenv("RELAYTV_IDLE_NOTIFICATIONS_ENABLED") or "").strip().lower()
     if raw in ("0", "false", "no", "off"):
         return False

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1935,6 +1935,31 @@ def test_process_wide_resume_start_disables_mpv_up_next_priming() -> None:
         player._set_mpv_process_start_option_active(False)
 
 
+def test_reused_mpv_process_keeps_resume_start_up_next_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    commands: list[list[object]] = []
+
+    class DummyProc:
+        def poll(self):
+            return None
+
+    monkeypatch.setenv('RELAYTV_MPV_SEAMLESS_REPLACE', '1')
+    monkeypatch.setattr(player, '_qt_shell_backend_enabled', lambda: False)
+    monkeypatch.setattr(player, 'MPV_PROC', DummyProc())
+    monkeypatch.setattr(player.os.path, 'exists', lambda path: True)
+    monkeypatch.setattr(player, '_qt_shell_runtime_accepts_mpv_commands', lambda: False)
+    monkeypatch.setattr(player, 'mpv_command', lambda cmd: commands.append(list(cmd)) or {'error': 'success'})
+
+    try:
+        player._set_mpv_process_start_option_active(True)
+
+        assert player._load_stream_in_existing_mpv('https://example.com/replacement.mp4') is True
+
+        assert commands == [['loadfile', 'https://example.com/replacement.mp4', 'replace']]
+        assert player._mpv_up_next_load_target({'url': 'https://example.com/next.mp4'}) is None
+    finally:
+        player._set_mpv_process_start_option_active(False)
+
+
 def test_resume_session_starts_resolved_stream_at_resume_position(monkeypatch: pytest.MonkeyPatch) -> None:
     load_calls: list[dict[str, object]] = []
     start_calls: list[dict[str, object]] = []

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 import json
+import os
 import shutil
 import subprocess
 import tomllib
@@ -880,6 +881,16 @@ def test_x11_overlay_can_be_disabled_with_idle_notifications_setting(monkeypatch
     assert x11_overlay.overlay_enabled() is False
 
 
+def test_x11_overlay_honors_explicit_disable(monkeypatch: pytest.MonkeyPatch) -> None:
+    from relaytv_app import x11_overlay
+
+    monkeypatch.setenv("RELAYTV_X11_OVERLAY", "0")
+    monkeypatch.setenv("RELAYTV_IDLE_NOTIFICATIONS_ENABLED", "1")
+    monkeypatch.setattr(routes.state, "get_settings", lambda: {"idle_notifications_enabled": True})
+
+    assert x11_overlay.overlay_enabled() is False
+
+
 def test_x11_overlay_click_through_defaults_on() -> None:
     text = (ROOT_DIR / "app/relaytv_app/overlay_app.py").read_text()
     assert 'os.getenv("RELAYTV_OVERLAY_CLICKTHROUGH", "1")' in text
@@ -934,9 +945,11 @@ def test_x11_overlay_launch_repairs_stale_xauthority(monkeypatch: pytest.MonkeyP
     runtime_dir = tmp_path / "runtime"
     runtime_dir.mkdir()
     stale_xauthority = tmp_path / ".Xauthority"
-    stale_xauthority.mkdir()
+    stale_xauthority.write_text("stale")
     valid_xauthority = runtime_dir / ".mutter-Xwaylandauth.TEST"
     valid_xauthority.write_text("auth")
+    os.utime(stale_xauthority, (1000, 1000))
+    os.utime(valid_xauthority, (2000, 2000))
     calls: list[dict] = []
 
     class DummyProc:
@@ -1529,6 +1542,50 @@ def test_playback_state_uses_mpv_ipc_when_qt_telemetry_is_unselected(monkeypatch
     assert payload['playback_runtime_state'] == 'playing'
 
 
+def test_playback_state_uses_ipc_when_qt_runtime_first_reports_playing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(routes.state, 'SESSION_STATE', 'idle', raising=False)
+    monkeypatch.setattr(routes.state, 'NOW_PLAYING', None, raising=False)
+    monkeypatch.setattr(routes.state, 'QUEUE', [], raising=False)
+    monkeypatch.setattr(routes.state, 'AUTO_NEXT_SUPPRESS_UNTIL', 0.0, raising=False)
+    monkeypatch.setattr(routes.player, 'playback_transitioning', lambda: False)
+    monkeypatch.setattr(routes.player, 'auto_next_transitioning', lambda: False)
+    monkeypatch.setattr(routes.player, 'natural_idle_reset_holding', lambda: False)
+    monkeypatch.setattr(
+        routes.player,
+        'qt_shell_runtime_telemetry',
+        lambda **_: {
+            'selected': True,
+            'available': True,
+            'freshness': 'fresh',
+            'mpv_runtime_playback_active': True,
+            'mpv_runtime_sample_detail': 'subprocess_runtime_heartbeat',
+        },
+    )
+    monkeypatch.setattr(
+        routes.player,
+        'mpv_get_many',
+        lambda props: {'pause': False, 'time-pos': 42.5, 'duration': 120.0, 'volume': 80.0, 'mute': False},
+    )
+    monkeypatch.setattr(
+        routes.state,
+        'update_playback_runtime_state',
+        lambda next_state, reason='': {
+            'playback_runtime_state': next_state,
+            'playback_runtime_state_reason': reason,
+        },
+    )
+
+    payload = routes.playback_state()
+
+    assert payload['playing'] is True
+    assert payload['state'] == 'playing'
+    assert payload['position'] == 42.5
+    assert payload['duration'] == 120.0
+    assert payload['volume'] == 80.0
+    assert payload['mute'] is False
+    assert payload['playback_telemetry_source'] == 'mpv_ipc'
+
+
 def test_close_preserves_now_playing_and_keeps_qt_shell_when_idle_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     now_values: list[object] = []
     session_values: list[str] = []
@@ -1867,6 +1924,15 @@ def test_mpv_start_args_include_resume_start_position(monkeypatch: pytest.Monkey
 
     assert '--start=42.5' in args
     assert args[-1] == 'https://example.com/video.mp4'
+
+
+def test_process_wide_resume_start_disables_mpv_up_next_priming() -> None:
+    try:
+        player._set_mpv_process_start_option_active(True)
+
+        assert player._mpv_up_next_load_target({'url': 'https://example.com/next.mp4'}) is None
+    finally:
+        player._set_mpv_process_start_option_active(False)
 
 
 def test_resume_session_starts_resolved_stream_at_resume_position(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- honor explicit X11 overlay opt-outs and prefer fresher Xwayland auth files over stale XAUTHORITY values
- fetch mpv IPC fields when Qt runtime telemetry is the first signal that playback is active
- prevent up-next mpv playlist priming while the current process was launched with a process-wide resume start offset

## Review comments addressed
- PR #7: allow IPC fallback when Qt runtime is already active
- PR #8: scope resume start so queued up-next media does not inherit the resumed offset
- PR #10: honor explicit overlay opt-outs and validate/reselect XAUTHORITY
- PR #12: already addressed by PR #14, confirmed merged into main before this branch

## User impact
Playback status should keep position/duration/volume visible when Qt runtime detects playback before session state catches up. Queued items after a resumed fresh mpv start should no longer inherit the resume offset. X11 overlay opt-outs should be respected.

## Operator/deployment impact
Deployments with RELAYTV_X11_OVERLAY=0/false/no/off will keep the overlay disabled even when idle notifications are enabled. Xwayland overlay launch can now prefer a fresher .mutter-Xwaylandauth file when XAUTHORITY is stale.

## Breaking changes
None.

## Tests run
- PYTHONPATH=app pytest -q tests/test_smoke.py
- python3 -m compileall app/relaytv_app/player.py app/relaytv_app/routes.py app/relaytv_app/x11_overlay.py
- git diff --check