### PR TITLE
fix: prevent closed sessions from priming queued playback

### DIFF
--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -3477,6 +3477,9 @@ def _clear_mpv_playlist_before_current() -> None:
 def _prime_mpv_up_next_from_queue(*, force: bool = False) -> bool:
     """Keep exactly one up-next item queued in mpv's internal playlist."""
     global _MPV_UPNEXT_ARMED_ID, _MPV_UPNEXT_ARMED_URL, _MPV_UPNEXT_ARMED_AT
+    if str(getattr(state, "SESSION_STATE", "idle") or "idle").strip().lower() == "closed":
+        _reset_mpv_up_next_state()
+        return False
     if not _is_playing():
         _reset_mpv_up_next_state()
         return False
@@ -3737,6 +3740,10 @@ def _consume_mpv_queued_next_if_started(
     force_playlist_advance: bool = False,
 ) -> bool:
     """When mpv auto-advances to queued item, consume queue head into app state."""
+    if str(getattr(state, "SESSION_STATE", "idle") or "idle").strip().lower() == "closed":
+        _reset_mpv_up_next_state()
+        return False
+
     def _same_media_ref(left: object, right: object) -> bool:
         volatile_query_keys = {
             "api_key",
@@ -4887,40 +4894,48 @@ def natural_idle_reset_holding() -> bool:
         return False
 
 
+def _session_tracker_tick() -> None:
+    """Persist one playback-state sample."""
+    if not _is_playing():
+        return
+    if str(getattr(state, "SESSION_STATE", "idle") or "idle").strip().lower() == "closed":
+        _reset_mpv_up_next_state()
+        return
+    props = mpv_get_many(["time-pos", "duration", "pause", "playlist-pos", "playlist-count", "path", "core-idle", "eof-reached"])
+    _consume_mpv_queued_next_if_started(props)
+    now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
+    if not now:
+        if _repair_orphan_runtime_playback(props):
+            return
+        _prime_mpv_up_next_from_queue()
+        return
+    pos = props.get("time-pos")
+    paused = bool(props.get("pause"))
+    if pos is not None:
+        pos_f = float(pos)
+        updated = dict(now)
+        updated["resume_pos"] = pos_f
+        try:
+            duration_f = float(props.get("duration"))
+            if duration_f > 0:
+                updated["duration_sec"] = duration_f
+        except Exception:
+            pass
+        state.set_now_playing(updated)
+        state.set_session_position(pos_f)
+        state.set_session_state("paused" if paused else "playing")
+        update_history_progress(updated)
+    if not paused:
+        state.set_pause_reason(None)
+    _prime_mpv_up_next_from_queue()
+
+
 def _session_tracker_worker() -> None:
     """Continuously persist playback position/state so reboots can resume accurately."""
     while True:
         time.sleep(2)
-        if not _is_playing():
-            continue
         try:
-            props = mpv_get_many(["time-pos", "duration", "pause", "playlist-pos", "playlist-count", "path", "core-idle", "eof-reached"])
-            _consume_mpv_queued_next_if_started(props)
-            now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
-            if not now:
-                if _repair_orphan_runtime_playback(props):
-                    continue
-                _prime_mpv_up_next_from_queue()
-                continue
-            pos = props.get("time-pos")
-            paused = bool(props.get("pause"))
-            if pos is not None:
-                pos_f = float(pos)
-                updated = dict(now)
-                updated["resume_pos"] = pos_f
-                try:
-                    duration_f = float(props.get("duration"))
-                    if duration_f > 0:
-                        updated["duration_sec"] = duration_f
-                except Exception:
-                    pass
-                state.set_now_playing(updated)
-                state.set_session_position(pos_f)
-                state.set_session_state("paused" if paused else "playing")
-                update_history_progress(updated)
-            if not paused:
-                state.set_pause_reason(None)
-            _prime_mpv_up_next_from_queue()
+            _session_tracker_tick()
         except Exception:
             continue
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1965,6 +1965,58 @@ def test_interrupt_preserved_queue_item_is_not_mpv_primed() -> None:
     ) is None
 
 
+def test_closed_session_does_not_prime_mpv_up_next(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'closed', raising=False)
+    monkeypatch.setattr(
+        player.state,
+        'QUEUE',
+        [{'url': 'https://www.youtube.com/watch?v=queued', 'title': 'Queued'}],
+        raising=False,
+    )
+    monkeypatch.setattr(player, '_is_playing', lambda: True)
+    monkeypatch.setattr(
+        player,
+        'mpv_command',
+        lambda command: (_ for _ in ()).throw(AssertionError(f'closed session must not prime mpv queue: {command!r}')),
+    )
+
+    assert player._prime_mpv_up_next_from_queue(force=True) is False
+
+
+def test_session_tracker_does_not_reopen_closed_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_calls: list[bool] = []
+
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'closed', raising=False)
+    monkeypatch.setattr(
+        player.state,
+        'NOW_PLAYING',
+        {'url': 'https://example.com/jellyfin.mp4', 'title': 'Closed Jellyfin', 'closed': True},
+        raising=False,
+    )
+    monkeypatch.setattr(player, '_is_playing', lambda: True)
+    monkeypatch.setattr(player, '_reset_mpv_up_next_state', lambda: reset_calls.append(True))
+    monkeypatch.setattr(
+        player,
+        'mpv_get_many',
+        lambda props: (_ for _ in ()).throw(AssertionError('closed session tracker must not sample runtime')),
+    )
+    monkeypatch.setattr(
+        player.state,
+        'set_session_state',
+        lambda value: (_ for _ in ()).throw(AssertionError(f'closed session must not become {value!r}')),
+    )
+    monkeypatch.setattr(
+        player,
+        '_prime_mpv_up_next_from_queue',
+        lambda force=False: (_ for _ in ()).throw(AssertionError('closed session must not prime up-next')),
+    )
+
+    player._session_tracker_tick()
+
+    assert reset_calls == [True]
+    assert player.state.SESSION_STATE == 'closed'
+
+
 def test_play_item_reuses_fresh_resolved_stream_without_ytdlp(monkeypatch: pytest.MonkeyPatch) -> None:
     start_calls: list[dict[str, object]] = []
     now_values: list[dict] = []


### PR DESCRIPTION
## Summary
- prevent mpv up-next priming while the RelayTV session is explicitly closed
- prevent mpv queued-next consumption while the session is closed
- split the session tracker into a testable tick and make it leave closed resumable sessions untouched
- add regressions for closed sessions retaining queue items without loading or reopening playback

## Runtime evidence
The running container showed `NOW_PLAYING` persisted as the closed Jellyfin title while Qt runtime was actively playing the queued YouTube resolved stream. The Qt control file's last action was `loadfile ... append-play`, which came from up-next priming after close.

## User impact
Pressing Close on a Jellyfin title should keep the resumable Jellyfin metadata and queued items, but should not start or preload the queued YouTube item behind the app state.

## Operator/deployment impact
None.

## Breaking changes
None.

## Tests run
- PYTHONPATH=app pytest -q tests/test_smoke.py
- python3 -m compileall app/relaytv_app/player.py
- git diff --check
