### PR TITLE
fix: surface bot checks everywhere and play live/post-live YouTube

### DIFF
--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -3875,16 +3875,12 @@ def _attempt_playlist_next_handoff(*, poll_sleep: Callable[[float], None] | None
     return "mpv_playlist_next_pending"
 
 
-def _notify_bot_check_skip(item: object) -> None:
-    """Toast that a queue item was skipped because YouTube demanded a bot check.
+def _notify_bot_check_toast(text: str) -> None:
+    """Deliver a bot-check warn toast from a daemon thread.
 
-    Delivered from a daemon thread: the toast path can block on Qt shell IPC
-    and this is called while holding ADVANCE_LOCK.
+    The toast path can block on Qt shell IPC and callers may hold
+    ADVANCE_LOCK, so never toast inline.
     """
-    label = ""
-    if isinstance(item, dict):
-        label = str(item.get("title") or item.get("url") or "").strip()
-    text = f"Skipped (YouTube bot check): {label}" if label else "Video skipped: YouTube bot check"
 
     def _run() -> None:
         try:
@@ -3895,6 +3891,15 @@ def _notify_bot_check_skip(item: object) -> None:
             pass
 
     threading.Thread(target=_run, daemon=True).start()
+
+
+def _notify_bot_check_skip(item: object) -> None:
+    """Toast that a queue item was skipped because YouTube demanded a bot check."""
+    label = ""
+    if isinstance(item, dict):
+        label = str(item.get("title") or item.get("url") or "").strip()
+    text = f"Skipped (YouTube bot check): {label}" if label else "Video skipped: YouTube bot check"
+    _notify_bot_check_toast(text)
 
 
 def advance_queue_playback(
@@ -5640,6 +5645,26 @@ def restart_current(apply_mode: str | None = None) -> dict | None:
         inp = (state.NOW_PLAYING.get("input") or state.NOW_PLAYING.get("url") or "").strip()
         if not inp:
             return None
+        target: object = inp
+        if is_youtube_url(inp):
+            # Resolve before stopping anything: a failed resolve (e.g. a
+            # YouTube bot check right after cookies were removed) must leave
+            # current playback running instead of tearing it down to idle.
+            item: dict[str, Any] = {"url": inp}
+            for key in ("title", "thumbnail"):
+                val = state.NOW_PLAYING.get(key)
+                if val:
+                    item[key] = val
+            try:
+                stream, audio = resolve_streams(inp)
+            except Exception as resolve_exc:
+                if isinstance(resolve_exc, YouTubeBotCheckError):
+                    label = str(item.get("title") or inp)
+                    _notify_bot_check_toast(f"Settings not applied (YouTube bot check): {label}")
+                logger.warning("restart_current_resolve_failed error=%s", resolve_exc)
+                return None
+            _store_prefetched_stream(item, inp, stream, audio)
+            target = item
         # capture position if possible
         pos = None
         try:
@@ -5651,7 +5676,7 @@ def restart_current(apply_mode: str | None = None) -> dict | None:
         # Use settings-driven video mode by default; apply_mode can force x11/drm.
         if apply_mode:
             runtime_config.set_value("RELAYTV_VIDEO_MODE", apply_mode)
-        now = play_item(inp, use_resolver=True, cec=False, clear_queue=False, mode="resume", start_pos=(float(pos) if pos is not None else None))
+        now = play_item(target, use_resolver=True, cec=False, clear_queue=False, mode="resume", start_pos=(float(pos) if pos is not None else None))
         return now
     except Exception as e:
         logger.warning("restart_current_failed error=%s", e)

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -3875,8 +3875,8 @@ def _attempt_playlist_next_handoff(*, poll_sleep: Callable[[float], None] | None
     return "mpv_playlist_next_pending"
 
 
-def _notify_bot_check_toast(text: str) -> None:
-    """Deliver a bot-check warn toast from a daemon thread.
+def _notify_warn_toast(text: str) -> None:
+    """Deliver a warn toast from a daemon thread.
 
     The toast path can block on Qt shell IPC and callers may hold
     ADVANCE_LOCK, so never toast inline.
@@ -3893,6 +3893,11 @@ def _notify_bot_check_toast(text: str) -> None:
     threading.Thread(target=_run, daemon=True).start()
 
 
+def _notify_bot_check_toast(text: str) -> None:
+    """Deliver a bot-check warn toast without blocking the caller."""
+    _notify_warn_toast(text)
+
+
 def _notify_bot_check_skip(item: object) -> None:
     """Toast that a queue item was skipped because YouTube demanded a bot check."""
     label = ""
@@ -3900,6 +3905,93 @@ def _notify_bot_check_skip(item: object) -> None:
         label = str(item.get("title") or item.get("url") or "").strip()
     text = f"Skipped (YouTube bot check): {label}" if label else "Video skipped: YouTube bot check"
     _notify_bot_check_toast(text)
+
+
+def _playback_start_timeout_sec() -> float:
+    raw = (os.getenv("RELAYTV_PLAYBACK_START_TIMEOUT_SEC") or "45").strip()
+    try:
+        return max(0.0, float(raw))
+    except Exception:
+        return 45.0
+
+
+def _playback_runtime_started() -> bool:
+    """Return True once the current media actually produced playback.
+
+    Queries mpv IPC directly instead of ``mpv_get``: its stale-cache fallback
+    can echo the previous media's time-pos while the new stream is still
+    stuck loading, which is exactly the state this check must detect.
+    """
+    try:
+        r = mpv_command(["get_property", "time-pos"])
+        if isinstance(r, dict) and r.get("error") == "success" and r.get("data") is not None:
+            return True
+    except Exception:
+        pass
+    try:
+        telemetry = qt_shell_runtime_telemetry(max_age_sec=5.0) or {}
+        if telemetry.get("mpv_runtime_playback_started") or telemetry.get("mpv_runtime_time_pos") is not None:
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _arm_playback_start_watchdog(now_item: dict) -> None:
+    """Abort a stream that never starts instead of leaving a silent black screen.
+
+    A resolved URL can accept the connection and then serve nothing (e.g. a
+    just-ended YouTube live stream returns 204 for its segment base URL), which
+    stalls mpv in loading forever with no user feedback. If the media produces
+    no playback within the timeout, toast a warning and hand off to the normal
+    end-of-playback policy (advance the queue, or return to idle).
+    """
+    timeout = _playback_start_timeout_sec()
+    if timeout <= 0 or not isinstance(now_item, dict):
+        return
+    history_id = str(now_item.get("history_id") or "")
+    started_marker = now_item.get("started")
+    label = str(now_item.get("title") or now_item.get("url") or "").strip()
+    if not history_id:
+        return
+
+    def _same_playback() -> bool:
+        current = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
+        return (
+            isinstance(current, dict)
+            and str(current.get("history_id") or "") == history_id
+            and current.get("started") == started_marker
+        )
+
+    def _run() -> None:
+        poll_sec = max(0.05, min(2.0, timeout / 5.0))
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            time.sleep(poll_sec)
+            if not _same_playback():
+                return
+            if _playback_runtime_started():
+                return
+        if not _same_playback() or _playback_runtime_started():
+            return
+        if str(getattr(state, "SESSION_STATE", "") or "").strip().lower() == "paused":
+            return
+        logger.warning(
+            "playback_start_timeout after_sec=%s title=%s", int(timeout), label[:120]
+        )
+        _notify_warn_toast(f"Can't start stream: {label}" if label else "Can't start stream")
+        try:
+            mpv_command(["stop"])
+        except Exception:
+            pass
+        try:
+            from . import playback_service
+
+            playback_service.natural_end()
+        except Exception as exc:
+            logger.warning("playback_start_timeout_recover_failed error=%s", exc)
+
+    threading.Thread(target=_run, daemon=True).start()
 
 
 def advance_queue_playback(
@@ -4553,6 +4645,8 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
         _prime_mpv_up_next_from_queue(force=True)
     except Exception:
         pass
+
+    _arm_playback_start_watchdog(now)
 
     debug_log("player", f"play_item complete in {int((time.monotonic() - play_t0) * 1000)}ms title={title!r}")
 

--- a/app/relaytv_app/resolver.py
+++ b/app/relaytv_app/resolver.py
@@ -501,6 +501,12 @@ def resolve_streams_ytdlp(url: str):
         candidates = ytdlp_format_policy.youtube_progressive_startup_candidates(settings, profile=profile)
     candidates = list(dict.fromkeys(candidates))
 
+    # For YouTube, print live_status alongside the stream URLs: live and
+    # just-ended (post_live) videos only expose segmented formats whose bare
+    # URLs return 204 No Content, so they must not be handed to mpv directly.
+    resolve_live_status = is_youtube_url(u)
+    output_args = ["--print", "urls", "--print", "live_status"] if resolve_live_status else ["-g"]
+
     strategies: list[tuple[list[str], list[str]]] = [(base, candidates)]
     if is_youtube_url(u):
         strategies = _build_youtube_strategies(base, candidates)
@@ -520,7 +526,7 @@ def resolve_streams_ytdlp(url: str):
             _log_resolve(f"yt-dlp strategy start host_arch={host_arch or 'unknown'} args={' '.join(args_base)}")
             for cand in strategy_candidates:
                 t_attempt = time.monotonic()
-                cmd = [*args_base, "-g", u] if not cand else [*args_base, "-f", cand, "-g", u]
+                cmd = [*args_base, *output_args, u] if not cand else [*args_base, "-f", cand, *output_args, u]
                 selected_format = cand or "auto"
                 p_local = run(cmd, check=False)
                 elapsed_ms = int((time.monotonic() - t_attempt) * 1000)
@@ -594,6 +600,10 @@ def resolve_streams_ytdlp(url: str):
         raise HTTPException(status_code=400, detail=f"yt-dlp failed: {err[:1200]}")
 
     lines = [ln.strip() for ln in (p.stdout or "").splitlines() if ln.strip()]
+    live_status = ""
+    if resolve_live_status and lines and not lines[-1].lower().startswith(("http://", "https://")):
+        live_status = lines[-1].strip().lower()
+        lines = lines[:-1]
     total_ms = int((time.monotonic() - t0) * 1000)
     debug_log("youtube", f"yt-dlp resolve succeeded in {total_ms}ms with {len(lines)} stream line(s)")
     _log_resolve(f"yt-dlp resolve succeeded total_ms={total_ms} stream_lines={len(lines)}")
@@ -604,6 +614,14 @@ def resolve_streams_ytdlp(url: str):
         outcome_category="success",
         success=True,
     )
+    if live_status in ("is_live", "post_live"):
+        # Live/post-live formats are segment feeds; their printed URLs serve
+        # no data without per-segment parameters. Hand mpv the page URL so
+        # its yt-dlp hook drives the manifest instead.
+        logger.info("ytdlp_live_stream_deferred_to_mpv live_status=%s url=%s", live_status, u)
+        return u, None
+    if not lines:
+        raise HTTPException(status_code=400, detail="yt-dlp returned no stream URLs")
     if len(lines) == 1:
         return lines[0], None
     return lines[0], lines[1]

--- a/app/relaytv_app/routes/playback.py
+++ b/app/relaytv_app/routes/playback.py
@@ -324,8 +324,20 @@ def play_now(req: PlayNowReq):
             )
         else:
             now = playback_service.play_now(req.url, use_resolver=True, cec=False, clear_queue=False, mode=(req.reason or "play_now"))
-    except Exception:
+    except Exception as exc:
         _rollback_play_now_preserve(preserved)
+        if isinstance(exc, player.YouTubeBotCheckError):
+            # The 400 detail only reaches the requesting client; the TV
+            # otherwise drops back to idle with no explanation.
+            try:
+                _push_overlay_toast(
+                    text=f"Can't play (YouTube bot check): {req.title or req.url}",
+                    duration=6.0,
+                    level="warn",
+                    icon="play",
+                )
+            except Exception:
+                pass
         raise
     try:
         title = now.get("title") if isinstance(now, dict) else None

--- a/docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md
+++ b/docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md
@@ -209,6 +209,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_PLAYBACK_NOTIFY_DISPLAY_SEC` | `routes/__init__.py` | - | static env |
 | `RELAYTV_PLAYBACK_NOTIFY_FADE_MS` | `routes/__init__.py` | - | static env |
 | `RELAYTV_PLAYBACK_RUNTIME_GAP_CONFIRM_SEC` | `player.py` | - | static env |
+| `RELAYTV_PLAYBACK_START_TIMEOUT_SEC` | `player.py` | - | static env |
 | `RELAYTV_PLAYBACK_TRANSITION_SEC` | `player.py` | - | static env |
 | `RELAYTV_PLAYER_BACKEND` | `player.py` | - | static env |
 | `RELAYTV_PORT` | `discovery_mdns.py` | - | static env |

--- a/tests/test_playback_routes.py
+++ b/tests/test_playback_routes.py
@@ -302,6 +302,47 @@ def test_play_now_route_rolls_back_preserved_current_when_start_fails(monkeypatc
     assert queue_events[-1]["queue"] == [existing]
 
 
+def test_play_now_bot_check_failure_pushes_warn_toast(monkeypatch) -> None:
+    toasts: list[dict] = []
+    monkeypatch.setattr(routes, "_push_overlay_toast", lambda **kwargs: toasts.append(dict(kwargs)))
+
+    def fake_play_item(*args, **kwargs):
+        raise routes.player.YouTubeBotCheckError(
+            status_code=400,
+            detail="yt-dlp failed: YouTube requires anti-bot verification/cookies.",
+        )
+
+    monkeypatch.setattr(routes.player, "play_item", fake_play_item)
+
+    client = TestClient(create_app(testing=True))
+    response = client.post(
+        "/play_now",
+        json={"url": "https://www.youtube.com/watch?v=blocked", "title": "Blocked Video"},
+    )
+
+    assert response.status_code == 400
+    assert len(toasts) == 1
+    assert "bot check" in toasts[0]["text"].lower()
+    assert "Blocked Video" in toasts[0]["text"]
+    assert toasts[0]["level"] == "warn"
+
+
+def test_play_now_non_botcheck_failure_does_not_toast(monkeypatch) -> None:
+    toasts: list[dict] = []
+    monkeypatch.setattr(routes, "_push_overlay_toast", lambda **kwargs: toasts.append(dict(kwargs)))
+
+    def fake_play_item(*args, **kwargs):
+        raise routes.HTTPException(status_code=400, detail="yt-dlp failed: timed out")
+
+    monkeypatch.setattr(routes.player, "play_item", fake_play_item)
+
+    client = TestClient(create_app(testing=True))
+    response = client.post("/play_now", json={"url": "https://example.com/flaky.mp4"})
+
+    assert response.status_code == 400
+    assert toasts == []
+
+
 def test_close_route_preserves_queue_and_returns_closed_session(monkeypatch) -> None:
     now_values: list[object] = []
     session_values: list[str] = []

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3183,6 +3183,82 @@ def test_bot_check_skip_toast_names_video_and_reason(monkeypatch: pytest.MonkeyP
     assert toasts[0]['level'] == 'warn'
 
 
+def test_restart_current_keeps_playback_when_bot_check_blocks_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
+    toasts: list[str] = []
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'playing', raising=False)
+    monkeypatch.setattr(
+        player.state,
+        'NOW_PLAYING',
+        {'url': 'https://www.youtube.com/watch?v=current', 'title': 'Current Video'},
+        raising=False,
+    )
+    monkeypatch.setattr(player, '_notify_bot_check_toast', lambda text: toasts.append(text))
+
+    def fake_resolve(url):
+        raise player.YouTubeBotCheckError(
+            status_code=400,
+            detail='yt-dlp failed: YouTube requires anti-bot verification/cookies.',
+        )
+
+    monkeypatch.setattr(player, 'resolve_streams', fake_resolve)
+    monkeypatch.setattr(player, 'stop_mpv', lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError('must not stop playback when resolve fails')))
+    monkeypatch.setattr(player, 'play_item', lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError('must not replay when resolve fails')))
+
+    assert player.restart_current() is None
+    assert len(toasts) == 1
+    assert 'bot check' in toasts[0].lower()
+    assert 'Current Video' in toasts[0]
+
+
+def test_restart_current_resolves_before_stopping_and_reuses_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    played: list[dict] = []
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'playing', raising=False)
+    monkeypatch.setattr(
+        player.state,
+        'NOW_PLAYING',
+        {'url': 'https://www.youtube.com/watch?v=current', 'title': 'Current Video'},
+        raising=False,
+    )
+    monkeypatch.setattr(player, 'resolve_streams', lambda url: (calls.append('resolve'), ('https://stream.example/v', 'https://stream.example/a'))[1])
+    monkeypatch.setattr(player, 'is_playing', lambda: False)
+    monkeypatch.setattr(player, 'stop_mpv', lambda *args, **kwargs: calls.append('stop'))
+
+    def fake_play(item, **kwargs):
+        calls.append('play')
+        played.append(dict(item))
+        return {'url': item['url']}
+
+    monkeypatch.setattr(player, 'play_item', fake_play)
+
+    now = player.restart_current()
+
+    assert now == {'url': 'https://www.youtube.com/watch?v=current'}
+    # Resolve must complete before the running player is torn down.
+    assert calls == ['resolve', 'stop', 'play']
+    assert played[0]['_resolved_stream'] == 'https://stream.example/v'
+    assert played[0]['_resolved_audio'] == 'https://stream.example/a'
+    assert played[0]['title'] == 'Current Video'
+
+
+def test_restart_current_non_youtube_does_not_preresolve(monkeypatch: pytest.MonkeyPatch) -> None:
+    played: list[object] = []
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'playing', raising=False)
+    monkeypatch.setattr(
+        player.state,
+        'NOW_PLAYING',
+        {'url': 'https://example.com/movie.mp4', 'title': 'Movie'},
+        raising=False,
+    )
+    monkeypatch.setattr(player, 'resolve_streams', lambda url: (_ for _ in ()).throw(AssertionError('non-YouTube restart must not pre-resolve')))
+    monkeypatch.setattr(player, 'is_playing', lambda: False)
+    monkeypatch.setattr(player, 'stop_mpv', lambda *args, **kwargs: None)
+    monkeypatch.setattr(player, 'play_item', lambda target, **kwargs: played.append(target) or {'url': 'https://example.com/movie.mp4'})
+
+    assert player.restart_current() == {'url': 'https://example.com/movie.mp4'}
+    assert played == ['https://example.com/movie.mp4']
+
+
 def test_closed_session_does_not_prime_mpv_up_next(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(player.state, 'SESSION_STATE', 'closed', raising=False)
     monkeypatch.setattr(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3259,6 +3259,162 @@ def test_restart_current_non_youtube_does_not_preresolve(monkeypatch: pytest.Mon
     assert played == ['https://example.com/movie.mp4']
 
 
+def _patch_resolver_ytdlp_env(monkeypatch: pytest.MonkeyPatch, stdout: str) -> list[list[str]]:
+    calls: list[list[str]] = []
+
+    class Proc:
+        returncode = 0
+        stderr = ''
+
+    Proc.stdout = stdout
+    monkeypatch.setattr('relaytv_app.state.get_settings', lambda: {})
+    monkeypatch.setattr(
+        'relaytv_app.video_profile.get_profile',
+        lambda: {'decode_profile': 'default', 'display_cap_height': 1080, 'av1_allowed': False},
+    )
+    monkeypatch.setattr(resolver.shutil, 'which', lambda name: None)
+
+    def fake_run(cmd, check=False):
+        calls.append(list(cmd))
+        return Proc()
+
+    monkeypatch.setattr(resolver, 'run', fake_run)
+    return calls
+
+
+def test_resolver_defers_postlive_youtube_to_mpv_ytdl_hook(monkeypatch: pytest.MonkeyPatch) -> None:
+    url = 'https://www.youtube.com/watch?v=postlive1'
+    calls = _patch_resolver_ytdlp_env(
+        monkeypatch,
+        'https://segments.example/videoplayback?a=1\n'
+        'https://segments.example/videoplayback?a=2\n'
+        'post_live\n',
+    )
+
+    stream, audio = resolver.resolve_streams_ytdlp(url)
+
+    # Segmented live formats 204 without per-segment params, so the page URL
+    # goes to mpv and its yt-dlp hook drives the manifest.
+    assert stream == url
+    assert audio is None
+    assert '--print' in calls[0]
+    assert 'live_status' in calls[0]
+    assert '-g' not in calls[0]
+
+
+def test_resolver_keeps_resolved_urls_for_vod_youtube(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _patch_resolver_ytdlp_env(
+        monkeypatch,
+        'https://cdn.example/video.mp4\nhttps://cdn.example/audio.m4a\nnot_live\n',
+    )
+
+    stream, audio = resolver.resolve_streams_ytdlp('https://www.youtube.com/watch?v=vod1')
+
+    assert stream == 'https://cdn.example/video.mp4'
+    assert audio == 'https://cdn.example/audio.m4a'
+    assert calls
+
+
+def test_resolver_non_youtube_keeps_plain_url_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _patch_resolver_ytdlp_env(
+        monkeypatch,
+        'https://cdn.example/rumble-video.mp4\n',
+    )
+
+    stream, audio = resolver.resolve_streams_ytdlp('https://rumble.com/v1abcd-some-video.html')
+
+    assert stream == 'https://cdn.example/rumble-video.mp4'
+    assert audio is None
+    assert '-g' in calls[0]
+    assert '--print' not in calls[0]
+
+
+def test_playback_start_watchdog_aborts_stream_that_never_starts(monkeypatch: pytest.MonkeyPatch) -> None:
+    from relaytv_app import playback_service
+
+    toasts: list[str] = []
+    stops: list[list] = []
+    ended: list[str] = []
+
+    class _SyncThread:
+        def __init__(self, target=None, daemon=None, **kwargs):
+            self._target = target
+
+        def start(self) -> None:
+            self._target()
+
+    now_item = {
+        'url': 'https://www.youtube.com/watch?v=stuck',
+        'title': 'Stuck Stream',
+        'history_id': 'h-stuck',
+        'started': 1234,
+    }
+    monkeypatch.setenv('RELAYTV_PLAYBACK_START_TIMEOUT_SEC', '0.2')
+    monkeypatch.setattr(player.state, 'NOW_PLAYING', dict(now_item), raising=False)
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'playing', raising=False)
+    monkeypatch.setattr(player.threading, 'Thread', _SyncThread)
+    monkeypatch.setattr(player, '_playback_runtime_started', lambda: False)
+    monkeypatch.setattr(player, '_notify_warn_toast', lambda text: toasts.append(text))
+    monkeypatch.setattr(player, 'mpv_command', lambda cmd: stops.append(list(cmd)))
+    monkeypatch.setattr(playback_service, 'natural_end', lambda: ended.append('natural_end') or 'idle')
+
+    player._arm_playback_start_watchdog(now_item)
+
+    assert len(toasts) == 1
+    assert "Can't start stream" in toasts[0]
+    assert 'Stuck Stream' in toasts[0]
+    assert ['stop'] in stops
+    assert ended == ['natural_end']
+
+
+def test_playback_runtime_started_uses_live_ipc_not_stale_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The previous media's cached time-pos must not count as "started" while
+    # the new stream is stuck loading.
+    monkeypatch.setattr(player, 'mpv_command', lambda cmd: {'error': 'property unavailable'})
+    monkeypatch.setattr(
+        player,
+        'qt_shell_runtime_telemetry',
+        lambda **kwargs: {'mpv_runtime_playback_started': False, 'mpv_runtime_time_pos': None},
+    )
+    assert player._playback_runtime_started() is False
+
+    monkeypatch.setattr(player, 'mpv_command', lambda cmd: {'error': 'success', 'data': 12.5})
+    assert player._playback_runtime_started() is True
+
+
+def test_playback_start_watchdog_noop_once_playback_starts(monkeypatch: pytest.MonkeyPatch) -> None:
+    from relaytv_app import playback_service
+
+    toasts: list[str] = []
+    ended: list[str] = []
+
+    class _SyncThread:
+        def __init__(self, target=None, daemon=None, **kwargs):
+            self._target = target
+
+        def start(self) -> None:
+            self._target()
+
+    now_item = {
+        'url': 'https://www.youtube.com/watch?v=fine',
+        'title': 'Working Stream',
+        'history_id': 'h-fine',
+        'started': 1234,
+    }
+    monkeypatch.setenv('RELAYTV_PLAYBACK_START_TIMEOUT_SEC', '0.2')
+    monkeypatch.setattr(player.state, 'NOW_PLAYING', dict(now_item), raising=False)
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'playing', raising=False)
+    monkeypatch.setattr(player.threading, 'Thread', _SyncThread)
+    monkeypatch.setattr(player, '_playback_runtime_started', lambda: True)
+    monkeypatch.setattr(player, '_notify_warn_toast', lambda text: toasts.append(text))
+    monkeypatch.setattr(playback_service, 'natural_end', lambda: ended.append('natural_end') or 'idle')
+
+    player._arm_playback_start_watchdog(now_item)
+
+    assert toasts == []
+    assert ended == []
+
+
 def test_closed_session_does_not_prime_mpv_up_next(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(player.state, 'SESSION_STATE', 'closed', raising=False)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Two follow-up fixes from NUC testing that landed on the `feat/pi-runtime-cec-ytdlp-hardening` branch after PR #27 was already squash-merged, cherry-picked onto main so they ship in v0.5.0:

- **Bot checks are surfaced everywhere, not just on auto-advance** — a direct `/play_now` that hits a YouTube bot check now pushes a warn toast on the TV (previously only the requesting client saw the 400), and the settings-apply restart pre-resolves YouTube URLs **before** stopping mpv, so a failed resolve keeps the current video playing and toasts "Settings not applied" instead of silently dropping to idle.
- **Live/post-live YouTube plays instead of hanging on a black screen** — just-ended live streams (`live_status=post_live`) only expose segmented formats whose bare URLs return HTTP 204, so the resolved URL stalled mpv in a silent loading state until an unexplained drop to idle. The resolver now prints `live_status` alongside the stream URLs and defers live/post-live videos to mpv's yt-dlp hook, which plays them correctly (verified on-device against a real post-live video that previously hung). A new playback-start watchdog (`RELAYTV_PLAYBACK_START_TIMEOUT_SEC`, default 45s) backstops any stream that connects but never produces playback: warn toast "Can't start stream: …", stop the stuck load, hand off to the normal end-of-playback policy. The started check reads mpv IPC directly because `mpv_get`'s stale-cache fallback can echo the previous media's position while a new stream is still loading.

## Test plan

- [x] 341 tests pass (`pytest tests/ -q`), including 11 new tests covering bot-check toast semantics on direct play and settings restart, resolve-before-stop ordering, live/post-live resolver deferral, and the playback-start watchdog (fire, stand-down, and stale-cache regression)
- [x] Live-verified on the NUC: direct play with cookies disabled toasts the bot check; a real `post_live` YouTube video that previously hung in a black screen now plays end-to-end via the mpv hook; a black-hole stream (accepts the connection, sends no data) triggers the watchdog at exactly 45s with the "Can't start stream" warn toast captured on the overlay event stream

## Release notes

BEGIN_COMMIT_OVERRIDE
fix: YouTube bot checks now explain themselves everywhere — the warning toast also appears on direct plays and settings changes, and your current video keeps playing instead of dropping to a black screen

fix: live and just-ended YouTube streams now play instead of hanging on a black screen, and any stream that can't start shows a "Can't start stream" toast within 45 seconds instead of leaving you staring at nothing
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
