### PR TITLE
docs: close out architecture review and slim agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,235 +29,68 @@ Do not manually edit `CHANGELOG.md` for normal feature, fix, docs, or dependency
 changes. Release Please owns version bumps, release pull requests, changelog
 generation, Git tags, GitHub Releases, and immutable release image tags.
 
-## Architecture Phase 6 Discipline
+Do not push new commits to a branch after its pull request has merged: the
+commits are silently orphaned (squash-merge already happened) and must be
+cherry-picked into a fresh PR. Release Please re-reads merged PR bodies on
+every run, so a PR body's `BEGIN_COMMIT_OVERRIDE` block must always describe
+exactly what its squash contains.
 
-When working on the Phase 6 architecture effort (operations test matrix),
-keep work on `codex/architecture-phase-6` unless the user explicitly directs
-otherwise.
+## Quality Gates
 
-Keep `docs/ARCHITECTURE_PHASE_6_ROADMAP.md` current when milestones start,
-complete, change scope, or uncover important follow-up work.
-
-Phase 6 scope:
-
-- machine-checked runtime profile matrix (`tests/test_runtime_matrix.py`)
-  pinning host-profile, Qt-runtime-mode, entrypoint-default, and
-  decode-profile decisions per profile (x11, wayland, headless, native Qt
-  embedded, Qt external mpv, Raspberry Pi, amd64 mini PC)
-- generated decision table plus per-profile operator validation checklists
-  in `docs/OPERATIONS_TEST_MATRIX.md`
-- docs wiring only; tests drive the real decision functions with fake
-  env/host inputs
-
-Out of scope for Phase 6 (document findings in the roadmap instead):
-
-- changing any runtime decision, installer behavior, compose output, or
-  capability payload shape
-- rewriting `install.sh` or modeling its generated output in Python
-- CI hardware-in-the-loop testing
-- new endpoints or API changes
-
-This is the final roadmap phase: once it completes, the no-release hold
-lifts. Until then, phases ship as `refactor:` PRs that intentionally do not
-trigger release-please. Prefer small PRs into `codex/architecture-phase-6`,
-not directly into `main`.
-
-## Architecture Phase 5 Discipline (complete)
-
-Phase 5 (optional API token) completed on `codex/architecture-phase-5`;
-final PR: https://github.com/mcgeezy/relaytv/pull/25. The full record lives
-in `docs/ARCHITECTURE_PHASE_5_ROADMAP.md`.
-
-When working on the Phase 5 architecture effort (optional API token), keep
-work on `codex/architecture-phase-5` unless the user explicitly directs
-otherwise.
-
-Keep `docs/ARCHITECTURE_PHASE_5_ROADMAP.md` current when milestones start,
-complete, change scope, or uncover important follow-up work.
-
-Phase 5 scope:
-
-- optional bearer-token auth for write requests (`POST`/`PUT`/`PATCH`/
-  `DELETE`) via app middleware; disabled by default, enabled with
-  `RELAYTV_API_TOKEN`; reads, `/health`, `/ui`, and static assets stay open
-- the token is env-only: plumbed through `runtime_config`
-  (`SETTINGS_BUS_VARS`), never persisted to settings.json, never returned by
-  `/settings`, never logged
-- minimal web UI compatibility (one fetch wrapper attaching the bearer
-  token from localStorage) — no frontend framework or redesign
-- operator docs: trusted-LAN default posture, token setup, reverse-proxy
-  exposure examples
-- guardrail tests for the auth contract (`tests/test_api_auth.py`)
-
-Do not start Phase 6+ work on this branch unless the user explicitly expands
-the scope. Out of scope for Phase 5:
-
-- auth for read endpoints, sessions/users, or credential stores beyond the
-  single env token
-- TLS termination inside RelayTV
-- frontend framework or build pipeline
-- endpoint removals or compatibility-breaking API changes
-- with `RELAYTV_API_TOKEN` unset, any behavior change at all
-
-Prefer small PRs into `codex/architecture-phase-5`, not directly into `main`.
-No release until the architecture roadmap completes: phases ship as
-`refactor:` PRs that intentionally do not trigger release-please.
-
-## Architecture Phase 4 Discipline (complete)
-
-Phase 4 (Jellyfin product service) completed on
-`codex/architecture-phase-4`; final PR:
-https://github.com/mcgeezy/relaytv/pull/24. The full record lives in
-`docs/ARCHITECTURE_PHASE_4_ROADMAP.md`.
-
-When working on the Phase 4 architecture effort (Jellyfin product service),
-keep work on `codex/architecture-phase-4` unless the user explicitly directs
-otherwise.
-
-Keep `docs/ARCHITECTURE_PHASE_4_ROADMAP.md` current when milestones start,
-complete, change scope, or uncover important follow-up work.
-
-Phase 4 scope:
-
-- extract Jellyfin product logic (command interpretation and ingress, stream
-  URL construction, direct/transcode policy, playable item resolution, track
-  preference handling, metadata enrichment, stopped/progress payloads) into
-  `integrations/jellyfin_service.py`
-- keep `integrations/jellyfin_receiver.py` as the transport/session/catalog
-  adapter and the routes modules as HTTP guards, request models, ack shaping,
-  and UI events; the service never imports the routes package
-- route playback transitions inside migrated code through `playback_service`
-  commands; document any remaining direct writes as pinned exceptions
-- machine-checked Jellyfin route-surface inventory
-  (`tests/test_jellyfin_inventory.py`) that tightens per milestone
-- service-level tests with fake receiver/player adapters
-  (`tests/test_jellyfin_service.py`)
-
-Do not start Phase 5+ work on this branch unless the user explicitly expands
-the scope. Out of scope for Phase 4:
-
-- optional API token auth
-- frontend framework or build pipeline
-- endpoint removals or compatibility-breaking API changes
-- rewriting `jellyfin_receiver.py` transport/cache/auth internals
-- changing persisted file formats
-- Jellyfin behavior changes — document discovered bugs in the roadmap instead
-
-Prefer small PRs into `codex/architecture-phase-4`, not directly into `main`.
-No release until the architecture roadmap completes: phases ship as
-`refactor:` PRs that intentionally do not trigger release-please.
-
-## Architecture Phase 3 Discipline (complete)
-
-Phase 3 (playback transition service) completed on
-`codex/architecture-phase-3`; final PR:
-https://github.com/mcgeezy/relaytv/pull/23. The full record lives in
-`docs/ARCHITECTURE_PHASE_3_ROADMAP.md`.
-
-Keep `docs/ARCHITECTURE_PHASE_3_ROADMAP.md` current when milestones start,
-complete, change scope, or uncover important follow-up work.
-
-Phase 3 scope:
-
-- introduce a `playback_service` module owning explicit transition commands
-  (play-now, queue, close, advance, resume, natural end, stop-all), facade
-  first with 1:1 delegation, policy moves later
-- centralize auto-next suppression writes behind one service API
-- move the temporary playback stack out of the routes package
-- centralize close/resume semantics; the service becomes the only writer of
-  playback transition globals outside `state.py`
-- machine-checked transition writer inventory that tightens per milestone
-
-Do not start Phase 4+ work on this branch unless the user explicitly expands
-the scope. Out of scope for Phase 3:
-
-- Jellyfin product service extraction
-- optional API token auth
-- frontend framework or build pipeline
-- endpoint removals or compatibility-breaking API changes
-- rewriting mpv process management, the Qt shell supervisor, or CEC handling
-- changing persisted session/queue/history file formats
-- playback behavior changes — document discovered bugs in the roadmap instead
-
-Prefer small PRs into `codex/architecture-phase-3`, not directly into `main`.
-No release until the architecture roadmap completes: phases ship as
-`refactor:` PRs that intentionally do not trigger release-please.
-
-## Architecture Phase 2 Discipline (complete)
-
-Phase 2 (runtime config service) completed on `codex/architecture-phase-2`;
-final PR: https://github.com/mcgeezy/relaytv/pull/22. The full record lives in
-`docs/ARCHITECTURE_PHASE_2_ROADMAP.md`.
-
-Keep `docs/ARCHITECTURE_PHASE_2_ROADMAP.md` current when milestones start,
-complete, change scope, or uncover important follow-up work.
-
-Phase 2 scope:
-
-- introduce a shared typed env-parsing module and a `RuntimeConfig` service
-  with typed settings snapshots
-- migrate in-process `os.getenv`/`os.environ` readers to config snapshots,
-  one domain at a time behind guardrail tests
-- contain runtime `os.environ` writes to an explicit subprocess-mirroring
-  boundary
-- reshape settings tests toward config behavior instead of monkeypatched env
-
-Do not start Phase 3+ work on this branch unless the user explicitly expands
-the scope. Out of scope for Phase 2:
-
-- playback transition/state-machine rewrite
-- Jellyfin product service extraction
-- optional API token auth
-- frontend framework or build pipeline
-- endpoint removals or compatibility-breaking API changes
-- changing `RELAYTV_*` variable names, defaults, or precedence semantics
-- changing what child processes (mpv, yt-dlp, Qt shell, overlay) receive in
-  their environment
-
-Prefer small PRs into `codex/architecture-phase-2`, not directly into `main`.
-Preserve public behavior while moving configuration plumbing. If a behavior bug
-is discovered, document it in the Phase 2 roadmap unless the user asks for an
-immediate fix.
-
-## Architecture Phase 1 Discipline (complete)
-
-Phase 1 is complete; the final PR to `main` is
-https://github.com/mcgeezy/relaytv/pull/21. The rules below remain for
-historical context and for any follow-up commits that must land on the Phase 1
-branch before merge.
-
-When working on the Phase 1 architecture effort, keep work on
-`codex/architecture-phase-1` unless the user explicitly directs otherwise.
-
-Keep `docs/ARCHITECTURE_PHASE_1_ROADMAP.md` current when milestones start,
-complete, change scope, or uncover important follow-up work. Preserve
-`docs/ARCHITECTURE_REVIEW.md` as the higher-level findings document.
-
-Phase 1 scope:
-
-- split `routes.py` into domain routers while preserving public endpoint paths,
-  aliases, request models, response shapes, and runtime behavior
-- extract `/ui` CSS and JavaScript into static assets without redesigning the UI
-- add or reshape tests only as needed to protect moved domains
-
-Do not start Phase 2+ work on this branch unless the user explicitly expands the
-scope. Out of scope for Phase 1:
-
-- runtime config service
-- playback transition/state-machine rewrite
-- Jellyfin product service extraction
-- optional API token auth
-- frontend framework or build pipeline
-- endpoint removals or compatibility-breaking API changes
-
-Prefer small PRs into `codex/architecture-phase-1`, not directly into `main`.
-Avoid behavior refactors while moving structure. If a behavior bug is discovered,
-document it in the Phase 1 roadmap unless the user asks for an immediate fix.
-
-Before finishing Phase 1 work, run:
+Run before finishing any change:
 
 ```text
 ruff check app tests
-PYTHONPATH=app pytest -q tests/test_smoke.py tests/test_route_inventory.py
+PYTHONPATH=app pytest -q
 git diff --check
 ```
+
+Several public surfaces are machine-checked against in-tree inventory docs.
+When intentionally changing one of these surfaces, regenerate its doc with the
+matching test's `--write` mode instead of hand-editing:
+
+- routes/aliases: `tests/test_route_inventory.py` → `docs/ARCHITECTURE_PHASE_1_ROUTE_INVENTORY.md`
+- env variables: `tests/test_env_inventory.py` → `docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md`
+- playback transition writers: `tests/test_transition_inventory.py` → `docs/ARCHITECTURE_PHASE_3_TRANSITION_INVENTORY.md`
+- Jellyfin route surface: `tests/test_jellyfin_inventory.py` → `docs/ARCHITECTURE_PHASE_4_JELLYFIN_INVENTORY.md`
+- runtime profile matrix: `tests/test_runtime_matrix.py` → `docs/OPERATIONS_TEST_MATRIX.md`
+
+## Security Constraints
+
+`RELAYTV_API_TOKEN` is an operator secret and stays env-only: plumbed through
+the runtime config settings bus, never persisted to `settings.json`, never
+returned by `/settings`, never logged. With the token unset, API behavior must
+not change (local-first default).
+
+## Architecture Roadmap (complete)
+
+The 2026-06/07 architecture review and its six-phase refactor roadmap are
+done — all phases squash-merged to `main` as `refactor:` PRs
+[#21](https://github.com/mcgeezy/relaytv/pull/21) through
+[#26](https://github.com/mcgeezy/relaytv/pull/26) (2026-07-03/04):
+
+1. routes/static-UI split (#21)
+2. runtime config service (#22)
+3. playback transition service (#23)
+4. Jellyfin product service (#24)
+5. optional API token (#25)
+6. operations test matrix (#26)
+
+`docs/ARCHITECTURE_REVIEW.md` holds the findings, per-finding outcomes, and
+the remaining open follow-ups; `docs/ARCHITECTURE_PHASE_*_ROADMAP.md` are the
+historical milestone logs. The former no-release hold is lifted; normal
+release flow applies. The `codex/architecture-phase-*` branch discipline no
+longer applies — work from `main` with normal feature/fix branches.
+
+Boundaries the roadmap established, to preserve in new work:
+
+- `playback_service.py` is the writer of playback transition state
+  (`NOW_PLAYING`, session state, queue advancement, auto-next suppression,
+  close/resume); `player.py` is the process/control adapter.
+- `config.py` owns env parsing and the settings bus; runtime `os.environ`
+  writes stay behind its explicit subprocess-mirroring boundary.
+- `integrations/jellyfin_service.py` owns Jellyfin product behavior;
+  `jellyfin_receiver.py` stays transport/session/catalog and never imports
+  the routes package.
+- Route modules own public endpoint registration; do not remove endpoint
+  aliases without a migration path for companion apps and Home Assistant.

--- a/docs/ARCHITECTURE_PHASE_1_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_1_ROADMAP.md
@@ -1,5 +1,8 @@
 # Phase 1 Architecture Roadmap
 
+Status: **complete** — squash-merged to `main` as PR #21 on 2026-07-03.
+This document is the historical milestone log for the phase.
+
 Date started: 2026-06-30
 
 Branch: `codex/architecture-phase-1`

--- a/docs/ARCHITECTURE_PHASE_2_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_2_ROADMAP.md
@@ -1,5 +1,8 @@
 # Phase 2 Architecture Roadmap
 
+Status: **complete** — squash-merged to `main` as PR #22 on 2026-07-03.
+This document is the historical milestone log for the phase.
+
 Date started: 2026-07-02
 
 Branch: `codex/architecture-phase-2`

--- a/docs/ARCHITECTURE_PHASE_3_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_3_ROADMAP.md
@@ -1,5 +1,8 @@
 # Phase 3 Architecture Roadmap
 
+Status: **complete** — squash-merged to `main` as PR #23 on 2026-07-03.
+This document is the historical milestone log for the phase.
+
 Date started: 2026-07-03
 
 Branch: `codex/architecture-phase-3`

--- a/docs/ARCHITECTURE_PHASE_4_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_4_ROADMAP.md
@@ -1,5 +1,8 @@
 # Phase 4 Architecture Roadmap
 
+Status: **complete** — squash-merged to `main` as PR #24 on 2026-07-03.
+This document is the historical milestone log for the phase.
+
 Date started: 2026-07-03
 
 Branch: `codex/architecture-phase-4` (cut from `main` at the Phase 3 squash

--- a/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_5_ROADMAP.md
@@ -1,5 +1,8 @@
 # Phase 5 Architecture Roadmap
 
+Status: **complete** — squash-merged to `main` as PR #25 on 2026-07-03.
+This document is the historical milestone log for the phase.
+
 Date started: 2026-07-03
 
 Branch: `codex/architecture-phase-5` (cut from `main` at the Phase 4 squash

--- a/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
+++ b/docs/ARCHITECTURE_PHASE_6_ROADMAP.md
@@ -1,5 +1,8 @@
 # Phase 6 Architecture Roadmap
 
+Status: **complete** — squash-merged to `main` as PR #26 on 2026-07-04.
+This document is the historical milestone log for the phase.
+
 Date started: 2026-07-03
 
 Branch: `codex/architecture-phase-6` (cut from `main` at the Phase 5 squash

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -2,11 +2,28 @@
 
 Date: 2026-06-30
 
-Status note, 2026-07-01: Phase 1 route and static UI extraction work is in
-progress on `codex/architecture-phase-1`. This review remains the higher-level
-findings document, but several Phase 1 items below now have branch-local
-progress. See [ARCHITECTURE_PHASE_1_ROADMAP.md](ARCHITECTURE_PHASE_1_ROADMAP.md)
-for the current milestone log.
+Status, 2026-07-04: **the recommended roadmap below is complete.** All six
+phases merged to `main` as PRs
+[#21](https://github.com/mcgeezy/relaytv/pull/21)–[#26](https://github.com/mcgeezy/relaytv/pull/26)
+(2026-07-03/04). This document is now the historical findings record; the
+per-phase milestone logs live in the `ARCHITECTURE_PHASE_*_ROADMAP.md` docs,
+and the machine-checked inventories (routes, env, transitions, Jellyfin,
+runtime matrix) remain active guardrails enforced by the test suite.
+
+Finding outcomes:
+
+| Finding | Addressed by | Status |
+| --- | --- | --- |
+| 1. `routes.py` owns too many boundaries | Phase 1 (PR #21) | Done — domain route modules; `routes/__init__.py` still holds shared helpers/glue (follow-up below) |
+| 2. UI embedded as a Python string | Phase 1 (PR #21) | Done — CSS/JS extracted to `static/ui/`; browser smoke test still open |
+| 3. `os.environ` as config bus | Phase 2 (PR #22) | Done — `config.py` runtime config service + machine-checked env inventory |
+| 4. Playback state spread across modules | Phase 3 (PR #23) | Done — `playback_service.py` owns transition commands; writer inventory enforced |
+| 5. Partial Jellyfin boundary | Phase 4 (PR #24) | Done — `integrations/jellyfin_service.py`; receiver stays transport-only |
+| 6. State persistence schema ownership | — | **Open** — no versioned models yet |
+| 7. Tests too concentrated | Phases 1–6 | Largely done — focused route/service/inventory test files; `test_smoke.py` still large |
+| 8. API trust boundary | Phase 5 (PR #25) | Done — optional `RELAYTV_API_TOKEN` bearer auth; trusted-LAN docs |
+| 9. Runtime/installer policy tracing | Phase 6 (PR #26) | Done — machine-checked runtime matrix + operator checklists |
+| 10. Duplication and drift | Phase 2 (partial) | Partial — env parsing centralized; provider/URL helper consolidation still open |
 
 Scope reviewed:
 
@@ -50,18 +67,26 @@ Original measured hotspots:
 - `app/relaytv_app/integrations/jellyfin_receiver.py`: 2,619 lines.
 - `tests/test_smoke.py`: 2,960 lines.
 
-Current Phase 1 branch shape:
+Shape after the roadmap completed (2026-07-04):
 
-- `app/relaytv_app/routes/` is now a package with domain modules for app info,
+- `app/relaytv_app/routes/` is a package with domain modules for app info,
   assets, capabilities, devices, health, Jellyfin, playback, queue, settings,
   snapshots, status, UI, and uploads.
 - `app/relaytv_app/routes/__init__.py` remains the aggregate compatibility
-  module and still owns shared helpers plus unresolved cross-domain glue.
-- Main UI CSS and JavaScript now live in
-  `app/relaytv_app/static/ui/app.css` and
+  module and still owns shared helpers plus cross-domain glue (~3,900 lines).
+- Main UI CSS and JavaScript live in `app/relaytv_app/static/ui/app.css` and
   `app/relaytv_app/static/ui/app.js`.
-- Focused route test files now cover capabilities, Jellyfin, playback,
-  queue/history, settings, uploads, and the public route inventory.
+- `app/relaytv_app/config.py` is the runtime config service (typed env
+  parsing, settings bus, subprocess mirroring boundary).
+- `app/relaytv_app/playback_service.py` owns playback transition commands;
+  `player.py` is the process/control adapter.
+- `app/relaytv_app/integrations/jellyfin_service.py` owns Jellyfin product
+  behavior; `jellyfin_receiver.py` stays transport/session/catalog.
+- Focused test files cover capabilities, Jellyfin routes/service, playback
+  routes/transitions, queue/history, settings, uploads, API auth, the runtime
+  matrix, and the machine-checked route/env/transition/Jellyfin inventories.
+- `tests/test_smoke.py` is still large (~4,200 lines) and remains the
+  catch-all for player/resolver behavior tests.
 
 Positive foundations:
 
@@ -92,7 +117,7 @@ The original monolithic `routes.py` owned:
 - PWA/static asset helpers
 - the full browser UI document
 
-Current Phase 1 status:
+Status after Phase 1 (PR #21):
 
 - Public route registration has been split into domain modules.
 - The aggregate `routes/__init__.py` still owns a large helper surface,
@@ -396,7 +421,7 @@ Create small shared modules:
 
 ## Recommended Roadmap
 
-### Phase 0: Guardrails And Documentation
+### Phase 0: Guardrails And Documentation (complete)
 
 Goal: improve reviewability without changing runtime behavior.
 
@@ -411,7 +436,7 @@ Status:
 
 Suggested PR size: small.
 
-### Phase 1: Extract Routes And Static UI Assets
+### Phase 1: Extract Routes And Static UI Assets (complete — PR #21)
 
 Goal: reduce `routes.py` risk.
 
@@ -429,7 +454,7 @@ Status:
 - Final validation and optional browser automation remain before merging Phase 1
   to `main`.
 
-### Phase 2: Runtime Config Service
+### Phase 2: Runtime Config Service (complete — PR #22)
 
 Goal: stop using process environment as the in-process config bus.
 
@@ -441,7 +466,7 @@ Goal: stop using process environment as the in-process config bus.
 
 Suggested PR size: medium.
 
-### Phase 3: Playback Transition Service
+### Phase 3: Playback Transition Service (complete — PR #23)
 
 Goal: make close/play-now/queue/resume behavior deterministic.
 
@@ -457,7 +482,7 @@ Goal: make close/play-now/queue/resume behavior deterministic.
 
 Suggested PR size: medium to large; split by command path.
 
-### Phase 4: Jellyfin Product Service
+### Phase 4: Jellyfin Product Service (complete — PR #24)
 
 Goal: make Jellyfin behavior testable without route context.
 
@@ -469,7 +494,7 @@ Goal: make Jellyfin behavior testable without route context.
 
 Suggested PR size: medium.
 
-### Phase 5: Optional API Token
+### Phase 5: Optional API Token (complete — PR #25)
 
 Goal: preserve local-first defaults while giving operators a safe exposure path.
 
@@ -480,7 +505,7 @@ Goal: preserve local-first defaults while giving operators a safe exposure path.
 
 Suggested PR size: small to medium.
 
-### Phase 6: Operations Test Matrix
+### Phase 6: Operations Test Matrix (complete — PR #26)
 
 Goal: catch runtime regressions before users do.
 
@@ -497,13 +522,21 @@ Goal: catch runtime regressions before users do.
 
 Suggested PR size: ongoing.
 
-## Suggested Next PRs
+## Open Follow-Ups
 
-1. `test(ui): add browser smoke for settings and queue shell`
-2. `docs: refresh module ownership map after phase 1 merge`
-3. `refactor(config): introduce runtime config snapshot`
-4. `test(playback): cover close and play-now transition service behavior`
-5. `refactor(playback): centralize close and queue advancement policy`
+Work the roadmap intentionally did not cover, in rough value order:
+
+1. `test(ui): add one browser (Playwright) smoke path for /ui` — settings
+   modal, queue actions, Jellyfin shell visibility (Finding 2's remaining
+   item; still string-asserted today).
+2. `refactor(state): add versioned models for queue/history/session/settings`
+   — Finding 6 was not addressed; migrations remain implicit.
+3. `refactor(routes): continue shrinking routes/__init__.py` — the aggregate
+   still owns ~3,900 lines of shared helpers, overlay/idle behavior, and
+   status payload construction.
+4. `refactor(providers): consolidate provider/URL classification` — still
+   duplicated between resolver and player paths (Finding 10 remainder).
+5. `test: keep splitting test_smoke.py by behavior` — still ~4,200 lines.
 
 ## Non-Goals
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,17 +13,26 @@ Use this directory as a small operator/product doc set for the public release br
 
 ## Engineering Review Docs
 
-- `ARCHITECTURE_REVIEW.md`: current architecture findings and recommended refactor roadmap
-- `ARCHITECTURE_PHASE_1_ROADMAP.md`: living Phase 1 branch roadmap, milestones, and PR log
-- `ARCHITECTURE_PHASE_1_ROUTE_INVENTORY.md`: Phase 1 route inventory and alias guardrail
-- `ARCHITECTURE_PHASE_2_ROADMAP.md`: living Phase 2 branch roadmap for the runtime config service
-- `ARCHITECTURE_PHASE_2_ENV_INVENTORY.md`: machine-checked env variable inventory and settings-bus classification
-- `ARCHITECTURE_PHASE_3_ROADMAP.md`: living Phase 3 branch roadmap for the playback transition service
-- `ARCHITECTURE_PHASE_3_TRANSITION_INVENTORY.md`: machine-checked playback transition writer inventory and containment contract
-- `ARCHITECTURE_PHASE_4_ROADMAP.md`: living Phase 4 branch roadmap for the Jellyfin product service
-- `ARCHITECTURE_PHASE_4_JELLYFIN_INVENTORY.md`: machine-checked Jellyfin route-surface inventory and containment contract
-- `ARCHITECTURE_PHASE_5_ROADMAP.md`: living Phase 5 branch roadmap for the optional API token
-- `ARCHITECTURE_PHASE_6_ROADMAP.md`: living Phase 6 branch roadmap for the operations test matrix
+The 2026-06/07 architecture review and its six-phase refactor roadmap are
+complete (PRs #21–#26, merged 2026-07-03/04).
+
+Historical records (findings and per-phase milestone logs; not updated further):
+
+- `ARCHITECTURE_REVIEW.md`: architecture findings, finding outcomes, and the
+  completed refactor roadmap (open follow-ups listed at the end)
+- `ARCHITECTURE_PHASE_1_ROADMAP.md` … `ARCHITECTURE_PHASE_6_ROADMAP.md`:
+  per-phase milestone logs (routes/UI split, runtime config service, playback
+  transition service, Jellyfin product service, optional API token, operations
+  test matrix)
+
+Active guardrails (machine-checked by the test suite; regenerate via each
+inventory test's `--write` mode after intentional changes):
+
+- `ARCHITECTURE_PHASE_1_ROUTE_INVENTORY.md`: route inventory and alias guardrail (`tests/test_route_inventory.py`)
+- `ARCHITECTURE_PHASE_2_ENV_INVENTORY.md`: env variable inventory and settings-bus classification (`tests/test_env_inventory.py`)
+- `ARCHITECTURE_PHASE_3_TRANSITION_INVENTORY.md`: playback transition writer inventory and containment contract (`tests/test_transition_inventory.py`)
+- `ARCHITECTURE_PHASE_4_JELLYFIN_INVENTORY.md`: Jellyfin route-surface inventory and containment contract (`tests/test_jellyfin_inventory.py`)
+- `OPERATIONS_TEST_MATRIX.md`: runtime profile decision table (`tests/test_runtime_matrix.py`; listed under Primary Docs above)
 
 ## Module Ownership Snapshot
 
@@ -32,6 +41,8 @@ Use this directory as a small operator/product doc set for the public release br
   package still owns shared route helpers and cross-domain glue.
 - `app/relaytv_app/static/ui/`: main web UI stylesheet and JavaScript loaded by
   `/ui`.
+- `app/relaytv_app/config.py`: runtime config service — typed env parsing,
+  settings bus, and the explicit subprocess env-mirroring boundary.
 - `app/relaytv_app/playback_service.py`: playback transition commands
   (play-now, queue, close, advance, resume, natural end, stop) — the writer
   of playback session state outside `state.py`.


### PR DESCRIPTION
## Summary

Doc closeout for the completed six-phase architecture roadmap (PRs #21–#26). The review docs still read as mid-Phase-1, and AGENTS.md carried six per-phase discipline sections with instructions that are now wrong ("no release until the roadmap completes", "keep work on `codex/architecture-phase-N`").

- **`docs/ARCHITECTURE_REVIEW.md`** — completion status header with a per-finding outcome table (what shipped in which phase, what's still open), post-roadmap module shape, phase headings marked complete with PR links, and the stale "Suggested Next PRs" replaced by the genuinely open follow-ups: browser smoke test for `/ui`, versioned state models (Finding 6, never addressed), continued `routes/__init__.py` shrink (~3,900 lines), provider/URL helper consolidation, and further `test_smoke.py` splitting (~4,200 lines).
- **`docs/ARCHITECTURE_PHASE_1..6_ROADMAP.md`** — one-line "complete" status headers marking each as a historical milestone log (merged PR + date).
- **`docs/README.md`** — review docs reorganized into *historical records* vs *active machine-checked guardrails* (each inventory listed with its enforcing test and `--write` regeneration mode); `config.py` added to the module ownership snapshot (it was missing).
- **`AGENTS.md`** — collapsed 263 → ~100 lines. Keeps the release/changelog discipline, adds two durable lessons from this cycle (never push to a merged PR's branch — commits orphan silently; a PR body's `COMMIT_OVERRIDE` must describe exactly its squash), documents the quality gates + inventory regeneration workflow, preserves the `RELAYTV_API_TOKEN` env-only security constraint, and replaces the six phase sections with a compact roadmap record plus the ownership boundaries new work must preserve (`playback_service`/`config`/`jellyfin_service` seams, endpoint alias policy).

No runtime or behavior changes — documentation only.

## Test plan

- [x] `ruff check app tests` clean; 330 tests pass (`pytest -q`) — the machine-checked inventory docs were not touched by hand, so all guardrail tests stay green
- [x] `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
