### PR TITLE
refactor: architecture phase 6 operations test matrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,44 @@ Do not manually edit `CHANGELOG.md` for normal feature, fix, docs, or dependency
 changes. Release Please owns version bumps, release pull requests, changelog
 generation, Git tags, GitHub Releases, and immutable release image tags.
 
-## Architecture Phase 5 Discipline
+## Architecture Phase 6 Discipline
+
+When working on the Phase 6 architecture effort (operations test matrix),
+keep work on `codex/architecture-phase-6` unless the user explicitly directs
+otherwise.
+
+Keep `docs/ARCHITECTURE_PHASE_6_ROADMAP.md` current when milestones start,
+complete, change scope, or uncover important follow-up work.
+
+Phase 6 scope:
+
+- machine-checked runtime profile matrix (`tests/test_runtime_matrix.py`)
+  pinning host-profile, Qt-runtime-mode, entrypoint-default, and
+  decode-profile decisions per profile (x11, wayland, headless, native Qt
+  embedded, Qt external mpv, Raspberry Pi, amd64 mini PC)
+- generated decision table plus per-profile operator validation checklists
+  in `docs/OPERATIONS_TEST_MATRIX.md`
+- docs wiring only; tests drive the real decision functions with fake
+  env/host inputs
+
+Out of scope for Phase 6 (document findings in the roadmap instead):
+
+- changing any runtime decision, installer behavior, compose output, or
+  capability payload shape
+- rewriting `install.sh` or modeling its generated output in Python
+- CI hardware-in-the-loop testing
+- new endpoints or API changes
+
+This is the final roadmap phase: once it completes, the no-release hold
+lifts. Until then, phases ship as `refactor:` PRs that intentionally do not
+trigger release-please. Prefer small PRs into `codex/architecture-phase-6`,
+not directly into `main`.
+
+## Architecture Phase 5 Discipline (complete)
+
+Phase 5 (optional API token) completed on `codex/architecture-phase-5`;
+final PR: https://github.com/mcgeezy/relaytv/pull/25. The full record lives
+in `docs/ARCHITECTURE_PHASE_5_ROADMAP.md`.
 
 When working on the Phase 5 architecture effort (optional API token), keep
 work on `codex/architecture-phase-5` unless the user explicitly directs

--- a/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
@@ -140,7 +140,7 @@ Status: complete
 
 ### M3: Phase 6 Final Validation
 
-Status: planned
+Status: complete
 
 - Full gates: `ruff check app tests`, `PYTHONPATH=app pytest -q`, CI-like
   fresh-venv run.
@@ -148,9 +148,27 @@ Status: planned
   match its matrix row (amd64 / Wayland / native Qt embed).
 - Open the final `codex/architecture-phase-6` to `main` PR — this completes
   the architecture roadmap.
+- Evidence: `ruff check app tests` clean and `PYTHONPATH=app pytest -q`
+  green (312 passed) on the branch and in a CI-like fresh venv. The phase
+  touches zero `app/` files (`git diff main..HEAD -- app/` is empty), so
+  the running Phase 5 image is content-identical to the Phase 6 runtime —
+  no rebuild/recreate needed for validation. The live appliance's
+  `/runtime/capabilities` matched the `amd64-wayland-native-qt-embed` row
+  field-by-field using the checklist's own cross-check command
+  (`player_backend=qt`, `qt_runtime_mode_configured/effective=embed`,
+  `player_runtime_engine=qt_shell`, `backend_ready=True`,
+  `backend_runtime_mismatch=False`, `host_session_type=wayland`,
+  `decode_profile=intel_amd64_qsv`, `av1_allowed=True`). The cross-check
+  also corrected a baseline error: the appliance runs a Wayland session,
+  not X11 as first assumed — the matrix row descriptions and the wayland
+  row's decode inputs were fixed to match before the final PR.
 
 ## PR And Milestone Log
 
 | Date | Item | Notes |
 | --- | --- | --- |
 | 2026-07-03 | Phase 6 started | Branch cut from `main` at `54081db` (Phase 5 squash merge); roadmap committed. |
+| 2026-07-03 | M0 complete | Roadmap, `AGENTS.md` Phase 6 discipline, `docs/README.md` link (`0c2c223`). |
+| 2026-07-04 | M1 complete | Machine-checked runtime profile matrix + generated decision table (`b321386`). |
+| 2026-07-04 | M2 complete | Per-profile validation checklists + docs wiring (`e036ba4`). |
+| 2026-07-04 | M3 complete | Gates green (312 passed, fresh venv), live appliance cross-check matched the wayland row (`1d295d1`); final PR opened. |

--- a/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
@@ -1,0 +1,143 @@
+# Phase 6 Architecture Roadmap
+
+Date started: 2026-07-03
+
+Branch: `codex/architecture-phase-6` (cut from `main` at the Phase 5 squash
+merge, PR #25 / `54081db`)
+
+Phase 6 goal: catch runtime regressions before users do. Turn the implicit
+runtime/installer policy (review Finding 9) into a machine-checked runtime
+profile matrix — host profile, display session, player backend, Qt runtime
+mode, decode profile, fallback behavior — and give operators a documented
+per-profile validation checklist covering the review's seven profiles: x11,
+wayland, headless, native Qt embedded, Qt external mpv, Raspberry Pi, and
+amd64 mini PC.
+
+This is the final phase of the architecture roadmap
+(`docs/ARCHITECTURE_REVIEW.md`, Finding 9 and the Phase 6 roadmap section).
+When it completes, the no-release hold lifts.
+
+## Working Rules
+
+- Keep Phase 6 work on `codex/architecture-phase-6` until the phase is
+  complete.
+- Merge small focused PRs into this branch instead of directly into `main`.
+- Documentation and tests only pin existing behavior: no changes to runtime
+  decisions, installer output, entrypoint policy, or capability payloads. If
+  a decision looks wrong while pinning it, document it here instead of
+  changing it.
+- The matrix tests drive the real decision functions with fake env/host
+  inputs — they must not spawn processes, touch `/dev`, or depend on the CI
+  host's display stack.
+- Update this file whenever a milestone starts, completes, changes scope,
+  or uncovers follow-up work.
+- Only open the final `codex/architecture-phase-6` to `main` PR after all
+  Phase 6 validation gates pass.
+- No release until the architecture roadmap completes (user decision
+  2026-07-03); this phase ships as a `refactor:` PR that does not trigger
+  release-please. Completing this phase ends the hold.
+
+## Scope
+
+In scope:
+
+- A machine-checked runtime profile matrix (`tests/test_runtime_matrix.py`)
+  that pins, per profile, the decisions made by:
+  - `container_entrypoint._host_profile` (explicit override, Raspberry Pi
+    device-tree detection, arm/amd64/generic fallback)
+  - `container_entrypoint._normalize_runtime_defaults` (headless remote
+    default, embed default for wayland/x11, Raspberry Pi GLES mpv args)
+  - `player.qt_runtime_mode_configured` / `qt_runtime_mode_effective`
+    (auto → external_mpv on wayland sessions, embed otherwise)
+  - `video_profile._decode_profile` and `_av1_allowed` (arm_safe, software,
+    intel qsv/vaapi, nvidia cuda, generic vaapi/vulkan; AV1 policy)
+- A generated decision table synced into `docs/OPERATIONS_TEST_MATRIX.md`
+  by the same test module (`--write`), following the Phase 2/3/4 inventory
+  doc pattern: the pinned rows and the generated listing must change in the
+  same commit.
+- Operator-facing per-profile validation checklists in
+  `docs/OPERATIONS_TEST_MATRIX.md`: bring-up command, `doctor.sh`,
+  `validate-native-qt-telemetry.sh` where applicable, the expected
+  `/runtime/capabilities` and `/status` fields for that profile, and soak
+  pointers into `NATIVE_RUNTIME_OPERATIONS.md`.
+- Docs wiring: `docs/README.md` and `NATIVE_RUNTIME_OPERATIONS.md` link to
+  the matrix.
+
+Out of scope:
+
+- Changing any runtime decision, installer behavior, compose output, or
+  capability payload shape.
+- Rewriting `install.sh` or modeling its generated output in Python
+  (Finding 9's installer-side suggestion stays future work).
+- CI hardware-in-the-loop testing; per-profile hardware validation remains
+  a documented manual checklist.
+- New endpoints or API changes.
+
+## Baseline (measured at phase start)
+
+- Runtime policy is spread across `install.sh`, `docker-compose.yml`,
+  `container_entrypoint.py` (`_host_profile`, `_normalize_runtime_defaults`),
+  `player.py` (backend/Qt-mode selection), and `video_profile.py` (decode
+  profile), with no single place stating what a given host/mode combination
+  is expected to decide.
+- The decision functions are already unit-testable: `_host_profile` and
+  `_normalize_runtime_defaults` take an env dict, `_decode_profile` and
+  `_av1_allowed` take explicit inputs, and the `player` mode functions read
+  env only.
+- Existing runtime test coverage (`tests/test_capability_routes.py`) pins
+  the capability endpoint shapes but not the per-profile decision policy.
+- `docs/INSTALL.md` describes mode defaults in prose; there is no
+  per-profile validation checklist for operators, and the review's seven
+  target profiles are not enumerated anywhere.
+- The live appliance (amd64 NUC, X11 session, native Qt embed) is available
+  to cross-check one matrix row end-to-end.
+
+## Milestones
+
+### M0: Branch, Roadmap, And Discipline Docs
+
+Status: complete
+
+- Branch cut from `main` at `54081db` (Phase 5 squash merge).
+- This roadmap; `AGENTS.md` Phase 6 discipline section (Phase 5 marked
+  complete); `docs/README.md` link.
+
+### M1: Machine-Checked Runtime Profile Matrix
+
+Status: planned
+
+- `tests/test_runtime_matrix.py`: `RUNTIME_PROFILE_MATRIX` rows for the
+  seven review profiles (plus the decision edge cases worth pinning:
+  explicit host-profile override, generic fallback, DRM-less software
+  decode, AV1 env override), each driving the real decision functions with
+  fake env/host inputs and asserting host profile, Qt runtime mode,
+  headless-remote default, Raspberry Pi mpv args, decode profile, and AV1
+  policy.
+- Doc-sync test + `--write` generator producing the decision table in
+  `docs/OPERATIONS_TEST_MATRIX.md`.
+
+### M2: Operator Validation Checklists And Docs Wiring
+
+Status: planned
+
+- Per-profile validation checklists in `docs/OPERATIONS_TEST_MATRIX.md`
+  (bring-up, doctor, telemetry validation, expected capability/status
+  fields, soak pointer).
+- Links from `docs/README.md` and `NATIVE_RUNTIME_OPERATIONS.md`.
+
+### M3: Phase 6 Final Validation
+
+Status: planned
+
+- Full gates: `ruff check app tests`, `PYTHONPATH=app pytest -q`, CI-like
+  fresh-venv run.
+- Live cross-check: the appliance's `/runtime/capabilities` and `/status`
+  match its matrix row (amd64 / X11 / native Qt embed).
+- Open the final `codex/architecture-phase-6` to `main` PR — this completes
+  the architecture roadmap.
+
+## PR And Milestone Log
+
+| Date | Item | Notes |
+| --- | --- | --- |
+| 2026-07-03 | Phase 6 started | Branch cut from `main` at `54081db` (Phase 5 squash merge); roadmap committed. |

--- a/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
@@ -125,12 +125,18 @@ Status: complete
 
 ### M2: Operator Validation Checklists And Docs Wiring
 
-Status: planned
+Status: complete
 
 - Per-profile validation checklists in `docs/OPERATIONS_TEST_MATRIX.md`
   (bring-up, doctor, telemetry validation, expected capability/status
   fields, soak pointer).
 - Links from `docs/README.md` and `NATIVE_RUNTIME_OPERATIONS.md`.
+- Landed: common steps (matrix tests, `doctor.sh`, a
+  `/runtime/capabilities` field cross-check with
+  `backend_runtime_mismatch=False` as the hard gate) plus seven
+  profile-specific checklists referencing the existing tooling
+  (`host-ops.sh up/native-ready/acceptance`,
+  `validate-native-qt-telemetry.sh`, soak playbook) and a reporting note.
 
 ### M3: Phase 6 Final Validation
 

--- a/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
@@ -104,7 +104,7 @@ Status: complete
 
 ### M1: Machine-Checked Runtime Profile Matrix
 
-Status: planned
+Status: complete
 
 - `tests/test_runtime_matrix.py`: `RUNTIME_PROFILE_MATRIX` rows for the
   seven review profiles (plus the decision edge cases worth pinning:
@@ -115,6 +115,13 @@ Status: planned
   policy.
 - Doc-sync test + `--write` generator producing the decision table in
   `docs/OPERATIONS_TEST_MATRIX.md`.
+- Landed: seven matrix rows (amd64 x11/wayland embed, wayland external
+  mpv explicit, unmanaged-mode auto→external on a Wayland session,
+  headless-remote with classic mpv, Raspberry Pi wayland embed with GLES
+  args, generic arm64) plus five edge-case tests (host-profile override,
+  generic fallback, explicit backend selection, decode accel branches,
+  AV1 env override). 13 tests; matrix rows assert entrypoint defaults
+  exactly (added-keys equality, not subset).
 
 ### M2: Operator Validation Checklists And Docs Wiring
 

--- a/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
@@ -89,8 +89,8 @@ Out of scope:
 - `docs/INSTALL.md` describes mode defaults in prose; there is no
   per-profile validation checklist for operators, and the review's seven
   target profiles are not enumerated anywhere.
-- The live appliance (amd64 NUC, X11 session, native Qt embed) is available
-  to cross-check one matrix row end-to-end.
+- The live appliance (amd64 NUC, Wayland session, native Qt embed) is
+  available to cross-check one matrix row end-to-end.
 
 ## Milestones
 
@@ -145,7 +145,7 @@ Status: planned
 - Full gates: `ruff check app tests`, `PYTHONPATH=app pytest -q`, CI-like
   fresh-venv run.
 - Live cross-check: the appliance's `/runtime/capabilities` and `/status`
-  match its matrix row (amd64 / X11 / native Qt embed).
+  match its matrix row (amd64 / Wayland / native Qt embed).
 - Open the final `codex/architecture-phase-6` to `main` PR — this completes
   the architecture roadmap.
 

--- a/docs/NATIVE_RUNTIME_OPERATIONS.md
+++ b/docs/NATIVE_RUNTIME_OPERATIONS.md
@@ -7,6 +7,9 @@ This runbook is the first-line operator workflow for native Qt on desktop hosts.
 Primary docs:
 
 - `docs/INSTALL.md`
+- `docs/OPERATIONS_TEST_MATRIX.md`: per-profile expected runtime decisions
+  and validation checklists (x11, wayland, headless, native Qt embedded,
+  Qt external mpv, Raspberry Pi, arm64/amd64)
 
 ## Quick Health Snapshot
 

--- a/docs/OPERATIONS_TEST_MATRIX.md
+++ b/docs/OPERATIONS_TEST_MATRIX.md
@@ -1,0 +1,51 @@
+# Operations Test Matrix
+
+This is the runtime validation matrix for RelayTV's supported operations
+profiles. It answers two questions:
+
+1. What runtime decisions should a given host/mode combination produce?
+   (machine-checked — the table below is generated from
+   `tests/test_runtime_matrix.py`, which drives the real decision functions
+   with faked host inputs)
+2. How does an operator validate a profile on real hardware? (the
+   per-profile checklists below; hardware validation stays manual)
+
+Regenerate the decision table after intentional changes with:
+
+    PYTHONPATH=app python3 tests/test_runtime_matrix.py --write
+
+## Profile Decision Table
+
+<!-- BEGIN GENERATED RUNTIME PROFILE MATRIX (tests/test_runtime_matrix.py) -->
+| Profile | `RELAYTV_MODE` | Session | Backend | Qt runtime mode | Host profile | Entrypoint defaults | Decode profile | AV1 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `amd64-x11-native-qt-embed` | `x11` | x11 | qt | embed | `amd64` | `RELAYTV_QT_RUNTIME_MODE=embed` | `intel_amd64_qsv` | yes |
+| `amd64-wayland-native-qt-embed` | `wayland` | wayland | qt | embed | `amd64` | `RELAYTV_QT_RUNTIME_MODE=embed` | `intel_amd64_vaapi` | yes |
+| `amd64-wayland-qt-external-mpv` | `wayland` | wayland | qt | external_mpv | `amd64` | — | `intel_amd64_vaapi` | yes |
+| `amd64-unmanaged-wayland-auto` | `(unset)` | wayland | qt | auto → external_mpv | `amd64` | — | `intel_amd64_vaapi` | yes |
+| `headless-remote` | `headless` | (none) | classic mpv | n/a (classic mpv) | `amd64` | `RELAYTV_HEADLESS_REMOTE_ENABLED=1` | `software` | no |
+| `raspi-wayland-native-qt-embed` | `wayland` | wayland | qt | embed | `raspi` | `RELAYTV_QT_RUNTIME_MODE=embed`; `RELAYTV_QT_SHELL_MPV_ARGS=--gpu-api=opengl --opengl-es=yes` | `arm_safe` | no |
+| `arm64-x11-native-qt-embed` | `x11` | x11 | qt | embed | `arm` | `RELAYTV_QT_RUNTIME_MODE=embed` | `arm_safe` | no |
+
+- `amd64-x11-native-qt-embed`: amd64 mini PC, X11 session, native Qt embedded (product default; live appliance)
+- `amd64-wayland-native-qt-embed`: amd64, Wayland session, native Qt embedded (installer default for wayland mode)
+- `amd64-wayland-qt-external-mpv`: amd64, Wayland session, Qt shell with external mpv (explicit operator opt-in)
+- `amd64-unmanaged-wayland-auto`: amd64, RELAYTV_MODE unset with a Wayland session: auto resolves to external mpv
+- `headless-remote`: Headless host, classic mpv backend, remote playback surface enabled by default
+- `raspi-wayland-native-qt-embed`: Raspberry Pi, Wayland session via xcb QPA, native Qt embedded with GLES mpv args
+- `arm64-x11-native-qt-embed`: Generic arm64 box (not a Raspberry Pi), X11 session, native Qt embedded
+<!-- END GENERATED RUNTIME PROFILE MATRIX (tests/test_runtime_matrix.py) -->
+
+Decision sources: `container_entrypoint._host_profile` and
+`_normalize_runtime_defaults` (host profile, entrypoint defaults),
+`player.qt_runtime_mode_configured`/`qt_runtime_mode_effective` (Qt runtime
+mode; `auto` resolves to `external_mpv` only on Wayland sessions),
+`video_profile._decode_profile`/`_av1_allowed` (decode policy). Edge cases
+pinned by tests but kept out of the operator table: explicit
+`RELAYTV_HOST_PROFILE` override, generic-architecture fallback,
+`RELAYTV_PLAYER_BACKEND` explicit selection, nvidia/vaapi/vulkan/software
+decode branches, and the `RELAYTV_VIDEO_PROFILE_ALLOW_AV1` override.
+
+## Per-Profile Validation Checklists
+
+(Deferred to Phase 6 M2.)

--- a/docs/OPERATIONS_TEST_MATRIX.md
+++ b/docs/OPERATIONS_TEST_MATRIX.md
@@ -48,4 +48,97 @@ decode branches, and the `RELAYTV_VIDEO_PROFILE_ALLOW_AV1` override.
 
 ## Per-Profile Validation Checklists
 
-(Deferred to Phase 6 M2.)
+Hardware validation is manual. Every profile starts with the same three
+steps, then adds profile-specific checks.
+
+Common steps (all profiles):
+
+1. `PYTHONPATH=app pytest -q tests/test_runtime_matrix.py` — the decision
+   policy itself is green on the checkout being validated.
+2. `./scripts/doctor.sh` on the host — records session type, display
+   env, GPU/DRI state, and overlay caveats for the report.
+3. After bring-up, verify the profile's row against the live runtime:
+
+   ```bash
+   curl -sS http://127.0.0.1:8787/runtime/capabilities | python3 -c '
+   import json,sys
+   d=json.load(sys.stdin)
+   for k in ("player_backend","configured_player_backend","qt_runtime_mode_configured",
+             "qt_runtime_mode_effective","player_runtime_engine","backend_ready",
+             "backend_runtime_mismatch","host_session_type","decode_profile","av1_allowed"):
+       print(f"{k}: {d.get(k)}")'
+   ```
+
+   `backend_runtime_mismatch` must be `False` and the mode/decode fields
+   must match the profile's row in the decision table above.
+
+### `amd64-x11-native-qt-embed` (product default)
+
+- Bring-up: `./scripts/host-ops.sh up --x11-native --native-playback`
+- Gate: `./scripts/host-ops.sh native-ready --wait 25` exits 0.
+- Expect: `player_backend=qt`, `qt_runtime_mode_effective=embed`,
+  `player_runtime_engine=qt_shell`, `decode_profile=intel_amd64_qsv` (QSV
+  hosts) or `intel_amd64_vaapi`.
+- Contract: `./scripts/host-ops.sh acceptance --no-up` (native telemetry,
+  control acks, overlay deliverability, YouTube pipeline).
+- Telemetry deep-check when touching player/qt_shell code:
+  `./scripts/validate-native-qt-telemetry.sh`.
+- Soak: follow "Native Soak" and "Acceptance + Overnight Playbook" in
+  `NATIVE_RUNTIME_OPERATIONS.md`.
+
+### `amd64-wayland-native-qt-embed`
+
+- Bring-up: `./scripts/host-ops.sh up --wayland-native --stable-playback`
+- Gate: `native-ready --wait 25` exits 0.
+- Expect: same as the x11 row but `host_session_type=wayland`; note the
+  host X11 overlay fallback is disabled under Wayland (`doctor.sh` prints
+  the caveat) — native Qt overlay/toast is the only overlay path, so also
+  verify a toast renders (`POST /overlay/toast`).
+
+### `amd64-wayland-qt-external-mpv`
+
+- Enable: set `RELAYTV_QT_RUNTIME_MODE=external_mpv` in `.env`, then
+  recreate the container.
+- Expect: `qt_runtime_mode_effective=external_mpv`,
+  `player_runtime_engine=qt_external_mpv` during playback, `mpv_pid` set
+  and `ipc_socket_exists=True`.
+- Play/pause/seek/volume smoke via `/ui`, then remove the override and
+  confirm the profile returns to `embed`.
+
+### `amd64-unmanaged-wayland-auto`
+
+- Setup: leave `RELAYTV_MODE` unset on a Wayland session host.
+- Expect: `qt_runtime_mode_configured=auto`,
+  `qt_runtime_mode_effective=external_mpv` — pins the auto fallback that
+  protects unmanaged installs.
+
+### `headless-remote`
+
+- Bring-up: install with `--mode headless` (or `RELAYTV_MODE=headless`).
+- Expect: `headless_runtime=True`, `player_backend=mpv` when the classic
+  backend is selected, `RELAYTV_HEADLESS_REMOTE_ENABLED=1` in the container
+  env (`docker exec relaytv env | grep HEADLESS`), `GET /health` ok, `/ui`
+  reachable from another machine, playback controllable remotely.
+
+### `raspi-wayland-native-qt-embed`
+
+- Bring-up: `host-ops.sh up --wayland-native --stable-playback` on the Pi.
+- Expect: GLES mpv args injected
+  (`docker exec relaytv env | grep RELAYTV_QT_SHELL_MPV_ARGS` →
+  `--gpu-api=opengl --opengl-es=yes`), `decode_profile=arm_safe`,
+  `av1_allowed=False` (AV1 content must transcode or fall back), playback
+  smoke with a 1080p H.264 stream.
+- See also "Raspberry Pi Notes" in `INSTALL.md`.
+
+### `arm64-x11-native-qt-embed`
+
+- Bring-up: `host-ops.sh up --x11-native --native-playback` on the arm64
+  box.
+- Expect: `decode_profile=arm_safe`, `av1_allowed=False`, native Qt embed
+  fields as in the amd64 x11 row.
+
+## Reporting
+
+Record validation runs (date, image tag, host, profile, pass/fail plus
+`doctor.sh` output) in the release notes or the operations log for the
+deployment — this file defines the checks, it does not store results.

--- a/docs/OPERATIONS_TEST_MATRIX.md
+++ b/docs/OPERATIONS_TEST_MATRIX.md
@@ -20,15 +20,15 @@ Regenerate the decision table after intentional changes with:
 | Profile | `RELAYTV_MODE` | Session | Backend | Qt runtime mode | Host profile | Entrypoint defaults | Decode profile | AV1 |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `amd64-x11-native-qt-embed` | `x11` | x11 | qt | embed | `amd64` | `RELAYTV_QT_RUNTIME_MODE=embed` | `intel_amd64_qsv` | yes |
-| `amd64-wayland-native-qt-embed` | `wayland` | wayland | qt | embed | `amd64` | `RELAYTV_QT_RUNTIME_MODE=embed` | `intel_amd64_vaapi` | yes |
+| `amd64-wayland-native-qt-embed` | `wayland` | wayland | qt | embed | `amd64` | `RELAYTV_QT_RUNTIME_MODE=embed` | `intel_amd64_qsv` | yes |
 | `amd64-wayland-qt-external-mpv` | `wayland` | wayland | qt | external_mpv | `amd64` | — | `intel_amd64_vaapi` | yes |
 | `amd64-unmanaged-wayland-auto` | `(unset)` | wayland | qt | auto → external_mpv | `amd64` | — | `intel_amd64_vaapi` | yes |
 | `headless-remote` | `headless` | (none) | classic mpv | n/a (classic mpv) | `amd64` | `RELAYTV_HEADLESS_REMOTE_ENABLED=1` | `software` | no |
 | `raspi-wayland-native-qt-embed` | `wayland` | wayland | qt | embed | `raspi` | `RELAYTV_QT_RUNTIME_MODE=embed`; `RELAYTV_QT_SHELL_MPV_ARGS=--gpu-api=opengl --opengl-es=yes` | `arm_safe` | no |
 | `arm64-x11-native-qt-embed` | `x11` | x11 | qt | embed | `arm` | `RELAYTV_QT_RUNTIME_MODE=embed` | `arm_safe` | no |
 
-- `amd64-x11-native-qt-embed`: amd64 mini PC, X11 session, native Qt embedded (product default; live appliance)
-- `amd64-wayland-native-qt-embed`: amd64, Wayland session, native Qt embedded (installer default for wayland mode)
+- `amd64-x11-native-qt-embed`: amd64 mini PC, X11 session, native Qt embedded (product default)
+- `amd64-wayland-native-qt-embed`: amd64, Wayland session, native Qt embedded (installer default for wayland mode; live appliance)
 - `amd64-wayland-qt-external-mpv`: amd64, Wayland session, Qt shell with external mpv (explicit operator opt-in)
 - `amd64-unmanaged-wayland-auto`: amd64, RELAYTV_MODE unset with a Wayland session: auto resolves to external mpv
 - `headless-remote`: Headless host, classic mpv backend, remote playback surface enabled by default

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Use this directory as a small operator/product doc set for the public release br
 - `ARCHITECTURE_PHASE_4_ROADMAP.md`: living Phase 4 branch roadmap for the Jellyfin product service
 - `ARCHITECTURE_PHASE_4_JELLYFIN_INVENTORY.md`: machine-checked Jellyfin route-surface inventory and containment contract
 - `ARCHITECTURE_PHASE_5_ROADMAP.md`: living Phase 5 branch roadmap for the optional API token
+- `ARCHITECTURE_PHASE_6_ROADMAP.md`: living Phase 6 branch roadmap for the operations test matrix
 
 ## Module Ownership Snapshot
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Use this directory as a small operator/product doc set for the public release br
 - `API.md`: HTTP endpoint reference
 - `JELLYFIN_OPERATIONS.md`: Jellyfin runtime config, verification, troubleshooting
 - `NATIVE_RUNTIME_OPERATIONS.md`: runtime operations, readiness checks, logging, and soak workflow
+- `OPERATIONS_TEST_MATRIX.md`: runtime profile decision table (machine-checked) and per-profile validation checklists
 - `RELEASE.md`: release inputs, image traceability, and compliance checklist
 
 ## Engineering Review Docs

--- a/tests/test_runtime_matrix.py
+++ b/tests/test_runtime_matrix.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Machine-checked runtime profile matrix (docs/ARCHITECTURE_PHASE_6_ROADMAP.md).
+
+Pins the runtime decisions RelayTV makes per operations profile — host
+profile detection, entrypoint defaults, Qt runtime mode, and decode
+profile — by driving the real decision functions with fake env/host
+inputs. The operator-facing table in docs/OPERATIONS_TEST_MATRIX.md is
+generated from RUNTIME_PROFILE_MATRIX; the pinned rows and the generated
+table must change in the same commit.
+
+Regenerate the doc table after intentional changes with:
+
+    PYTHONPATH=app python3 tests/test_runtime_matrix.py --write
+
+The rows use an explicit RELAYTV_PLAYER_BACKEND so the matrix stays
+hermetic: the backend default path probes display sockets on the host and
+is covered separately by the explicit-override tests below.
+"""
+import re
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from relaytv_app import container_entrypoint, player, video_profile
+
+
+DOC_PATH = Path(__file__).resolve().parent.parent / "docs" / "OPERATIONS_TEST_MATRIX.md"
+BEGIN_MARK = "<!-- BEGIN GENERATED RUNTIME PROFILE MATRIX (tests/test_runtime_matrix.py) -->"
+END_MARK = "<!-- END GENERATED RUNTIME PROFILE MATRIX (tests/test_runtime_matrix.py) -->"
+
+# Env variables the matrix controls; cleared before each row is applied.
+_MATRIX_ENV_VARS = (
+    "RELAYTV_MODE",
+    "RELAYTV_HOST_SESSION_TYPE",
+    "XDG_SESSION_TYPE",
+    "RELAYTV_PLAYER_BACKEND",
+    "RELAYTV_QT_RUNTIME_MODE",
+    "RELAYTV_HOST_PROFILE",
+    "RELAYTV_HEADLESS_REMOTE_ENABLED",
+    "RELAYTV_QT_SHELL_MPV_ARGS",
+    "RELAYTV_QT_SHELL_MODULE",
+    "QT_QPA_PLATFORM",
+    "RELAYTV_VIDEO_PROFILE_ALLOW_AV1",
+)
+
+
+RUNTIME_PROFILE_MATRIX = [
+    {
+        "profile": "amd64-x11-native-qt-embed",
+        "description": "amd64 mini PC, X11 session, native Qt embedded (product default; live appliance)",
+        "env": {
+            "RELAYTV_MODE": "x11",
+            "RELAYTV_HOST_SESSION_TYPE": "x11",
+            "RELAYTV_PLAYER_BACKEND": "qt",
+        },
+        "host": {"machine": "x86_64", "model": "", "has_dri": True},
+        "decode": {"hwaccels": ["qsv", "vaapi"], "av1_paths": ["libdav1d"]},
+        "expected": {
+            "host_profile": "amd64",
+            "entrypoint_defaults": {"RELAYTV_QT_RUNTIME_MODE": "embed"},
+            "qt_backend_enabled": True,
+            "qt_runtime_mode_configured": "embed",
+            "qt_runtime_mode_effective": "embed",
+            "decode_profile": "intel_amd64_qsv",
+            "av1_allowed": True,
+        },
+    },
+    {
+        "profile": "amd64-wayland-native-qt-embed",
+        "description": "amd64, Wayland session, native Qt embedded (installer default for wayland mode)",
+        "env": {
+            "RELAYTV_MODE": "wayland",
+            "RELAYTV_HOST_SESSION_TYPE": "wayland",
+            "RELAYTV_PLAYER_BACKEND": "qt",
+        },
+        "host": {"machine": "x86_64", "model": "", "has_dri": True},
+        "decode": {"hwaccels": ["vaapi"], "av1_paths": ["libdav1d"]},
+        "expected": {
+            "host_profile": "amd64",
+            "entrypoint_defaults": {"RELAYTV_QT_RUNTIME_MODE": "embed"},
+            "qt_backend_enabled": True,
+            "qt_runtime_mode_configured": "embed",
+            "qt_runtime_mode_effective": "embed",
+            "decode_profile": "intel_amd64_vaapi",
+            "av1_allowed": True,
+        },
+    },
+    {
+        "profile": "amd64-wayland-qt-external-mpv",
+        "description": "amd64, Wayland session, Qt shell with external mpv (explicit operator opt-in)",
+        "env": {
+            "RELAYTV_MODE": "wayland",
+            "RELAYTV_HOST_SESSION_TYPE": "wayland",
+            "RELAYTV_PLAYER_BACKEND": "qt",
+            "RELAYTV_QT_RUNTIME_MODE": "external_mpv",
+        },
+        "host": {"machine": "x86_64", "model": "", "has_dri": True},
+        "decode": {"hwaccels": ["vaapi"], "av1_paths": ["libdav1d"]},
+        "expected": {
+            "host_profile": "amd64",
+            "entrypoint_defaults": {},
+            "qt_backend_enabled": True,
+            "qt_runtime_mode_configured": "external_mpv",
+            "qt_runtime_mode_effective": "external_mpv",
+            "decode_profile": "intel_amd64_vaapi",
+            "av1_allowed": True,
+        },
+    },
+    {
+        "profile": "amd64-unmanaged-wayland-auto",
+        "description": "amd64, RELAYTV_MODE unset with a Wayland session: auto resolves to external mpv",
+        "env": {
+            "RELAYTV_HOST_SESSION_TYPE": "wayland",
+            "RELAYTV_PLAYER_BACKEND": "qt",
+        },
+        "host": {"machine": "x86_64", "model": "", "has_dri": True},
+        "decode": {"hwaccels": ["vaapi"], "av1_paths": ["libdav1d"]},
+        "expected": {
+            "host_profile": "amd64",
+            "entrypoint_defaults": {},
+            "qt_backend_enabled": True,
+            "qt_runtime_mode_configured": "auto",
+            "qt_runtime_mode_effective": "external_mpv",
+            "decode_profile": "intel_amd64_vaapi",
+            "av1_allowed": True,
+        },
+    },
+    {
+        "profile": "headless-remote",
+        "description": "Headless host, classic mpv backend, remote playback surface enabled by default",
+        "env": {
+            "RELAYTV_MODE": "headless",
+            "RELAYTV_PLAYER_BACKEND": "mpv",
+        },
+        "host": {"machine": "x86_64", "model": "", "has_dri": False},
+        "decode": {"hwaccels": [], "av1_paths": []},
+        "expected": {
+            "host_profile": "amd64",
+            "entrypoint_defaults": {"RELAYTV_HEADLESS_REMOTE_ENABLED": "1"},
+            "qt_backend_enabled": False,
+            "qt_runtime_mode_configured": "auto",
+            "qt_runtime_mode_effective": "embed",
+            "decode_profile": "software",
+            "av1_allowed": False,
+        },
+    },
+    {
+        "profile": "raspi-wayland-native-qt-embed",
+        "description": "Raspberry Pi, Wayland session via xcb QPA, native Qt embedded with GLES mpv args",
+        "env": {
+            "RELAYTV_MODE": "wayland",
+            "RELAYTV_HOST_SESSION_TYPE": "wayland",
+            "RELAYTV_PLAYER_BACKEND": "qt",
+            "QT_QPA_PLATFORM": "xcb",
+        },
+        "host": {"machine": "aarch64", "model": "Raspberry Pi 5 Model B Rev 1.0", "has_dri": True},
+        "decode": {"hwaccels": ["drm"], "av1_paths": ["libdav1d"]},
+        "expected": {
+            "host_profile": "raspi",
+            "entrypoint_defaults": {
+                "RELAYTV_QT_RUNTIME_MODE": "embed",
+                "RELAYTV_QT_SHELL_MPV_ARGS": "--gpu-api=opengl --opengl-es=yes",
+            },
+            "qt_backend_enabled": True,
+            "qt_runtime_mode_configured": "embed",
+            "qt_runtime_mode_effective": "embed",
+            "decode_profile": "arm_safe",
+            "av1_allowed": False,
+        },
+    },
+    {
+        "profile": "arm64-x11-native-qt-embed",
+        "description": "Generic arm64 box (not a Raspberry Pi), X11 session, native Qt embedded",
+        "env": {
+            "RELAYTV_MODE": "x11",
+            "RELAYTV_HOST_SESSION_TYPE": "x11",
+            "RELAYTV_PLAYER_BACKEND": "qt",
+        },
+        "host": {"machine": "aarch64", "model": "", "has_dri": True},
+        "decode": {"hwaccels": ["v4l2m2m"], "av1_paths": []},
+        "expected": {
+            "host_profile": "arm",
+            "entrypoint_defaults": {"RELAYTV_QT_RUNTIME_MODE": "embed"},
+            "qt_backend_enabled": True,
+            "qt_runtime_mode_configured": "embed",
+            "qt_runtime_mode_effective": "embed",
+            "decode_profile": "arm_safe",
+            "av1_allowed": False,
+        },
+    },
+]
+
+
+def _clear_matrix_env(monkeypatch) -> None:
+    for var in _MATRIX_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _fake_host(monkeypatch, host: dict) -> None:
+    monkeypatch.setattr(container_entrypoint, "_host_model", lambda: str(host.get("model") or ""))
+    monkeypatch.setattr(container_entrypoint, "_has_dri", lambda: bool(host.get("has_dri")))
+    monkeypatch.setattr(
+        container_entrypoint.os,
+        "uname",
+        lambda: SimpleNamespace(machine=str(host.get("machine") or "")),
+    )
+
+
+@pytest.mark.parametrize("row", RUNTIME_PROFILE_MATRIX, ids=lambda r: r["profile"])
+def test_runtime_profile_matrix(monkeypatch, row) -> None:
+    host = row["host"]
+    expected = row["expected"]
+    _fake_host(monkeypatch, host)
+
+    env = dict(row["env"])
+    baseline = dict(env)
+    container_entrypoint._normalize_runtime_defaults(env)
+
+    assert container_entrypoint._host_profile(env) == expected["host_profile"]
+
+    added = {k: v for k, v in env.items() if baseline.get(k) != v}
+    assert added == expected["entrypoint_defaults"]
+
+    _clear_matrix_env(monkeypatch)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    assert player.qt_shell_backend_enabled() is expected["qt_backend_enabled"]
+    assert player.qt_runtime_mode_configured() == expected["qt_runtime_mode_configured"]
+    assert player.qt_runtime_mode_effective() == expected["qt_runtime_mode_effective"]
+
+    decode = row["decode"]
+    assert (
+        video_profile._decode_profile(host["machine"], bool(host["has_dri"]), decode["hwaccels"])
+        == expected["decode_profile"]
+    )
+    assert video_profile._av1_allowed(host["machine"], decode["av1_paths"]) is expected["av1_allowed"]
+
+
+# --- decision edge cases not in the operator-facing table --------------------
+
+
+def test_host_profile_explicit_override_wins(monkeypatch) -> None:
+    _fake_host(monkeypatch, {"machine": "x86_64", "model": "Raspberry Pi 4", "has_dri": True})
+    assert container_entrypoint._host_profile({"RELAYTV_HOST_PROFILE": "kiosk-a"}) == "kiosk-a"
+
+
+def test_host_profile_generic_fallback(monkeypatch) -> None:
+    _fake_host(monkeypatch, {"machine": "riscv64", "model": "", "has_dri": True})
+    assert container_entrypoint._host_profile({}) == "generic"
+
+
+def test_player_backend_explicit_classic(monkeypatch) -> None:
+    _clear_matrix_env(monkeypatch)
+    monkeypatch.setenv("RELAYTV_PLAYER_BACKEND", "mpv")
+    assert player.qt_shell_backend_enabled() is False
+    monkeypatch.setenv("RELAYTV_PLAYER_BACKEND", "qt")
+    assert player.qt_shell_backend_enabled() is True
+
+
+def test_decode_profile_accel_branches() -> None:
+    assert video_profile._decode_profile("x86_64", True, ["cuda"]) == "nvidia_cuda"
+    assert video_profile._decode_profile("riscv64", True, ["vaapi"]) == "vaapi_generic"
+    assert video_profile._decode_profile("riscv64", True, ["vulkan"]) == "vulkan_generic"
+    assert video_profile._decode_profile("x86_64", False, ["qsv"]) == "software"
+    assert video_profile._decode_profile("x86_64", True, []) == "software"
+
+
+def test_av1_env_override_beats_policy(monkeypatch) -> None:
+    monkeypatch.setenv("RELAYTV_VIDEO_PROFILE_ALLOW_AV1", "0")
+    assert video_profile._av1_allowed("x86_64", ["libdav1d"]) is False
+    monkeypatch.setenv("RELAYTV_VIDEO_PROFILE_ALLOW_AV1", "1")
+    assert video_profile._av1_allowed("aarch64", []) is True
+    monkeypatch.delenv("RELAYTV_VIDEO_PROFILE_ALLOW_AV1", raising=False)
+    assert video_profile._av1_allowed("x86_64", []) is False
+
+
+# --- generated doc table ------------------------------------------------------
+
+
+def _mode_cell(row: dict) -> str:
+    return row["env"].get("RELAYTV_MODE") or "(unset)"
+
+
+def _session_cell(row: dict) -> str:
+    return row["env"].get("RELAYTV_HOST_SESSION_TYPE") or "(none)"
+
+
+def _qt_mode_cell(row: dict) -> str:
+    expected = row["expected"]
+    if not expected["qt_backend_enabled"]:
+        return "n/a (classic mpv)"
+    configured = expected["qt_runtime_mode_configured"]
+    effective = expected["qt_runtime_mode_effective"]
+    return configured if configured == effective else f"{configured} → {effective}"
+
+
+def _defaults_cell(row: dict) -> str:
+    defaults = row["expected"]["entrypoint_defaults"]
+    if not defaults:
+        return "—"
+    return "; ".join(f"`{k}={v}`" for k, v in sorted(defaults.items()))
+
+
+def generate_matrix_table() -> str:
+    lines = [
+        "| Profile | `RELAYTV_MODE` | Session | Backend | Qt runtime mode | Host profile | Entrypoint defaults | Decode profile | AV1 |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in RUNTIME_PROFILE_MATRIX:
+        expected = row["expected"]
+        lines.append(
+            "| `{profile}` | `{mode}` | {session} | {backend} | {qt_mode} | `{host_profile}` | {defaults} | `{decode}` | {av1} |".format(
+                profile=row["profile"],
+                mode=_mode_cell(row),
+                session=_session_cell(row),
+                backend="qt" if expected["qt_backend_enabled"] else "classic mpv",
+                qt_mode=_qt_mode_cell(row),
+                host_profile=expected["host_profile"],
+                defaults=_defaults_cell(row),
+                decode=expected["decode_profile"],
+                av1="yes" if expected["av1_allowed"] else "no",
+            )
+        )
+    lines.append("")
+    for row in RUNTIME_PROFILE_MATRIX:
+        lines.append(f"- `{row['profile']}`: {row['description']}")
+    return "\n".join(lines)
+
+
+def _render_doc_block() -> str:
+    return f"{BEGIN_MARK}\n{generate_matrix_table()}\n{END_MARK}"
+
+
+def test_matrix_doc_matches_source() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    match = re.search(re.escape(BEGIN_MARK) + r".*?" + re.escape(END_MARK), text, flags=re.DOTALL)
+    assert match, f"generated matrix markers missing from {DOC_PATH}"
+    assert match.group(0) == _render_doc_block(), (
+        "docs/OPERATIONS_TEST_MATRIX.md is out of date; regenerate with "
+        "`PYTHONPATH=app python3 tests/test_runtime_matrix.py --write`"
+    )
+
+
+def _write_doc() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(re.escape(BEGIN_MARK) + r".*?" + re.escape(END_MARK), flags=re.DOTALL)
+    assert pattern.search(text), f"generated matrix markers missing from {DOC_PATH}"
+    DOC_PATH.write_text(pattern.sub(lambda _m: _render_doc_block(), text), encoding="utf-8")
+    print(f"wrote {DOC_PATH}")
+
+
+if __name__ == "__main__":
+    if "--write" in sys.argv:
+        _write_doc()
+    else:
+        print(generate_matrix_table())

--- a/tests/test_runtime_matrix.py
+++ b/tests/test_runtime_matrix.py
@@ -49,7 +49,7 @@ _MATRIX_ENV_VARS = (
 RUNTIME_PROFILE_MATRIX = [
     {
         "profile": "amd64-x11-native-qt-embed",
-        "description": "amd64 mini PC, X11 session, native Qt embedded (product default; live appliance)",
+        "description": "amd64 mini PC, X11 session, native Qt embedded (product default)",
         "env": {
             "RELAYTV_MODE": "x11",
             "RELAYTV_HOST_SESSION_TYPE": "x11",
@@ -69,21 +69,21 @@ RUNTIME_PROFILE_MATRIX = [
     },
     {
         "profile": "amd64-wayland-native-qt-embed",
-        "description": "amd64, Wayland session, native Qt embedded (installer default for wayland mode)",
+        "description": "amd64, Wayland session, native Qt embedded (installer default for wayland mode; live appliance)",
         "env": {
             "RELAYTV_MODE": "wayland",
             "RELAYTV_HOST_SESSION_TYPE": "wayland",
             "RELAYTV_PLAYER_BACKEND": "qt",
         },
         "host": {"machine": "x86_64", "model": "", "has_dri": True},
-        "decode": {"hwaccels": ["vaapi"], "av1_paths": ["libdav1d"]},
+        "decode": {"hwaccels": ["qsv", "vaapi"], "av1_paths": ["libdav1d"]},
         "expected": {
             "host_profile": "amd64",
             "entrypoint_defaults": {"RELAYTV_QT_RUNTIME_MODE": "embed"},
             "qt_backend_enabled": True,
             "qt_runtime_mode_configured": "embed",
             "qt_runtime_mode_effective": "embed",
-            "decode_profile": "intel_amd64_vaapi",
+            "decode_profile": "intel_amd64_qsv",
             "av1_allowed": True,
         },
     },


### PR DESCRIPTION
## Summary

Phase 6 of the architecture roadmap (`docs/ARCHITECTURE_REVIEW.md`, Finding 9): turn the implicit runtime/installer policy into a machine-checked runtime profile matrix plus operator-facing per-profile validation checklists. **This is the final roadmap phase — merging it completes the architecture roadmap.**

- `tests/test_runtime_matrix.py`: `RUNTIME_PROFILE_MATRIX` pins seven operations profiles (amd64 x11/wayland native Qt embed, wayland external mpv, unmanaged-mode auto fallback, headless remote, Raspberry Pi wayland embed with GLES args, generic arm64) by driving the real decision functions — `container_entrypoint._host_profile` / `_normalize_runtime_defaults`, `player.qt_runtime_mode_configured/effective`, `video_profile._decode_profile` / `_av1_allowed` — with fake env/host inputs. Matrix rows assert entrypoint defaults exactly (added-keys equality). Five edge-case tests cover host-profile override, generic fallback, explicit backend selection, decode accel branches, and the AV1 env override.
- `docs/OPERATIONS_TEST_MATRIX.md`: generated decision table (doc-sync test + `--write` mode, same pattern as the Phase 2/3/4 inventories) plus per-profile validation checklists reusing the existing tooling (`host-ops.sh`, `doctor.sh`, `validate-native-qt-telemetry.sh`, soak playbook) with `backend_runtime_mismatch=False` as the hard gate.
- Docs wiring: `docs/README.md` and `docs/NATIVE_RUNTIME_OPERATIONS.md` link to the matrix; `AGENTS.md` Phase 6 discipline section; living roadmap in `docs/ARCHITECTURE_PHASE_6_ROADMAP.md`.

## User impact

None. Docs and tests only — zero `app/` changes (`git diff main..HEAD -- app/` is empty), so runtime behavior is byte-identical.

## Operator impact

Operators get a single source of truth for what each host/mode combination should decide (host profile, entrypoint defaults, Qt runtime mode, decode profile, AV1 policy) and a manual validation checklist per profile. The decision table is machine-checked: it regenerates via `PYTHONPATH=app python3 tests/test_runtime_matrix.py --write` and a doc-sync test fails CI if the table and the decision functions drift.

## Breaking changes

None.

## Tests

- `ruff check app tests` clean; `PYTHONPATH=app pytest -q` green (312 passed, 13 of them new matrix/doc-sync tests), locally and in a CI-like fresh venv.
- Live appliance cross-check: `/runtime/capabilities` matched the `amd64-wayland-native-qt-embed` row field-by-field using the checklist's own command (`backend_runtime_mismatch=False`, `decode_profile=intel_amd64_qsv`, `qt_runtime_mode_effective=embed`). The cross-check caught and fixed a baseline error (the appliance runs Wayland, not X11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)