### PR TITLE
refactor: architecture phase 5 optional api token

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,49 @@ Do not manually edit `CHANGELOG.md` for normal feature, fix, docs, or dependency
 changes. Release Please owns version bumps, release pull requests, changelog
 generation, Git tags, GitHub Releases, and immutable release image tags.
 
-## Architecture Phase 4 Discipline
+## Architecture Phase 5 Discipline
+
+When working on the Phase 5 architecture effort (optional API token), keep
+work on `codex/architecture-phase-5` unless the user explicitly directs
+otherwise.
+
+Keep `docs/ARCHITECTURE_PHASE_5_ROADMAP.md` current when milestones start,
+complete, change scope, or uncover important follow-up work.
+
+Phase 5 scope:
+
+- optional bearer-token auth for write requests (`POST`/`PUT`/`PATCH`/
+  `DELETE`) via app middleware; disabled by default, enabled with
+  `RELAYTV_API_TOKEN`; reads, `/health`, `/ui`, and static assets stay open
+- the token is env-only: plumbed through `runtime_config`
+  (`SETTINGS_BUS_VARS`), never persisted to settings.json, never returned by
+  `/settings`, never logged
+- minimal web UI compatibility (one fetch wrapper attaching the bearer
+  token from localStorage) — no frontend framework or redesign
+- operator docs: trusted-LAN default posture, token setup, reverse-proxy
+  exposure examples
+- guardrail tests for the auth contract (`tests/test_api_auth.py`)
+
+Do not start Phase 6+ work on this branch unless the user explicitly expands
+the scope. Out of scope for Phase 5:
+
+- auth for read endpoints, sessions/users, or credential stores beyond the
+  single env token
+- TLS termination inside RelayTV
+- frontend framework or build pipeline
+- endpoint removals or compatibility-breaking API changes
+- with `RELAYTV_API_TOKEN` unset, any behavior change at all
+
+Prefer small PRs into `codex/architecture-phase-5`, not directly into `main`.
+No release until the architecture roadmap completes: phases ship as
+`refactor:` PRs that intentionally do not trigger release-please.
+
+## Architecture Phase 4 Discipline (complete)
+
+Phase 4 (Jellyfin product service) completed on
+`codex/architecture-phase-4`; final PR:
+https://github.com/mcgeezy/relaytv/pull/24. The full record lives in
+`docs/ARCHITECTURE_PHASE_4_ROADMAP.md`.
 
 When working on the Phase 4 architecture effort (Jellyfin product service),
 keep work on `codex/architecture-phase-4` unless the user explicitly directs

--- a/app/relaytv_app/api_auth.py
+++ b/app/relaytv_app/api_auth.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Optional bearer-token guard for write endpoints.
+
+The API is local-first and unauthenticated by default (trusted LAN,
+docs/ARCHITECTURE_REVIEW.md Finding 8). Setting ``RELAYTV_API_TOKEN``
+turns on bearer auth for write requests (``POST``/``PUT``/``PATCH``/
+``DELETE``) across the whole app via middleware, so future write routes
+are covered by default. Reads (``GET``/``HEAD``/``OPTIONS``) — health,
+status, ``/ui``, static assets — are never guarded.
+
+The token is env-only: read through runtime config snapshots, never
+persisted with settings, never returned by ``/settings``, never logged.
+"""
+import hmac
+
+from .config import runtime_config
+
+WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def configured_api_token() -> str:
+    """Return the operator-configured API token ("" when auth is disabled)."""
+    return str(runtime_config.snapshot().raw("RELAYTV_API_TOKEN", "") or "").strip()
+
+
+def bearer_token_from_header(authorization: str | None) -> str:
+    """Extract the credentials from an ``Authorization: Bearer`` header."""
+    value = str(authorization or "").strip()
+    if not value:
+        return ""
+    scheme, _, credentials = value.partition(" ")
+    if scheme.lower() != "bearer":
+        return ""
+    return credentials.strip()
+
+
+def write_request_allowed(method: str, authorization: str | None) -> bool:
+    """Return True when a request may proceed under the token policy."""
+    token = configured_api_token()
+    if not token:
+        return True
+    if str(method or "").upper() not in WRITE_METHODS:
+        return True
+    presented = bearer_token_from_header(authorization)
+    if not presented:
+        return False
+    return hmac.compare_digest(presented.encode("utf-8"), token.encode("utf-8"))

--- a/app/relaytv_app/config.py
+++ b/app/relaytv_app/config.py
@@ -99,6 +99,7 @@ SETTINGS_BUS_VARS = frozenset(
     {
         "INVIDIOUS_BASE",
         "MPV_AUDIO_DEVICE",
+        "RELAYTV_API_TOKEN",
         "RELAYTV_CEC",
         "RELAYTV_CEC_ENABLED",
         "RELAYTV_DEVICE_NAME",

--- a/app/relaytv_app/main.py
+++ b/app/relaytv_app/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from .player import (
     ensure_qt_shell_idle,
@@ -19,6 +20,7 @@ from .player import (
     stop_splash_screen,
 )
 from .x11_overlay import start_overlay as start_x11_overlay, stop_overlay as stop_x11_overlay
+from . import api_auth
 from .config import runtime_config
 from .routes import router
 from .state import get_settings, load_state_from_disk
@@ -101,6 +103,18 @@ def create_app(*, testing: bool = False) -> FastAPI:
             stop_splash_screen()
 
     app = FastAPI(lifespan=_lifespan)
+
+    # Registered before the slow-request logger so the logger middleware sits
+    # outermost and rejected writes still show up in request logging.
+    @app.middleware("http")
+    async def _api_token_guard(request: Request, call_next):
+        if api_auth.write_request_allowed(request.method, request.headers.get("authorization")):
+            return await call_next(request)
+        return JSONResponse(
+            {"detail": "api token required"},
+            status_code=401,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     @app.middleware("http")
     async def _log_slow_requests(request: Request, call_next):

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -1,3 +1,58 @@
+// --- Optional API token support (RELAYTV_API_TOKEN, docs/API.md) -----------
+// When the operator enables the write-endpoint token, browsers must send
+// Authorization: Bearer <token>. The token lives in localStorage and is
+// attached transparently to same-origin requests; on the first rejected
+// write we prompt once, store the entered token, and retry.
+(function(){
+  const STORAGE_KEY = 'relaytv_api_token';
+  let promptedThisLoad = false;
+
+  function storedToken(){
+    try { return (window.localStorage.getItem(STORAGE_KEY) || '').trim(); } catch(_e) { return ''; }
+  }
+  function storeToken(value){
+    try {
+      const v = String(value || '').trim();
+      if (v) window.localStorage.setItem(STORAGE_KEY, v);
+      else window.localStorage.removeItem(STORAGE_KEY);
+    } catch(_e) {}
+  }
+  function isSameOrigin(input){
+    try {
+      const url = typeof input === 'string' ? input : ((input && input.url) || '');
+      return new URL(url, window.location.href).origin === window.location.origin;
+    } catch(_e) { return false; }
+  }
+  function withAuth(opts, token){
+    const out = Object.assign({}, opts || {});
+    const headers = new Headers((opts && opts.headers) || {});
+    headers.set('Authorization', 'Bearer ' + token);
+    out.headers = headers;
+    return out;
+  }
+
+  const nativeFetch = window.fetch.bind(window);
+  window.fetch = async function(input, opts){
+    const sameOrigin = isSameOrigin(input);
+    const token = sameOrigin ? storedToken() : '';
+    let res = await nativeFetch(input, token ? withAuth(opts, token) : opts);
+    if (res.status === 401 && sameOrigin && !promptedThisLoad){
+      let wantsBearer = false;
+      try { wantsBearer = ((res.headers.get('www-authenticate') || '').toLowerCase().indexOf('bearer') === 0); } catch(_e) {}
+      if (wantsBearer){
+        promptedThisLoad = true;
+        const entered = window.prompt('This RelayTV server requires an API token for control actions.\nEnter the API token (RELAYTV_API_TOKEN):', '');
+        const v = String(entered || '').trim();
+        if (v){
+          storeToken(v);
+          res = await nativeFetch(input, withAuth(opts, v));
+        }
+      }
+    }
+    return res;
+  };
+})();
+
 function _fetchWithTimeout(url, opts, timeoutMs){
   const ms = Number(timeoutMs || 0);
   if (!(Number.isFinite(ms) && ms > 0) || typeof AbortController === 'undefined'){

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,6 +14,71 @@ TV notifications, and interact with Jellyfin. Do not expose RelayTV directly to
 the public internet. Use a VPN, trusted reverse proxy, or Home Assistant access
 layer if remote access is required.
 
+### Optional API token
+
+By default every endpoint is open (trusted LAN). Setting `RELAYTV_API_TOKEN`
+in `/opt/relaytv/.env` enables bearer auth for all write requests
+(`POST`/`PUT`/`PATCH`/`DELETE`):
+
+```bash
+# /opt/relaytv/.env
+RELAYTV_API_TOKEN=use-a-long-random-value
+```
+
+```bash
+docker compose up -d --force-recreate relaytv
+```
+
+With the token enabled:
+
+- Write requests must send the header, or they receive
+  `401 {"detail": "api token required"}` with `WWW-Authenticate: Bearer`:
+
+  ```bash
+  curl -X POST http://<host>:8787/pause \
+    -H "Authorization: Bearer use-a-long-random-value"
+  ```
+
+- Reads stay open: all `GET` endpoints (`/health`, `/status`, `/ui`, static
+  assets, SSE streams, Jellyfin browse) behave exactly as before, so
+  dashboards and health checks keep working.
+- The web UI prompts for the token on the first rejected control action and
+  stores it in browser localStorage (`relaytv_api_token`); it can also be
+  pre-set from the browser console with
+  `localStorage.setItem('relaytv_api_token', '<token>')`.
+- The token is env-only. It is never persisted with settings and never
+  returned by `/settings`.
+
+Unset or blank `RELAYTV_API_TOKEN` restores the fully open behavior.
+
+The token protects control actions; it is not transport security. For
+exposure beyond the trusted LAN, terminate TLS and (optionally) an extra
+auth layer at a reverse proxy. Example with Caddy:
+
+```caddyfile
+relay.example.com {
+    reverse_proxy 127.0.0.1:8787
+}
+```
+
+Example with nginx:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name relay.example.com;
+    # ssl_certificate / ssl_certificate_key ...
+
+    location / {
+        proxy_pass http://127.0.0.1:8787;
+        proxy_set_header Host $host;
+        # Required for /ui/events (Server-Sent Events):
+        proxy_buffering off;
+        proxy_read_timeout 1h;
+    }
+}
+```
+
 ## UI and utility endpoints
 
 - `GET /ui`: main web UI HTML

--- a/docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md
+++ b/docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md
@@ -89,6 +89,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_ACCESS_LOG` | `debug.py` | - | static env |
 | `RELAYTV_ACCESS_LOG_HOT_PATHS` | `debug.py` | - | static env |
 | `RELAYTV_ACCESS_LOG_LEVEL` | `debug.py` | - | static env |
+| `RELAYTV_API_TOKEN` | `api_auth.py`<br>`config.py` | - | static env |
 | `RELAYTV_ARM_DEFAULT_QUALITY` | `state.py`<br>`ytdlp_format_policy.py` | - | static env |
 | `RELAYTV_ARM_ENFORCE_SAFE_YTDL_FORMAT` | `ytdlp_format_policy.py` | - | static env |
 | `RELAYTV_ARM_FAST_PROFILE` | `player.py`<br>`qt_shell_app.py` | - | child process input |

--- a/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
@@ -94,7 +94,7 @@ Status: complete
 
 ### M1: Token Guard Middleware, Config Plumbing, And Tests
 
-Status: planned
+Status: complete
 
 - `RELAYTV_API_TOKEN` added to `SETTINGS_BUS_VARS` (snapshot-readable,
   env-only; excluded from `/settings` responses and settings persistence).
@@ -107,6 +107,8 @@ Status: planned
   wrong token 401, correct token accepted, reads and `/health`/`/ui`/static
   always open, `WWW-Authenticate` header shape, `/settings` never exposes
   the token.
+- Landed as designed; `docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md`
+  regenerated for the new settings-bus variable. 299 tests green.
 
 ### M2: Web UI Token Support
 

--- a/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
@@ -141,16 +141,28 @@ Status: complete
 
 ### M4: Phase 5 Final Validation
 
-Status: planned
+Status: complete
 
-- Full gates: `ruff check app tests`, `PYTHONPATH=app pytest -q`, CI-like
-  fresh-venv run.
-- Live validation on the appliance: token unset → behavior identical
-  (playback, queue, settings, Jellyfin smoke); token set in `.env` →
-  writes rejected without the header and accepted with it, `GET`
-  endpoints/UI/healthcheck unaffected, Jellyfin receiver operation
-  unaffected, web UI works after storing the token; then restore the
-  token-off default.
+- Full gates green: `ruff check app tests`; `PYTHONPATH=app pytest -q`
+  (299 passed); CI-like fresh-venv run (pip install -e '.[dev]' → pytest +
+  ruff) green.
+- Live validation on the appliance (branch image deployed via
+  `RELAYTV_IMAGE_REF`). All passing:
+  - Token unset (default): writes open (`POST` 200 with no header),
+    behavior unchanged.
+  - Token set in `.env` + recreate: `POST` with no header → `401
+    {"detail": "api token required"}` with `WWW-Authenticate: Bearer`;
+    wrong token → 401; correct bearer token → 200.
+  - Reads stayed open with the token on: `/health`, `/status`, `/ui`,
+    `/static/ui/app.js`, `/settings` all 200 with no header; the token
+    value appears nowhere in the `/settings` response.
+  - Runtime unaffected with the token on: the active playback session
+    auto-resumed through the container recreate (`startup_resume`,
+    position advancing) and the outbound-polling Jellyfin receiver stayed
+    connected/authenticated with `sync_health: ok`.
+  - UI fetch wrapper confirmed in the served `app.js`.
+  - Token removed and container recreated: writes open again, playback
+    resumed, appliance restored to the token-off default.
 - Open the final `codex/architecture-phase-5` to `main` PR.
 
 ## PR And Milestone Log
@@ -158,3 +170,5 @@ Status: planned
 | Date | Item | Notes |
 | --- | --- | --- |
 | 2026-07-03 | Phase 5 started | Branch cut from `main` at `5ebebb3` (Phase 4 squash merge); roadmap committed. |
+| 2026-07-03 | M0–M3 landed | `80f6f8b` M0 docs, `e89152f` M1 token guard + config + tests, `cdc593a` M2 UI fetch wrapper, `a9afd76` M3 operator docs. |
+| 2026-07-03 | M4 complete | Live appliance validation passed (token off unchanged, token on guards writes only, runtime/Jellyfin unaffected); final PR opened. |

--- a/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
@@ -1,0 +1,148 @@
+# Phase 5 Architecture Roadmap
+
+Date started: 2026-07-03
+
+Branch: `codex/architecture-phase-5` (cut from `main` at the Phase 4 squash
+merge, PR #24 / `5ebebb3`)
+
+Phase 5 goal: make the API trust boundary explicit while preserving
+local-first defaults. Add optional bearer-token auth for write endpoints —
+disabled by default, enabled with `RELAYTV_API_TOKEN` — and document the
+trusted-LAN assumption plus safe exposure patterns (reverse proxy examples).
+
+Related review: `docs/ARCHITECTURE_REVIEW.md` (Finding 8 and the Phase 5
+roadmap section)
+
+## Working Rules
+
+- Keep Phase 5 work on `codex/architecture-phase-5` until the phase is
+  complete.
+- Merge small focused PRs into this branch instead of directly into `main`.
+- Backward compatibility is the hard constraint: with `RELAYTV_API_TOKEN`
+  unset (the default), every endpoint behaves exactly as today.
+- Update this file whenever a milestone starts, completes, changes scope, or
+  uncovers follow-up work.
+- The token is an env-only secret: read through `runtime_config` snapshots,
+  never persisted to settings.json, never returned by `/settings`, never
+  logged.
+- Only open the final `codex/architecture-phase-5` to `main` PR after all
+  Phase 5 validation gates pass.
+- No release until the architecture roadmap completes (user decision
+  2026-07-03); phases ship as `refactor:` PRs that do not trigger
+  release-please.
+
+## Scope
+
+In scope:
+
+- Optional bearer-token guard for write requests (`POST`/`PUT`/`PATCH`/
+  `DELETE`), enforced by app middleware so current and future write routes
+  are covered by default:
+  - disabled when `RELAYTV_API_TOKEN` is unset or blank (default)
+  - `Authorization: Bearer <token>` with constant-time comparison
+  - `401` + `WWW-Authenticate: Bearer` on missing/incorrect token
+  - reads stay open: `GET`/`HEAD`/`OPTIONS` (health, status, `/ui`, static
+    assets) are never guarded
+- `RELAYTV_API_TOKEN` plumbed through the Phase 2 runtime config service
+  (`SETTINGS_BUS_VARS`) so in-process readers use snapshots.
+- Minimal web UI compatibility: a fetch wrapper that attaches the bearer
+  token from browser localStorage and prompts once when a write is rejected,
+  so the served UI keeps working when an operator enables the token.
+- Operator docs: explicit "trusted LAN only" default, token setup, curl
+  examples, and reverse-proxy exposure examples.
+- Guardrail tests for the auth contract (`tests/test_api_auth.py`).
+
+Out of scope (per review and user direction):
+
+- Auth for read endpoints, sessions/users, or any credential store beyond
+  the single env token.
+- TLS termination inside RelayTV (documented as the reverse proxy's job).
+- Frontend framework or build pipeline changes; the UI change is a small
+  plain-JS wrapper.
+- Endpoint removals or compatibility-breaking API changes.
+- Changing Jellyfin receiver transport/auth internals.
+
+## Baseline (measured at phase start)
+
+- Every write endpoint is unauthenticated; the app relies on trusted-LAN
+  host networking (`network_mode: host`, port 8787).
+- All state-mutating endpoints use `POST` (routes packages register no
+  `PUT`/`PATCH`/`DELETE` handlers); guarding by method covers the full
+  write surface including uploads and Jellyfin command ingress.
+- Internal runtime components (`qt_shell_app`, `overlay_app`, idle
+  dashboard) only issue `GET` requests against the local API, and the ops
+  scripts (`doctor.sh`, `host-ops.sh`) do not POST — enabling the token
+  cannot break the appliance runtime itself.
+- The Jellyfin integration is outbound-polling (receiver → server); nothing
+  external pushes writes into RelayTV as part of normal operation.
+- The docker healthcheck and install verification use `GET /health`.
+- `docker-compose.yml` loads `.env` via `env_file`, so `RELAYTV_API_TOKEN`
+  set in `/opt/relaytv/.env` reaches the app with no compose changes.
+- The web UI issues writes as plain `fetch(..., {method: 'POST'})` calls
+  scattered across `static/ui/app.js` (~25 call sites) — token support
+  belongs in one global wrapper, not per call site.
+
+## Milestones
+
+### M0: Branch, Roadmap, And Discipline Docs
+
+Status: complete
+
+- Branch cut from `main` at `5ebebb3` (Phase 4 squash merge).
+- This roadmap; `AGENTS.md` Phase 5 discipline section (Phase 4 marked
+  complete); `docs/README.md` link.
+
+### M1: Token Guard Middleware, Config Plumbing, And Tests
+
+Status: planned
+
+- `RELAYTV_API_TOKEN` added to `SETTINGS_BUS_VARS` (snapshot-readable,
+  env-only; excluded from `/settings` responses and settings persistence).
+- New `app/relaytv_app/api_auth.py`: token lookup from the runtime config
+  snapshot, bearer extraction, constant-time verification
+  (`hmac.compare_digest`), and the middleware guard callable.
+- Guard registered in `create_app` before the slow-request logger is
+  registered, so rejected writes still show up in request logging.
+- `tests/test_api_auth.py`: default-off passthrough, missing token 401,
+  wrong token 401, correct token accepted, reads and `/health`/`/ui`/static
+  always open, `WWW-Authenticate` header shape, `/settings` never exposes
+  the token.
+
+### M2: Web UI Token Support
+
+Status: planned
+
+- One global fetch wrapper in `static/ui/app.js` that attaches
+  `Authorization: Bearer <token>` from `localStorage['relaytv_api_token']`
+  when present, and on a `401` write response prompts once for the token,
+  stores it, and retries.
+- No visual redesign; behavior with no token configured is unchanged.
+
+### M3: Operator Docs
+
+Status: planned
+
+- `INSTALL.md`/`API.md`: explicit "trusted LAN only" default posture,
+  `RELAYTV_API_TOKEN` setup, curl examples with the bearer header, what
+  stays open (reads, health, UI, static assets), UI token entry, and
+  reverse-proxy exposure examples (TLS + auth at the proxy).
+
+### M4: Phase 5 Final Validation
+
+Status: planned
+
+- Full gates: `ruff check app tests`, `PYTHONPATH=app pytest -q`, CI-like
+  fresh-venv run.
+- Live validation on the appliance: token unset → behavior identical
+  (playback, queue, settings, Jellyfin smoke); token set in `.env` →
+  writes rejected without the header and accepted with it, `GET`
+  endpoints/UI/healthcheck unaffected, Jellyfin receiver operation
+  unaffected, web UI works after storing the token; then restore the
+  token-off default.
+- Open the final `codex/architecture-phase-5` to `main` PR.
+
+## PR And Milestone Log
+
+| Date | Item | Notes |
+| --- | --- | --- |
+| 2026-07-03 | Phase 5 started | Branch cut from `main` at `5ebebb3` (Phase 4 squash merge); roadmap committed. |

--- a/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
@@ -127,12 +127,17 @@ Status: complete
 
 ### M3: Operator Docs
 
-Status: planned
+Status: complete
 
 - `INSTALL.md`/`API.md`: explicit "trusted LAN only" default posture,
   `RELAYTV_API_TOKEN` setup, curl examples with the bearer header, what
   stays open (reads, health, UI, static assets), UI token entry, and
   reverse-proxy exposure examples (TLS + auth at the proxy).
+- Landed: `API.md` gained an "Optional API token" subsection under the
+  network trust model (enable/curl/UI/localStorage, what stays open, Caddy
+  and nginx examples with the SSE proxy caveat); `INSTALL.md`'s stale "token
+  auth is not part of the current release branch" sentence replaced with
+  the `RELAYTV_API_TOKEN` summary and a pointer to `API.md`.
 
 ### M4: Phase 5 Final Validation
 

--- a/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
@@ -112,13 +112,18 @@ Status: complete
 
 ### M2: Web UI Token Support
 
-Status: planned
+Status: complete
 
 - One global fetch wrapper in `static/ui/app.js` that attaches
   `Authorization: Bearer <token>` from `localStorage['relaytv_api_token']`
   when present, and on a `401` write response prompts once for the token,
   stores it, and retries.
 - No visual redesign; behavior with no token configured is unchanged.
+- Landed as a self-contained IIFE wrapping `window.fetch` at the top of
+  `app.js`: bearer header attached only to same-origin requests, prompt
+  fires at most once per page load and only when the `401` carries
+  `WWW-Authenticate: Bearer`, entered token stored and the request
+  retried once.
 
 ### M3: Operator Docs
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -120,8 +120,15 @@ to the public internet.
 
 If remote access is needed, put RelayTV behind a VPN, trusted reverse proxy, or
 Home Assistant access layer that provides authentication and transport
-security. Optional built-in API token auth is not part of the current release
-branch.
+security.
+
+Optionally, set `RELAYTV_API_TOKEN` in `/opt/relaytv/.env` to require
+`Authorization: Bearer <token>` on all write requests (playback control,
+queue/settings changes, uploads, Jellyfin commands). Reads — `/health`,
+`/status`, the web UI, and static assets — stay open, and the web UI prompts
+for the token on first use. Leave it unset (the default) for the fully open
+trusted-LAN behavior. See `API.md` ("Optional API token") for details and
+reverse-proxy examples.
 
 ## Docker Build Bundles
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Use this directory as a small operator/product doc set for the public release br
 - `ARCHITECTURE_PHASE_3_TRANSITION_INVENTORY.md`: machine-checked playback transition writer inventory and containment contract
 - `ARCHITECTURE_PHASE_4_ROADMAP.md`: living Phase 4 branch roadmap for the Jellyfin product service
 - `ARCHITECTURE_PHASE_4_JELLYFIN_INVENTORY.md`: machine-checked Jellyfin route-surface inventory and containment contract
+- `ARCHITECTURE_PHASE_5_ROADMAP.md`: living Phase 5 branch roadmap for the optional API token
 
 ## Module Ownership Snapshot
 

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Optional API token guard contract (docs/ARCHITECTURE_PHASE_5_ROADMAP.md M1).
+
+With RELAYTV_API_TOKEN unset the API must behave exactly as before: every
+write endpoint open. With a token configured, write requests require
+``Authorization: Bearer <token>`` while reads, /health, /ui, and static
+assets stay open.
+"""
+from fastapi.testclient import TestClient
+
+from relaytv_app import api_auth
+from relaytv_app.config import runtime_config
+from relaytv_app.main import create_app
+
+
+TOKEN = "sekrit-token-123"
+
+
+def _client() -> TestClient:
+    return TestClient(create_app(testing=True))
+
+
+def _enable_token(monkeypatch, value: str = TOKEN) -> None:
+    monkeypatch.setenv("RELAYTV_API_TOKEN", value)
+    runtime_config.refresh_from_env()
+
+
+# --- helper contract ---------------------------------------------------------
+
+
+def test_bearer_token_from_header_parses_scheme() -> None:
+    assert api_auth.bearer_token_from_header(f"Bearer {TOKEN}") == TOKEN
+    assert api_auth.bearer_token_from_header(f"bearer {TOKEN}") == TOKEN
+    assert api_auth.bearer_token_from_header(f"Basic {TOKEN}") == ""
+    assert api_auth.bearer_token_from_header(TOKEN) == ""
+    assert api_auth.bearer_token_from_header("") == ""
+    assert api_auth.bearer_token_from_header(None) == ""
+
+
+def test_write_request_allowed_policy(monkeypatch) -> None:
+    monkeypatch.delenv("RELAYTV_API_TOKEN", raising=False)
+    runtime_config.refresh_from_env()
+    assert api_auth.write_request_allowed("POST", None) is True
+
+    _enable_token(monkeypatch)
+    assert api_auth.write_request_allowed("GET", None) is True
+    assert api_auth.write_request_allowed("HEAD", None) is True
+    assert api_auth.write_request_allowed("OPTIONS", None) is True
+    assert api_auth.write_request_allowed("POST", None) is False
+    assert api_auth.write_request_allowed("POST", "Bearer wrong") is False
+    assert api_auth.write_request_allowed("POST", f"Bearer {TOKEN}") is True
+    assert api_auth.write_request_allowed("PUT", None) is False
+    assert api_auth.write_request_allowed("PATCH", None) is False
+    assert api_auth.write_request_allowed("DELETE", None) is False
+
+
+# --- default off: behavior unchanged -----------------------------------------
+
+
+def test_writes_open_when_token_unset(monkeypatch) -> None:
+    monkeypatch.delenv("RELAYTV_API_TOKEN", raising=False)
+    runtime_config.refresh_from_env()
+
+    client = _client()
+    response = client.post("/clear")
+    assert response.status_code == 200
+    assert response.json() == {"status": "cleared"}
+
+
+def test_blank_token_means_disabled(monkeypatch) -> None:
+    _enable_token(monkeypatch, "   ")
+
+    client = _client()
+    response = client.post("/clear")
+    assert response.status_code == 200
+
+
+# --- token on: write guard ----------------------------------------------------
+
+
+def test_write_without_token_rejected(monkeypatch) -> None:
+    _enable_token(monkeypatch)
+
+    client = _client()
+    response = client.post("/clear")
+    assert response.status_code == 401
+    assert response.json() == {"detail": "api token required"}
+    assert response.headers.get("www-authenticate") == "Bearer"
+
+
+def test_write_with_wrong_token_rejected(monkeypatch) -> None:
+    _enable_token(monkeypatch)
+
+    client = _client()
+    response = client.post("/clear", headers={"Authorization": "Bearer nope"})
+    assert response.status_code == 401
+
+
+def test_write_with_wrong_scheme_rejected(monkeypatch) -> None:
+    _enable_token(monkeypatch)
+
+    client = _client()
+    response = client.post("/clear", headers={"Authorization": TOKEN})
+    assert response.status_code == 401
+
+
+def test_write_with_correct_token_accepted(monkeypatch) -> None:
+    _enable_token(monkeypatch)
+
+    client = _client()
+    response = client.post("/clear", headers={"Authorization": f"Bearer {TOKEN}"})
+    assert response.status_code == 200
+    assert response.json() == {"status": "cleared"}
+
+
+# --- token on: reads stay open -------------------------------------------------
+
+
+def test_reads_stay_open_with_token(monkeypatch) -> None:
+    _enable_token(monkeypatch)
+
+    client = _client()
+    assert client.get("/health").status_code == 200
+    assert client.get("/status").status_code == 200
+    assert client.get("/settings").status_code == 200
+    ui = client.get("/ui")
+    assert ui.status_code == 200
+    css = client.get("/static/ui/app.css")
+    assert css.status_code == 200
+
+
+def test_settings_response_never_exposes_token(monkeypatch) -> None:
+    _enable_token(monkeypatch)
+
+    client = _client()
+    response = client.get("/settings")
+    assert response.status_code == 200
+    assert TOKEN not in response.text
+    assert "api_token" not in response.json()


### PR DESCRIPTION
## Summary

Phase 5 of the architecture roadmap (`docs/ARCHITECTURE_REVIEW.md`, Finding 8): make the API trust boundary explicit while preserving local-first defaults.

- Optional bearer-token auth for write requests (`POST`/`PUT`/`PATCH`/`DELETE`), enforced by app middleware so current and future write routes are covered by default. Disabled when `RELAYTV_API_TOKEN` is unset or blank (the default) — behavior is then byte-identical to today. Enabled: `Authorization: Bearer <token>` with constant-time comparison; missing/wrong token → `401 {"detail": "api token required"}` + `WWW-Authenticate: Bearer`. Reads (`GET`/`HEAD`/`OPTIONS` — health, status, `/ui`, static assets, SSE) are never guarded.
- The token is env-only, plumbed through the Phase 2 runtime config service (`SETTINGS_BUS_VARS`): never persisted to settings.json, never returned by `/settings`, never logged. Reaches the container via the existing `env_file: .env` — no compose changes.
- Minimal web UI compatibility: one self-contained wrapper around `window.fetch` in `static/ui/app.js` attaches the bearer token from browser localStorage to same-origin requests and, on the first write rejected with `401` + `WWW-Authenticate: Bearer`, prompts once, stores the token, and retries. No visual or framework changes.
- Operator docs: `API.md` gains an "Optional API token" section (setup, curl example, what stays open, UI token entry, Caddy/nginx reverse-proxy examples with the SSE buffering caveat); `INSTALL.md`'s stale "token auth is not part of the current release branch" sentence replaced.
- Guardrail tests: `tests/test_api_auth.py` (10 tests) pins the auth contract — default-off passthrough, blank token means disabled, missing/wrong/wrong-scheme/correct token, reads always open, `/settings` never exposes the token.
- Full record: `docs/ARCHITECTURE_PHASE_5_ROADMAP.md`.

## User impact

None by default — with `RELAYTV_API_TOKEN` unset, every endpoint behaves exactly as before. Operators who opt in get write-endpoint protection; the web UI prompts once for the token and keeps working.

## Operator/deployment impact

New optional env variable `RELAYTV_API_TOKEN` (documented in `INSTALL.md`/`API.md`). No compose, dependency, or persisted-format changes. Health checks and dashboards (all reads) are unaffected when the token is enabled.

## Breaking changes

None.

## Tests

- `ruff check app tests` clean; `PYTHONPATH=app pytest -q` — 299 passed (including the new auth contract tests); CI-like fresh-venv run green; `docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md` regenerated for the new settings-bus variable.
- Live validation on the appliance with the branch image (evidence in roadmap M4): token off → writes open, behavior unchanged; token on → writes 401 without / with wrong bearer and 200 with the correct one, `WWW-Authenticate: Bearer` present, all reads open, token absent from `/settings`, active playback auto-resumed through the recreate and the outbound-polling Jellyfin receiver stayed connected with `sync_health: ok`; token removed → open behavior restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)