### PR TITLE
feat: flatpak packaging for the relaytv appliance

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build Flatpak bundle
-        uses: flathub-infra/flatpak-github-actions/flatpak-builder@v6
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6.7
         with:
           bundle: relaytv-x86_64.flatpak
           manifest-path: packaging/flatpak/io.github.mcgeezy.relaytv.yml

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,30 @@
+name: flatpak
+
+on:
+  pull_request:
+    paths:
+      - 'packaging/flatpak/**'
+      - 'app/**'
+      - '.github/workflows/flatpak.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  flatpak-bundle:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build Flatpak bundle
+        uses: flathub-infra/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: relaytv-x86_64.flatpak
+          manifest-path: packaging/flatpak/io.github.mcgeezy.relaytv.yml
+          cache-key: flatpak-builder-${{ hashFiles('packaging/flatpak/**') }}
+          arch: x86_64
+          upload-artifact: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -109,7 +109,7 @@ jobs:
           platforms: arm64
 
       - name: Build Flatpak bundle
-        uses: flathub-infra/flatpak-github-actions/flatpak-builder@v6
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6.7
         with:
           bundle: relaytv-${{ needs.release-please.outputs.tag_name }}-${{ matrix.arch }}.flatpak
           manifest-path: packaging/flatpak/io.github.mcgeezy.relaytv.yml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,7 +76,77 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Publish GitHub Release after image push
+  release-flatpak:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.sha }}
+
+      - name: Stamp release version into metainfo
+        run: |
+          sed -i "s|<release version=\"[^\"]*\" date=\"[^\"]*\"/>|<release version=\"${{ needs.release-please.outputs.version }}\" date=\"$(date -u +%F)\"/>|" \
+            packaging/flatpak/io.github.mcgeezy.relaytv.metainfo.xml
+
+      - name: Install docker for QEMU setup
+        if: matrix.arch == 'aarch64'
+        run: dnf -y install docker
+
+      - name: Set up QEMU
+        if: matrix.arch == 'aarch64'
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64
+
+      - name: Build Flatpak bundle
+        uses: flathub-infra/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: relaytv-${{ needs.release-please.outputs.tag_name }}-${{ matrix.arch }}.flatpak
+          manifest-path: packaging/flatpak/io.github.mcgeezy.relaytv.yml
+          cache-key: flatpak-builder-${{ hashFiles('packaging/flatpak/**') }}
+          arch: ${{ matrix.arch }}
+          upload-artifact: false
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: relaytv-flatpak-${{ matrix.arch }}
+          path: relaytv-${{ needs.release-please.outputs.tag_name }}-${{ matrix.arch }}.flatpak
+          if-no-files-found: error
+
+  publish-release:
+    needs: [release-please, release-image, release-flatpak]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.sha }}
+
+      - name: Download Flatpak bundles
+        uses: actions/download-artifact@v4
+        with:
+          pattern: relaytv-flatpak-*
+          merge-multiple: true
+
+      - name: Attach Flatpak bundles to the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" relaytv-*.flatpak --clobber
+
+      - name: Publish GitHub Release after image push and bundle upload
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${{ needs.release-please.outputs.tag_name }}" --draft=false

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ docker compose up -d --build
 ./scripts/doctor.sh
 ```
 
+### Flatpak (no Docker)
+
+Each GitHub Release also ships a host-native Flatpak bundle:
+
+```bash
+flatpak install --user ./relaytv-vX.Y.Z-x86_64.flatpak
+flatpak run io.github.mcgeezy.relaytv
+```
+
+See [docs/FLATPAK_OPERATIONS.md](docs/FLATPAK_OPERATIONS.md) for permissions,
+configuration, autostart, and current limitations.
+
 ---
 
 ## Common ways people use RelayTV

--- a/README.md
+++ b/README.md
@@ -47,16 +47,10 @@ docker compose up -d --build
 
 ### Flatpak (no Docker)
 
-Each GitHub Release also ships a host-native Flatpak bundle. One-line install
-from the latest release:
+Each GitHub Release also ships a host-native Flatpak bundle:
 
 ```bash
-sh -c 'set -eu; flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo; tag=$(curl -fsSL https://api.github.com/repos/mcgeezy/relaytv/releases/latest | sed -n "s/.*\"tag_name\": *\"\([^\"]*\)\".*/\1/p" | head -1); arch=$(uname -m); tmp=$(mktemp --suffix=.flatpak); curl -fL -o "$tmp" "https://github.com/mcgeezy/relaytv/releases/download/${tag}/relaytv-${tag}-${arch}.flatpak"; flatpak install --user -y "$tmp"; rm -f "$tmp"'
-```
-
-Then run:
-
-```bash
+flatpak install --user ./relaytv-vX.Y.Z-x86_64.flatpak
 flatpak run io.github.mcgeezy.relaytv
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,16 @@ docker compose up -d --build
 
 ### Flatpak (no Docker)
 
-Each GitHub Release also ships a host-native Flatpak bundle:
+Each GitHub Release also ships a host-native Flatpak bundle. One-line install
+from the latest release:
 
 ```bash
-flatpak install --user ./relaytv-vX.Y.Z-x86_64.flatpak
+sh -c 'set -eu; flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo; tag=$(curl -fsSL https://api.github.com/repos/mcgeezy/relaytv/releases/latest | sed -n "s/.*\"tag_name\": *\"\([^\"]*\)\".*/\1/p" | head -1); arch=$(uname -m); tmp=$(mktemp --suffix=.flatpak); curl -fL -o "$tmp" "https://github.com/mcgeezy/relaytv/releases/download/${tag}/relaytv-${tag}-${arch}.flatpak"; flatpak install --user -y "$tmp"; rm -f "$tmp"'
+```
+
+Then run:
+
+```bash
 flatpak run io.github.mcgeezy.relaytv
 ```
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -59,6 +59,7 @@ Python packages listed above:
 - `libass` (ISC)
 - `LuaJIT` (openresty/luajit2 fork, MIT)
 - `libcec` and `p8-platform` (GPL-2.0-or-later with Pulse-Eight dual-license terms)
+- `alsa-utils` (GPL-2.0-or-later)
 - `deno` (MIT)
 
 FFmpeg, Mesa, Qt platform libraries, and other system components come from the

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -48,6 +48,22 @@ hardware acceleration, audio, CEC, and diagnostics. Examples include:
 The generated inventory records installed Debian packages and versions when run
 inside the container or another Debian-based runtime environment.
 
+## Flatpak Bundle Components
+
+The Flatpak bundle (`packaging/flatpak/`) builds and redistributes these
+components on top of the `org.freedesktop.Platform` runtime, alongside the
+Python packages listed above:
+
+- `mpv` / `libmpv` (GPL-2.0-or-later / LGPL-2.1-or-later)
+- `libplacebo` (LGPL-2.1-or-later)
+- `libass` (ISC)
+- `LuaJIT` (openresty/luajit2 fork, MIT)
+- `libcec` and `p8-platform` (GPL-2.0-or-later with Pulse-Eight dual-license terms)
+- `deno` (MIT)
+
+FFmpeg, Mesa, Qt platform libraries, and other system components come from the
+freedesktop runtime and are licensed and distributed by that project.
+
 ## Bundled Assets
 
 RelayTV includes project artwork and UI assets under:

--- a/app/relaytv_app/container_entrypoint.py
+++ b/app/relaytv_app/container_entrypoint.py
@@ -35,10 +35,17 @@ def _wait_for_socket(path: Path, timeout_sec: float = 12.0) -> bool:
     return path.exists()
 
 
+def _state_dir(env: dict[str, str] | None = None) -> Path:
+    """Resolve the persistent state dir with the same precedence as state.py."""
+    src = env if env is not None else os.environ
+    raw = (src.get("RELAYTV_STATE_DIR") or src.get("BRAVECAST_STATE_DIR") or "/data").strip()
+    return Path(raw or "/data")
+
+
 def _sync_legacy_brand_assets() -> None:
-    """Ensure legacy /data/assets files exist when /data is a bind-mounted volume."""
-    src_dir = Path("/app/relaytv_app/static/brand")
-    dst_dir = Path("/data/assets")
+    """Ensure legacy <state>/assets files exist when the state dir is a mounted volume."""
+    src_dir = Path(__file__).resolve().parent / "static" / "brand"
+    dst_dir = _state_dir() / "assets"
     if not src_dir.is_dir():
         return
     try:
@@ -172,6 +179,15 @@ def _yt_dlp_version(env: dict[str, str]) -> str:
     return (p.stdout or "").strip().splitlines()[0] if (p.stdout or "").strip() else ""
 
 
+def _ytdlp_update_state_path(env: dict[str, str]) -> Path:
+    state_dir = _state_dir(env)
+    raw = (env.get("RELAYTV_YTDLP_AUTO_UPDATE_STATE_FILE") or "").strip()
+    if not raw:
+        return state_dir / ".relaytv-ytdlp-update.json"
+    path = Path(raw)
+    return path if path.is_absolute() else state_dir / path
+
+
 def _yt_dlp_auto_update(env: dict[str, str]) -> None:
     if not _is_true(env.get("RELAYTV_YTDLP_AUTO_UPDATE"), False):
         return
@@ -188,10 +204,7 @@ def run_yt_dlp_update(env: dict[str, str], *, force: bool = False) -> bool:
     """
     interval_hours = max(0.0, _parse_float_env(env, "RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS", 24.0))
     timeout_sec = max(10.0, _parse_float_env(env, "RELAYTV_YTDLP_AUTO_UPDATE_TIMEOUT_SEC", 180.0))
-    state_path_raw = (env.get("RELAYTV_YTDLP_AUTO_UPDATE_STATE_FILE") or "/data/.relaytv-ytdlp-update.json").strip()
-    state_path = Path(state_path_raw)
-    if not state_path.is_absolute():
-        state_path = Path("/data") / state_path
+    state_path = _ytdlp_update_state_path(env)
 
     now = float(time.time())
     state = _read_json_file(state_path)
@@ -401,11 +414,22 @@ def _terminate(proc: subprocess.Popen | None) -> None:
             pass
 
 
+def _server_port(env: dict[str, str] | None = None) -> int:
+    """Resolve the HTTP port for the default uvicorn args (discovery_mdns reads
+    the same variable so advertised and bound ports stay in sync)."""
+    src = env if env is not None else os.environ
+    try:
+        port = int(float((src.get("RELAYTV_PORT") or "").strip() or "8787"))
+    except Exception:
+        return 8787
+    return port if 0 < port < 65536 else 8787
+
+
 def main(argv: list[str] | None = None) -> int:
     configure_logging()
     args = list(argv if argv is not None else sys.argv[1:])
     if not args:
-        args = ["uvicorn", "relaytv_app.main:app", "--host", "0.0.0.0", "--port", "8787"]
+        args = ["uvicorn", "relaytv_app.main:app", "--host", "0.0.0.0", "--port", str(_server_port())]
     if args and args[0] == "uvicorn" and (not access_logging_enabled()) and "--no-access-log" not in args:
         args.append("--no-access-log")
 

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -1127,6 +1127,8 @@ def _qt_external_wayland_mode_args() -> list[str]:
     profile = (os.getenv("RELAYTV_QT_EXTERNAL_WAYLAND_PROFILE") or "conservative").strip().lower()
     if profile in ("baseline", "simple", "legacy"):
         return ["--vo=gpu", "--gpu-context=wayland"]
+    if _flatpak_arm_runtime():
+        return ["--vo=wlshm"]
     # Conservative profile is default; validated on NUC Wayland stack.
     return [
         "--vo=gpu",
@@ -1135,6 +1137,19 @@ def _qt_external_wayland_mode_args() -> list[str]:
         "--opengl-es=yes",
         "--fbo-format=rgba8",
     ]
+
+
+def _flatpak_arm_runtime() -> bool:
+    if not os.path.exists("/.flatpak-info"):
+        return False
+    arch = (platform.machine() or "").strip().lower()
+    if arch in ("aarch64", "arm64") or arch.startswith(("armv6", "armv7", "armv8")):
+        return True
+    try:
+        profile = dict(video_profile.get_profile() or {})
+    except Exception:
+        profile = {}
+    return str(profile.get("decode_profile") or "").strip().lower() == "arm_safe"
 
 
 def _qt_external_launch_env(mode_args: list[str]) -> dict[str, str] | None:
@@ -2597,7 +2612,7 @@ def _video_output_healthy(timeout: float = 2.0) -> bool:
     while time.time() < deadline:
         if not _is_playing():
             return False
-        native_state = _qt_shell_runtime_output_state(max_age_sec=native_age)
+        native_state = None if _qt_runtime_uses_external_mpv() else _qt_shell_runtime_output_state(max_age_sec=native_age)
         if native_state is not None:
             has_video = bool(native_state.get("current_vo"))
             has_audio = bool(native_state.get("current_ao")) or isinstance(native_state.get("aid"), int)

--- a/app/relaytv_app/qt_shell_app.py
+++ b/app/relaytv_app/qt_shell_app.py
@@ -52,6 +52,21 @@ def _initial_load_presentation_ready(exposed: bool, swaps: int, settled_age_sec:
     return bool(exposed) and int(swaps) >= 3 and float(settled_age_sec) >= 0.25
 
 
+def _initial_load_gate_timeout_sec() -> float:
+    """How long the first video load may wait for a presentable window.
+
+    Boot is the case that matters: the compositor can take well over the old
+    6s here, and loading early wedges presentation for the whole process
+    life, which is strictly worse than starting late.
+    """
+    raw = (os.getenv("RELAYTV_QT_LIBMPV_PRESENT_GATE_TIMEOUT_SEC") or "90").strip()
+    try:
+        val = float(raw)
+    except Exception:
+        return 90.0
+    return min(600.0, max(6.0, val))
+
+
 def _has_opt(args: list[str], opt: str) -> bool:
     return any(a == opt or a.startswith(opt + "=") for a in args)
 
@@ -2909,40 +2924,55 @@ def main(argv: list[str] | None = None) -> int:
         win.installEventFilter(initial_gate_filter)
         video_widget.installEventFilter(initial_gate_filter)
 
-        def _window_presentation_ready() -> bool:
+        def _window_exposed() -> bool:
             try:
                 handle = win.windowHandle()
-                exposed = bool(handle is not None and handle.isExposed())
+                return bool(handle is not None and handle.isExposed())
             except Exception:
                 return False
+
+        def _window_presentation_ready() -> bool:
             return _initial_load_presentation_ready(
-                exposed,
+                _window_exposed(),
                 int(initial_gate["swaps"]),
                 time.monotonic() - float(initial_gate["settled_ts"]),
             )
+
+        initial_gate["started_ts"] = time.monotonic()
+        initial_gate["progress_logged_sec"] = 0.0
 
         def _load_initial_libmpv_stream() -> None:
             if libmpv_player is None:
                 return
             initial_load_attempts["n"] += 1
+            waited = time.monotonic() - float(initial_gate["started_ts"])
             try:
-                if not libmpv_player.render_context_ready():
-                    if initial_load_attempts["n"] < 120:
-                        QTimer.singleShot(50, _load_initial_libmpv_stream)
-                        return
+                ctx_ready = bool(libmpv_player.render_context_ready())
+                presentation_ready = ctx_ready and _window_presentation_ready()
+                if not presentation_ready and waited < _initial_load_gate_timeout_sec():
+                    if waited - float(initial_gate["progress_logged_sec"]) >= 10.0:
+                        initial_gate["progress_logged_sec"] = waited
+                        _eprint(
+                            "qt-shell libmpv initial load waiting for presentation "
+                            f"(waited={waited:.0f}s ctx={ctx_ready} "
+                            f"exposed={_window_exposed()} swaps={initial_gate['swaps']})"
+                        )
+                    # Poll fast through a normal bring-up, then back off for
+                    # slow session starts (boot).
+                    QTimer.singleShot(50 if waited < 6.0 else 500, _load_initial_libmpv_stream)
+                    return
+                if not ctx_ready:
                     raise RuntimeError("libmpv render context not ready")
-                if not _window_presentation_ready():
-                    if initial_load_attempts["n"] < 120:
-                        QTimer.singleShot(50, _load_initial_libmpv_stream)
-                        return
+                if presentation_ready:
                     _eprint(
-                        "qt-shell libmpv initial load proceeding despite unsettled window "
-                        f"(swaps={initial_gate['swaps']})"
+                        "qt-shell libmpv initial load gated until presentation ready "
+                        f"(waited={waited:.1f}s swaps={initial_gate['swaps']})"
                     )
                 else:
                     _eprint(
-                        "qt-shell libmpv initial load gated until presentation ready "
-                        f"(checks={initial_load_attempts['n']} swaps={initial_gate['swaps']})"
+                        "qt-shell libmpv initial load proceeding despite unsettled window "
+                        f"(waited={waited:.0f}s exposed={_window_exposed()} "
+                        f"swaps={initial_gate['swaps']})"
                     )
                 libmpv_player.load_stream(initial_stream, initial_audio, initial_start)
                 _sync_idle_visibility()

--- a/app/relaytv_app/qt_shell_app.py
+++ b/app/relaytv_app/qt_shell_app.py
@@ -2867,6 +2867,48 @@ def main(argv: list[str] | None = None) -> int:
                 overlay_win.activateWindow()
             except Exception:
                 pass
+    if not headless_qpa:
+        # A window mapped while gnome-shell is still initializing (boot) can
+        # land in a corrupted stacking state (mutter logs
+        # "meta_window_set_stack_position_no_sync: assertion
+        # 'window->stack_position >= 0' failed") and is then never exposed:
+        # the appliance boots to a black screen until something re-maps the
+        # window. If the window has never been exposed, re-map it so the
+        # settled compositor stacks a fresh surface.
+        exposure_state = {"ever_exposed": False, "remaps": 0}
+
+        def _exposure_watchdog() -> None:
+            try:
+                handle = win.windowHandle()
+                exposed = bool(handle is not None and handle.isExposed())
+            except Exception:
+                exposed = False
+            if exposed:
+                exposure_state["ever_exposed"] = True
+                try:
+                    exposure_timer.stop()
+                except Exception:
+                    pass
+                return
+            if exposure_state["ever_exposed"] or exposure_state["remaps"] >= 5:
+                return
+            exposure_state["remaps"] += 1
+            _eprint(
+                "qt-shell window never exposed; remapping fullscreen window "
+                f"(attempt {exposure_state['remaps']})"
+            )
+            try:
+                win.hide()
+                win.showFullScreen()
+                win.raise_()
+                win.activateWindow()
+            except Exception as exc:
+                _eprint(f"qt-shell window remap failed: {exc}")
+
+        exposure_timer = QTimer()
+        exposure_timer.setInterval(8000)
+        exposure_timer.timeout.connect(_exposure_watchdog)
+        exposure_timer.start()
     if overlay is not None and overlay_win is None:
         overlay.show()
         overlay.raise_()

--- a/app/relaytv_app/qt_shell_app.py
+++ b/app/relaytv_app/qt_shell_app.py
@@ -662,6 +662,16 @@ _MPV_FORMAT_NODE_ARRAY = 7
 _MPV_FORMAT_NODE_MAP = 8
 
 
+def _ensure_c_numeric_locale() -> None:
+    """Force LC_NUMERIC=C so mpv_create() accepts the process locale."""
+    try:
+        import locale
+
+        locale.setlocale(locale.LC_NUMERIC, "C")
+    except Exception:
+        pass
+
+
 def _find_libmpv() -> str | None:
     p = ctypes.util.find_library("mpv")
     if p:
@@ -1056,6 +1066,11 @@ class _QtLibMpvPlayer:
         ytdl_raw_options: str | None,
     ) -> None:
         self._bind_api()
+        # Qt adopts the session locale at QApplication init; libmpv refuses to
+        # create a handle unless LC_NUMERIC is "C" (hosts with LANG set, e.g.
+        # desktop sessions the Flatpak runs in, hit this; containers without
+        # LANG never did).
+        _ensure_c_numeric_locale()
         handle = ctypes.c_void_p(self._lib.mpv_create())
         if not handle:
             raise RuntimeError("mpv_create returned null handle")
@@ -1320,6 +1335,7 @@ def main(argv: list[str] | None = None) -> int:
             self._net = QNetworkAccessManager(self)
             self._toasts: list[QWidget] = []
             self._replies: set[object] = set()
+            self._position = "top-left"
             self.setAttribute(Qt.WA_TranslucentBackground, True)
             self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
             self.setStyleSheet("background: transparent;")
@@ -1346,6 +1362,26 @@ def main(argv: list[str] | None = None) -> int:
 
         def _insert_index_for_position(self, position: str) -> int:
             return self._layout.count() if str(position or "").startswith("bottom-") else 0
+
+        def fit_to_bounds(self, bounds) -> None:
+            if not self._toasts:
+                return
+            try:
+                self.adjustSize()
+                hint = self.sizeHint()
+                width = max(1, min(int(bounds.width()), int(hint.width())))
+                height = max(1, min(int(bounds.height()), int(hint.height())))
+                position = self._position_name({"position": self._position})
+                if position.endswith("right"):
+                    x = max(0, int(bounds.width()) - width)
+                elif position.endswith("center"):
+                    x = max(0, (int(bounds.width()) - width) // 2)
+                else:
+                    x = 0
+                y = max(0, int(bounds.height()) - height) if position.startswith("bottom-") else 0
+                self.setGeometry(x, y, width, height)
+            except Exception:
+                pass
 
         def _icon_text(self, payload: dict[str, object]) -> str:
             icon = str(payload.get("icon") or "").strip().lower()
@@ -1452,6 +1488,10 @@ def main(argv: list[str] | None = None) -> int:
                 pass
             if not self._toasts:
                 self.hide()
+            else:
+                parent = self.parentWidget()
+                if parent is not None:
+                    self.fit_to_bounds(parent.rect())
 
         def clear_all(self) -> None:
             for widget in list(self._toasts):
@@ -1477,6 +1517,7 @@ def main(argv: list[str] | None = None) -> int:
             if not text:
                 return
             position = self._position_name(payload)
+            self._position = position
             item_alignment = self._layout_alignment_for_position(position)
             self._layout.setAlignment(item_alignment)
             frame = QFrame(self)
@@ -1520,6 +1561,9 @@ def main(argv: list[str] | None = None) -> int:
             while len(self._toasts) > 4:
                 self._remove_toast(self._toasts[-1])
             self.show()
+            parent = self.parentWidget()
+            if parent is not None:
+                self.fit_to_bounds(parent.rect())
             self.raise_()
             ttl_sec = max(0.8, float(payload.get("duration") or 4.0))
             ttl_ms = min(30000, max(800, int(ttl_sec * 1000.0)))
@@ -2187,6 +2231,7 @@ def main(argv: list[str] | None = None) -> int:
     native_toast_toplevel = False
     native_idle_toplevel = False
     overlay_parent_is_main_window = False
+    native_toast_parent_is_main_window = False
     overlay_raise_timer = None
     overlay_last_rect = None
     overlay_load_deferred: list[callable] = []
@@ -2320,7 +2365,15 @@ def main(argv: list[str] | None = None) -> int:
 
     if native_toasts_enabled:
         native_toast_toplevel = overlay_win is None and _native_overlay_toasts_use_toplevel(use_libmpv=use_libmpv)
-        toast_parent = None if native_toast_toplevel else (overlay_win if overlay_win is not None else (win if overlay_parent_is_main_window else video_widget))
+        if native_toast_toplevel:
+            toast_parent = None
+        elif overlay_win is not None:
+            toast_parent = overlay_win
+        elif use_libmpv or overlay_parent_is_main_window:
+            toast_parent = win
+            native_toast_parent_is_main_window = True
+        else:
+            toast_parent = video_widget
         native_toast_host = _NativeToastLayer(toast_parent, overlay_url=args.overlay_url)
         if native_toast_toplevel:
             toast_flags = Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
@@ -2332,6 +2385,11 @@ def main(argv: list[str] | None = None) -> int:
             native_toast_host.setAttribute(Qt.WA_TranslucentBackground, True)
             if not use_wayland_window_flags:
                 native_toast_host.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+        else:
+            try:
+                native_toast_host.setAttribute(Qt.WA_AlwaysStackOnTop, True)
+            except Exception:
+                pass
         native_toast_host.hide()
 
     if native_idle_enabled:
@@ -2361,8 +2419,9 @@ def main(argv: list[str] | None = None) -> int:
                 overlay_win.setGeometry(rect)
                 overlay_last_rect = rect
             if native_toast_host is not None:
-                native_toast_host.setGeometry(overlay_win.rect())
-                native_toast_host.raise_()
+                if native_toast_host.isVisible():
+                    native_toast_host.fit_to_bounds(overlay_win.rect())
+                    native_toast_host.raise_()
             return
         target_rect = win.rect() if overlay_parent_is_main_window else video_widget.rect()
         if overlay is not None:
@@ -2372,9 +2431,12 @@ def main(argv: list[str] | None = None) -> int:
         if native_toast_host is not None:
             if native_toast_toplevel:
                 native_toast_host.setGeometry(win.frameGeometry())
+            elif native_toast_parent_is_main_window:
+                native_toast_host.fit_to_bounds(win.rect())
             else:
-                native_toast_host.setGeometry(target_rect)
-            native_toast_host.raise_()
+                native_toast_host.fit_to_bounds(target_rect)
+            if native_toast_host.isVisible():
+                native_toast_host.raise_()
         if native_idle_host is not None:
             if native_idle_toplevel:
                 native_idle_host.setGeometry(win.frameGeometry())
@@ -2433,12 +2495,12 @@ def main(argv: list[str] | None = None) -> int:
         try:
             if overlay_win is not None:
                 overlay_win.raise_()
-                if native_toast_host is not None:
+                if native_toast_host is not None and native_toast_host.isVisible():
                     native_toast_host.raise_()
                 return
             if overlay is not None:
                 overlay.raise_()
-            if native_toast_host is not None:
+            if native_toast_host is not None and native_toast_host.isVisible():
                 native_toast_host.raise_()
             if native_idle_host is not None and native_idle_host.isVisible():
                 native_idle_host.raise_()

--- a/app/relaytv_app/qt_shell_app.py
+++ b/app/relaytv_app/qt_shell_app.py
@@ -45,6 +45,13 @@ def _eprint(*a: object) -> None:
     logger.info(" ".join(str(part) for part in a))
 
 
+def _initial_load_presentation_ready(exposed: bool, swaps: int, settled_age_sec: float) -> bool:
+    """Gate for the first video load: the window must be mapped, actively
+    swapping frames, and past its bring-up geometry churn, or the Wayland
+    presentation loop can wedge into an audio-only frozen frame."""
+    return bool(exposed) and int(swaps) >= 3 and float(settled_age_sec) >= 0.25
+
+
 def _has_opt(args: list[str], opt: str) -> bool:
     return any(a == opt or a.startswith(opt + "=") for a in args)
 
@@ -2876,6 +2883,43 @@ def main(argv: list[str] | None = None) -> int:
         initial_audio = (args.audio or None)
         initial_start = args.start
         initial_load_attempts = {"n": 0}
+        # Starting the first video while the fullscreen Wayland surface is
+        # still being mapped/reconfigured wedges the window's presentation
+        # loop: one frame renders, then playback continues audio-only over a
+        # frozen frame and even later idle/overlay paints never reach the
+        # screen (observed on the Flatpak turn-up; starting from a settled
+        # idle window is always healthy). Hold the initial load until the
+        # window is exposed, has swapped real frames, and its geometry has
+        # stopped changing.
+        initial_gate = {"swaps": 0, "settled_ts": time.monotonic()}
+        try:
+            video_widget.frameSwapped.connect(
+                lambda: initial_gate.__setitem__("swaps", initial_gate["swaps"] + 1)
+            )
+        except Exception:
+            pass
+
+        class _InitialLoadGateFilter(QObject):
+            def eventFilter(self, _obj, event):  # noqa: N802 (Qt naming)
+                if event.type() in (QEvent.Resize, QEvent.Show, QEvent.Expose):
+                    initial_gate["settled_ts"] = time.monotonic()
+                return False
+
+        initial_gate_filter = _InitialLoadGateFilter()
+        win.installEventFilter(initial_gate_filter)
+        video_widget.installEventFilter(initial_gate_filter)
+
+        def _window_presentation_ready() -> bool:
+            try:
+                handle = win.windowHandle()
+                exposed = bool(handle is not None and handle.isExposed())
+            except Exception:
+                return False
+            return _initial_load_presentation_ready(
+                exposed,
+                int(initial_gate["swaps"]),
+                time.monotonic() - float(initial_gate["settled_ts"]),
+            )
 
         def _load_initial_libmpv_stream() -> None:
             if libmpv_player is None:
@@ -2883,10 +2927,23 @@ def main(argv: list[str] | None = None) -> int:
             initial_load_attempts["n"] += 1
             try:
                 if not libmpv_player.render_context_ready():
-                    if initial_load_attempts["n"] < 80:
+                    if initial_load_attempts["n"] < 120:
                         QTimer.singleShot(50, _load_initial_libmpv_stream)
                         return
                     raise RuntimeError("libmpv render context not ready")
+                if not _window_presentation_ready():
+                    if initial_load_attempts["n"] < 120:
+                        QTimer.singleShot(50, _load_initial_libmpv_stream)
+                        return
+                    _eprint(
+                        "qt-shell libmpv initial load proceeding despite unsettled window "
+                        f"(swaps={initial_gate['swaps']})"
+                    )
+                else:
+                    _eprint(
+                        "qt-shell libmpv initial load gated until presentation ready "
+                        f"(checks={initial_load_attempts['n']} swaps={initial_gate['swaps']})"
+                    )
                 libmpv_player.load_stream(initial_stream, initial_audio, initial_start)
                 _sync_idle_visibility()
                 _nudge_overlay_stack()

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -1004,7 +1004,12 @@ def _ui_event_push_jellyfin(
 
 
 def _host_urls() -> list[str]:
-    port = int(os.getenv("PORT", "8787"))
+    # RELAYTV_PORT is the documented port knob (entrypoint, mDNS, Flatpak
+    # launcher); PORT stays as a legacy fallback for existing deployments.
+    try:
+        port = int((os.getenv("RELAYTV_PORT") or os.getenv("PORT") or "8787").strip() or "8787")
+    except Exception:
+        port = 8787
     out: list[str] = [f"http://127.0.0.1:{port}/ui", f"http://localhost:{port}/ui"]
     ips: set[str] = set()
     try:

--- a/app/relaytv_app/state.py
+++ b/app/relaytv_app/state.py
@@ -13,6 +13,11 @@ from .debug import get_logger
 
 logger = get_logger("state")
 
+_OLD_ARM_NON_AV1_YOUTUBE_DEFAULT_RE = re.compile(
+    r"^bestvideo\[vcodec!\*=av01\]\[height<=([0-9]{3,4})\]\[fps<=60\]\+bestaudio/"
+    r"best\[vcodec!\*=av01\]\[height<=\1\]/best$"
+)
+
 # =========================
 # Persistent state (queue + history)
 # =========================
@@ -31,14 +36,21 @@ def _default_ytdlp_format() -> str:
     if env_fmt:
         return env_fmt
 
-    # Raspberry Pi / arm64 defaults to the same 1080p non-AV1 selector as other
-    # hosts unless explicitly overridden.
+    # Raspberry Pi / arm64 should avoid YouTube VP9/AV1 by default. Those can
+    # look sharp on paper but commonly fall back to software decode and black or
+    # badly delayed presentation on Pi-class hardware.
     arch = (platform.machine() or "").lower()
     if arch in ("aarch64", "arm64"):
         arm_cap = (os.getenv("RELAYTV_ARM_DEFAULT_QUALITY") or "1080").strip()
         if arm_cap not in {"360", "480", "720", "1080"}:
             arm_cap = "1080"
-        return f"bestvideo[vcodec!*=av01][height<={arm_cap}][fps<=60]+bestaudio/best[vcodec!*=av01][height<={arm_cap}]/best"
+        return (
+            f"bestvideo[vcodec^=avc1][height<={arm_cap}][fps<=30]+bestaudio[acodec^=mp4a]/"
+            f"bestvideo[vcodec^=avc1][height<={arm_cap}][fps<=30]+bestaudio/"
+            f"best*[vcodec^=avc1][height<={arm_cap}][fps<=30]/"
+            f"best[height<={arm_cap}][fps<=30][vcodec^=avc1]/"
+            f"best[height<={arm_cap}]/best"
+        )
 
     # Universal default for unknown providers: avoid AV1-heavy picks while
     # still allowing split streams where that is the only good choice.
@@ -69,6 +81,14 @@ def _normalize_ytdlp_format(v: str | None) -> str:
     if "/best" not in out:
         out = f"{out}/best"
     return out
+
+
+def _migrate_generated_ytdlp_default(value: object, quality_mode: object) -> str:
+    fmt = str(value or "").strip()
+    mode = _normalize_quality_mode(str(quality_mode or ""))
+    if mode in ("auto_profile",) and _OLD_ARM_NON_AV1_YOUTUBE_DEFAULT_RE.match(fmt):
+        return _default_ytdlp_format()
+    return _normalize_ytdlp_format(fmt)
 
 
 def _normalize_quality_mode(v: str | None) -> str:
@@ -970,8 +990,11 @@ def load_settings() -> None:
     data = _load_json(path, {})
     if isinstance(data, dict):
         defaults.update({k: v for k, v in data.items() if v is not None})
-    defaults["ytdlp_format"] = _normalize_ytdlp_format(defaults.get("ytdlp_format"))
     defaults["quality_mode"] = _normalize_quality_mode(defaults.get("quality_mode"))
+    defaults["ytdlp_format"] = _migrate_generated_ytdlp_default(
+        defaults.get("ytdlp_format"),
+        defaults.get("quality_mode"),
+    )
     defaults["quality_cap"] = _normalize_quality_cap(defaults.get("quality_cap"))
     defaults["youtube_cookies_path"] = str(defaults.get("youtube_cookies_path") or "").strip()
     defaults["youtube_use_invidious"] = bool(defaults.get("youtube_use_invidious"))

--- a/app/relaytv_app/ytdlp_format_policy.py
+++ b/app/relaytv_app/ytdlp_format_policy.py
@@ -98,7 +98,17 @@ def _arm_default_quality_cap() -> int:
     return _parse_cap(os.getenv("RELAYTV_ARM_DEFAULT_QUALITY")) or 1080
 
 
-def _auto_provider_format(provider: str, cap: int, *, av1_allowed: bool) -> str:
+def _arm_safe_profile(profile: dict[str, Any] | None) -> bool:
+    arch = (platform.machine() or "").lower()
+    if arch in ("aarch64", "arm64"):
+        return True
+    return (
+        isinstance(profile, dict)
+        and str(profile.get("decode_profile") or "").strip().lower() == "arm_safe"
+    )
+
+
+def _auto_provider_format(provider: str, cap: int, *, av1_allowed: bool, arm_safe: bool = False) -> str:
     p = str(provider or "other").strip().lower() or "other"
     if p == "rumble":
         # Rumble HLS manifests have shown that plain `best[...]` can still pick
@@ -107,6 +117,14 @@ def _auto_provider_format(provider: str, cap: int, *, av1_allowed: bool) -> str:
         return f"best*[height<={cap}][fps<=60]/best*[height<={cap}]/best[height<={cap}][fps<=60]/best"
     if p in ("twitch", "tiktok", "bitchute"):
         return f"best[height<={cap}][fps<=60]/best"
+    if p == "youtube" and arm_safe:
+        return (
+            f"bestvideo[vcodec^=avc1][height<={cap}][fps<=30]+bestaudio[acodec^=mp4a]/"
+            f"bestvideo[vcodec^=avc1][height<={cap}][fps<=30]+bestaudio/"
+            f"best*[vcodec^=avc1][height<={cap}][fps<=30]/"
+            f"best[height<={cap}][fps<=30][vcodec^=avc1]/"
+            f"best[height<={cap}]/best"
+        )
     vcodec = "" if av1_allowed else "[vcodec!*=av01]"
     return f"bestvideo{vcodec}[height<={cap}][fps<=60]+bestaudio/best{vcodec}[height<={cap}]/best"
 
@@ -122,8 +140,7 @@ def youtube_progressive_startup_format(
     if cap <= 0:
         cap = 720
     arm_cap = _arm_default_quality_cap()
-    machine = (platform.machine() or "").lower()
-    if machine in ("aarch64", "arm64") or (isinstance(profile, dict) and str(profile.get("decode_profile") or "").strip().lower() == "arm_safe"):
+    if _arm_safe_profile(profile):
         cap = min(cap, arm_cap)
     return f"best*[height<={cap}][fps<=30][vcodec!=none][acodec!=none][vcodec^=avc1]/best*[height<={cap}][fps<=30][vcodec!=none][acodec!=none]/best[height<={cap}]/best"
 
@@ -140,8 +157,7 @@ def youtube_progressive_startup_candidates(
     if cap <= 0:
         cap = 720
     arm_cap = _arm_default_quality_cap()
-    machine = (platform.machine() or "").lower()
-    if machine in ("aarch64", "arm64") or (isinstance(profile, dict) and str(profile.get("decode_profile") or "").strip().lower() == "arm_safe"):
+    if _arm_safe_profile(profile):
         cap = min(cap, arm_cap)
     return list(
         dict.fromkeys(
@@ -197,5 +213,10 @@ def effective_ytdlp_format(
     if mode == "manual" and explicit:
         return _arm_safe_if_needed(explicit, mode=mode, cap=cap)
 
-    out = _auto_provider_format(provider, cap, av1_allowed=_av1_allowed(profile))
+    out = _auto_provider_format(
+        provider,
+        cap,
+        av1_allowed=_av1_allowed(profile),
+        arm_safe=_arm_safe_profile(profile),
+    )
     return _arm_safe_if_needed(out, mode=mode, cap=cap)

--- a/docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md
+++ b/docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md
@@ -212,7 +212,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_PLAYBACK_START_TIMEOUT_SEC` | `player.py` | - | static env |
 | `RELAYTV_PLAYBACK_TRANSITION_SEC` | `player.py` | - | static env |
 | `RELAYTV_PLAYER_BACKEND` | `player.py` | - | static env |
-| `RELAYTV_PORT` | `discovery_mdns.py` | - | static env |
+| `RELAYTV_PORT` | `container_entrypoint.py`<br>`discovery_mdns.py` | - | entrypoint input |
 | `RELAYTV_QT_AUDIO_RECOVERY_COOLDOWN` | `player.py` | - | static env |
 | `RELAYTV_QT_AUDIO_WATCHDOG_INTERVAL` | `player.py` | - | static env |
 | `RELAYTV_QT_CURSOR_AUTOHIDE` | `qt_shell_app.py` | - | child process input |
@@ -283,7 +283,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_SPLASH_ARGS` | `player.py` | - | static env |
 | `RELAYTV_SPLASH_IMAGE` | `player.py` | - | static env |
 | `RELAYTV_SPLASH_X11` | `player.py` | - | static env |
-| `RELAYTV_STATE_DIR` | `state.py` | - | static env |
+| `RELAYTV_STATE_DIR` | `container_entrypoint.py`<br>`state.py` | - | entrypoint input |
 | `RELAYTV_STATIC_DIR` | `routes/assets.py` | - | static env |
 | `RELAYTV_STATUS_INCLUDE_MPV_LOG` | `routes/__init__.py` | - | static env |
 | `RELAYTV_SUB_LANG` | `config.py`<br>`player.py`<br>`routes/settings.py`<br>`state.py` | `routes/settings.py` | settings bus |

--- a/docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md
+++ b/docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md
@@ -212,7 +212,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_PLAYBACK_START_TIMEOUT_SEC` | `player.py` | - | static env |
 | `RELAYTV_PLAYBACK_TRANSITION_SEC` | `player.py` | - | static env |
 | `RELAYTV_PLAYER_BACKEND` | `player.py` | - | static env |
-| `RELAYTV_PORT` | `container_entrypoint.py`<br>`discovery_mdns.py` | - | entrypoint input |
+| `RELAYTV_PORT` | `container_entrypoint.py`<br>`discovery_mdns.py`<br>`routes/__init__.py` | - | entrypoint input |
 | `RELAYTV_QT_AUDIO_RECOVERY_COOLDOWN` | `player.py` | - | static env |
 | `RELAYTV_QT_AUDIO_WATCHDOG_INTERVAL` | `player.py` | - | static env |
 | `RELAYTV_QT_CURSOR_AUTOHIDE` | `qt_shell_app.py` | - | child process input |

--- a/docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md
+++ b/docs/ARCHITECTURE_PHASE_2_ENV_INVENTORY.md
@@ -229,6 +229,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_QT_EXTERNAL_WAYLAND_PROFILE` | `player.py` | - | static env |
 | `RELAYTV_QT_LIBMPV` | `qt_shell_app.py` | - | child process input |
 | `RELAYTV_QT_LIBMPV_FRAME_MS` | `qt_shell_app.py` | - | child process input |
+| `RELAYTV_QT_LIBMPV_PRESENT_GATE_TIMEOUT_SEC` | `qt_shell_app.py` | - | child process input |
 | `RELAYTV_QT_LIBMPV_TOPLEVEL_OVERLAY` | `qt_shell_app.py` | - | child process input |
 | `RELAYTV_QT_NATIVE_IDLE` | `qt_shell_app.py`<br>`routes/__init__.py` | - | child process input |
 | `RELAYTV_QT_NATIVE_IDLE_TOPLEVEL` | `qt_shell_app.py` | - | child process input |

--- a/docs/FLATPAK_OPERATIONS.md
+++ b/docs/FLATPAK_OPERATIONS.md
@@ -10,6 +10,31 @@ control, and mDNS discovery. Not included: headless Xvfb/x11vnc remote mode,
 the GTK/WebKitGTK X11 notification overlay (the Qt WebEngine overlay is used
 instead), and the Chromium idle browser.
 
+## arm64 validation status
+
+Do not promote the `aarch64`/arm64 Flatpak bundle as a recommended release
+path yet. Live Raspberry Pi 4B Wayland testing showed that the packaged
+runtime can start and play, but playback quality is still below release bar:
+
+- The successful render path on the tested host was Qt external mpv with
+  `--vo=wlshm`. The default OpenGL ES Wayland path
+  (`--vo=gpu --gpu-context=wayland --gpu-api=opengl --opengl-es=yes`) rendered
+  video but produced visible plaid/checker texture corruption. `--vo=dmabuf-wayland`
+  initialized but ended in audio-only playback with no configured video output.
+  `gpu-next`/Vulkan did not survive the playback health check.
+- YouTube playback had to avoid VP9/AV1 and prefer H.264. For the validation
+  URL, YouTube only exposed H.264 at 480p30, 720p60, and 1080p60; there was no
+  H.264 720p30 or 1080p30 variant. The ARM-safe selector therefore chose
+  H.264 480p30 (`itag=135`) rather than the overloaded 60fps variants.
+- Even on the degraded H.264 480p30 `wlshm` path, mpv still reported dropped
+  frames during the live run, so the arm64 Flatpak should remain experimental
+  until render smoothness is improved or hardware decode/render integration is
+  validated.
+
+The x86_64 Flatpak path remains the primary release target for this packaging
+profile. Prefer the Docker/native appliance install path for Raspberry Pi
+deployments until arm64 Flatpak validation is re-run and documented.
+
 ## Install
 
 Download the bundle for your architecture from the GitHub Release assets and

--- a/docs/FLATPAK_OPERATIONS.md
+++ b/docs/FLATPAK_OPERATIONS.md
@@ -67,6 +67,11 @@ RELAYTV_MODE=wayland
 `RELAYTV_PORT` changes the HTTP port (default 8787); the launcher re-derives
 the Qt overlay and idle URLs automatically.
 
+If audio lands on the wrong output (e.g. a USB DAC instead of the TV), pin
+the HDMI sink in the web UI's audio-device setting or via the API — with the
+device on auto, RelayTV prefers an HDMI ALSA output detected through the
+bundled `aplay`, falling back to the session default sink.
+
 ## Data locations
 
 Everything persistent lives in the app's private data dir on the host:
@@ -101,10 +106,17 @@ systemd user unit ordered after the graphical session:
 Description=RelayTV
 After=graphical-session.target
 PartOf=graphical-session.target
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 [Service]
-ExecStart=flatpak run io.github.mcgeezy.relaytv
+ExecStart=/usr/bin/flatpak run io.github.mcgeezy.relaytv
+# flatpak instances live in their own transient scope outside this service's
+# cgroup; without an explicit kill, stop/restart leaves the old instance
+# running and the unit crash-loops on the busy port.
+ExecStop=/usr/bin/flatpak kill io.github.mcgeezy.relaytv
 Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=graphical-session.target

--- a/docs/FLATPAK_OPERATIONS.md
+++ b/docs/FLATPAK_OPERATIONS.md
@@ -1,0 +1,146 @@
+# Flatpak Operations
+
+RelayTV ships as a single-file Flatpak bundle attached to each GitHub Release,
+alongside the Docker image. The Flatpak runs the same server + Qt shell + mpv
+stack directly on the host session — no Docker required.
+
+**Scope (v1):** core playback (Wayland/X11 Qt shell, mpv/libmpv, YouTube via
+yt-dlp + deno, Jellyfin/Emby, direct URLs), audio, GPU decode, HDMI-CEC
+control, and mDNS discovery. Not included: headless Xvfb/x11vnc remote mode,
+the GTK/WebKitGTK X11 notification overlay (the Qt WebEngine overlay is used
+instead), and the Chromium idle browser.
+
+## Install
+
+Download the bundle for your architecture from the GitHub Release assets and
+install it user-level:
+
+```sh
+flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak install --user -y ./relaytv-vX.Y.Z-x86_64.flatpak
+```
+
+The flathub remote is needed once so the `org.freedesktop.Platform` runtime
+dependency can be resolved. Updating means installing the bundle from a newer
+release the same way.
+
+Run it:
+
+```sh
+flatpak run io.github.mcgeezy.relaytv
+```
+
+The web UI comes up on `http://<host>:8787/` by default.
+
+## Permissions
+
+The bundle requests:
+
+| Permission | Why |
+| --- | --- |
+| `--share=network` | HTTP API/UI on the configured port; zeroconf/mDNS multicast discovery |
+| `--socket=wayland`, `--socket=fallback-x11`, `--share=ipc` | Qt shell + mpv on the host display session |
+| `--socket=pulseaudio` | Audio output (PulseAudio/PipeWire) |
+| `--device=all` | GPU decode (`/dev/dri`), ALSA enumeration (`/dev/snd`), HDMI-CEC (`/dev/cec*`) |
+| `--filesystem=/run/udev:ro` | Device metadata for the devices inventory |
+
+`--device=all` is the broad Flatpak device grant; it is required because CEC
+device nodes cannot be granted individually. Trim it to `--device=dri` with a
+`flatpak override` if you do not use CEC.
+
+## Configuration
+
+The Flatpak analog of the Docker `.env` file is:
+
+```
+~/.var/app/io.github.mcgeezy.relaytv/config/relaytv/env
+```
+
+Plain `KEY=value` lines, exported into the app at launch. All `RELAYTV_*`
+variables documented for the Docker runtime work here too. Example:
+
+```sh
+RELAYTV_PORT=8790
+RELAYTV_MODE=wayland
+```
+
+`RELAYTV_PORT` changes the HTTP port (default 8787); the launcher re-derives
+the Qt overlay and idle URLs automatically.
+
+## Data locations
+
+Everything persistent lives in the app's private data dir on the host:
+
+```
+~/.var/app/io.github.mcgeezy.relaytv/data/    # settings.json, queue, history, assets/
+├── thumbs/                                   # thumbnail cache
+└── uploads/                                  # uploaded media
+```
+
+Back up or reset state by copying or clearing that directory while the app is
+stopped. `flatpak uninstall --delete-data io.github.mcgeezy.relaytv` removes
+it all.
+
+## yt-dlp updates
+
+The bundle pins yt-dlp at build time and disables the pip self-update path by
+default (the sandbox has no supported pip-user flow). If YouTube playback
+breaks between releases, install the bundle from a newer release. Setting
+`RELAYTV_YTDLP_AUTO_UPDATE=1` in the env file re-enables the updater — pip
+installs land in the writable app HOME and usually work, but this path is
+unsupported in the Flatpak.
+
+## Autostart on boot
+
+The flatpak does not install a service. For appliance-style bring-up, create a
+systemd user unit ordered after the graphical session:
+
+```ini
+# ~/.config/systemd/user/relaytv.service
+[Unit]
+Description=RelayTV
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+ExecStart=flatpak run io.github.mcgeezy.relaytv
+Restart=on-failure
+
+[Install]
+WantedBy=graphical-session.target
+```
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now relaytv.service
+```
+
+## Coexistence with the Docker install
+
+Both runtimes default to port 8787 and will conflict if run simultaneously on
+one host. Either stop the Docker container (`docker compose down`) before
+running the Flatpak, or move the Flatpak to another port with `RELAYTV_PORT`
+in the env file. They keep separate state (Docker: `./data`; Flatpak:
+`~/.var/app/.../data`) — settings are not shared.
+
+## Building locally
+
+```sh
+flatpak install --user -y flathub org.flatpak.Builder \
+  org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+flatpak run org.flatpak.Builder --user --install --force-clean --ccache \
+  builddir packaging/flatpak/io.github.mcgeezy.relaytv.yml
+```
+
+Add `--disable-rofiles-fuse` if the build fails with a `rofiles-fuse` /
+`fusermount` error (host FUSE incompatibility). To produce a distributable
+bundle from the build:
+
+```sh
+flatpak build-bundle ~/.local/share/flatpak/repo relaytv-x86_64.flatpak \
+  io.github.mcgeezy.relaytv
+```
+
+CI builds the bundle on every PR touching `packaging/flatpak/**` or `app/**`
+(`.github/workflows/flatpak.yml`) and attaches `x86_64` + `aarch64` bundles to
+each GitHub Release (`.github/workflows/release-please.yml`).

--- a/docs/FLATPAK_OPERATIONS.md
+++ b/docs/FLATPAK_OPERATIONS.md
@@ -89,11 +89,16 @@ it all.
 ## yt-dlp updates
 
 The bundle pins yt-dlp at build time and disables the pip self-update path by
-default (the sandbox has no supported pip-user flow). If YouTube playback
-breaks between releases, install the bundle from a newer release. Setting
-`RELAYTV_YTDLP_AUTO_UPDATE=1` in the env file re-enables the updater — pip
-installs land in the writable app HOME and usually work, but this path is
-unsupported in the Flatpak.
+default. The runtime's Python ships without pip, so the updater cannot work
+inside the sandbox at all: if it runs anyway it fails cleanly with
+`No module named pip` and retries on its normal interval. If YouTube playback
+breaks between releases, install the bundle from a newer release.
+
+Note for state migrated from a Docker install: the `ytdlp_auto_update_enabled`
+setting in `settings.json` overrides the launcher's env default, so a Docker
+deployment that had the updater on will keep attempting (and failing) the
+update under the Flatpak. Turn the yt-dlp auto-update toggle off in Settings
+to silence it.
 
 ## Toast overlay mode
 

--- a/docs/FLATPAK_OPERATIONS.md
+++ b/docs/FLATPAK_OPERATIONS.md
@@ -95,6 +95,20 @@ breaks between releases, install the bundle from a newer release. Setting
 installs land in the writable app HOME and usually work, but this path is
 unsupported in the Flatpak.
 
+## Toast overlay mode
+
+Flatpak defaults toast notifications to the browser overlay:
+
+```sh
+RELAYTV_QT_NATIVE_TOASTS=0
+RELAYTV_QT_NATIVE_TOASTS_TOPLEVEL=0
+```
+
+Native Qt toast surfaces remain override-only because both top-level and child
+Qt surfaces can disturb fullscreen compositor state or stall embedded libmpv
+video on Wayland. Set `RELAYTV_QT_NATIVE_TOASTS=1` only for diagnostics. The
+Flatpak does not fall back to mpv OSD notifications.
+
 ## Autostart on boot
 
 The flatpak does not install a service. For appliance-style bring-up, create a

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,6 +4,11 @@ RelayTV supports a native Qt desktop runtime by default. Rollback for a broken
 runtime rollout is a tagged-baseline redeploy, not a parallel compatibility
 runtime.
 
+Docker is the primary install path (below). A host-native Flatpak bundle also
+ships with each GitHub Release — see
+[FLATPAK_OPERATIONS.md](FLATPAK_OPERATIONS.md) for that path and its current
+limitations.
+
 Supported default product profiles:
 
 - Wayland desktop: native Qt

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Use this directory as a small operator/product doc set for the public release br
 ## Primary Docs
 
 - `INSTALL.md`: installation, first boot, and environment defaults
+- `FLATPAK_OPERATIONS.md`: host-native Flatpak install, permissions, configuration, and limitations
 - `API.md`: HTTP endpoint reference
 - `JELLYFIN_OPERATIONS.md`: Jellyfin runtime config, verification, troubleshooting
 - `NATIVE_RUNTIME_OPERATIONS.md`: runtime operations, readiness checks, logging, and soak workflow

--- a/packaging/flatpak/io.github.mcgeezy.relaytv.desktop
+++ b/packaging/flatpak/io.github.mcgeezy.relaytv.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=RelayTV
+Comment=Local-first TV playback and automation endpoint
+Exec=relaytv-launch.sh
+Icon=io.github.mcgeezy.relaytv
+Terminal=false
+Categories=AudioVideo;Video;Player;Network;
+Keywords=tv;cast;mpv;youtube;jellyfin;

--- a/packaging/flatpak/io.github.mcgeezy.relaytv.metainfo.xml
+++ b/packaging/flatpak/io.github.mcgeezy.relaytv.metainfo.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.mcgeezy.relaytv</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  <name>RelayTV</name>
+  <summary>Local-first TV playback and automation endpoint</summary>
+  <description>
+    <p>
+      RelayTV turns a Linux box plugged into a TV into a local-first playback
+      appliance: a web UI and HTTP API drive fullscreen mpv playback of
+      YouTube, Jellyfin/Emby, and direct media URLs, with queueing, HDMI-CEC
+      TV control, and mDNS discovery on the local network.
+    </p>
+  </description>
+  <launchable type="desktop-id">io.github.mcgeezy.relaytv.desktop</launchable>
+  <url type="homepage">https://github.com/mcgeezy/relaytv</url>
+  <url type="bugtracker">https://github.com/mcgeezy/relaytv/issues</url>
+  <developer id="io.github.mcgeezy">
+    <name>mcgeezy</name>
+  </developer>
+  <categories>
+    <category>AudioVideo</category>
+    <category>Video</category>
+  </categories>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.5.0" date="2026-07-05"/>
+  </releases>
+</component>

--- a/packaging/flatpak/io.github.mcgeezy.relaytv.yml
+++ b/packaging/flatpak/io.github.mcgeezy.relaytv.yml
@@ -129,6 +129,22 @@ modules:
         dest-filename: deno.zip
         only-arches: [aarch64]
 
+  # devices.detect_audio_device() enumerates HDMI outputs via `aplay -L`;
+  # without it mpv falls back to the session default sink, which on most
+  # TV appliances is not the HDMI output.
+  - name: alsa-utils
+    buildsystem: autotools
+    config-opts:
+      - --disable-alsamixer
+      - --disable-xmlto
+      - --disable-nls
+      - --with-udev-rules-dir=/app/lib/udev/rules.d
+    sources:
+      # Keep in lockstep with the runtime's alsa-lib version.
+      - type: archive
+        url: https://www.alsa-project.org/files/pub/utils/alsa-utils-1.2.14.tar.bz2
+        sha256: 0794c74d33fed943e7c50609c13089e409312b6c403d6ae8984fc429c0960741
+
   # PySide6's Qt libraries link libgssapi_krb5 and libpcsclite, which the
   # freedesktop runtime does not ship — bundle both client libraries.
   - name: krb5

--- a/packaging/flatpak/io.github.mcgeezy.relaytv.yml
+++ b/packaging/flatpak/io.github.mcgeezy.relaytv.yml
@@ -1,0 +1,202 @@
+app-id: io.github.mcgeezy.relaytv
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+command: relaytv-launch.sh
+separate-locales: false
+
+finish-args:
+  # HTTP API on RELAYTV_PORT (default 8787) + zeroconf/mDNS multicast; host netns.
+  - --share=network
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  # /dev/dri (GPU decode), /dev/snd (ALSA enumeration/output), /dev/cec* (HDMI-CEC).
+  - --device=all
+  # Device metadata used by devices.py enumeration.
+  - --filesystem=/run/udev:ro
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /lib/cmake
+  - /share/man
+  - /share/doc
+  - '*.la'
+  - '*.a'
+
+modules:
+  - name: p8-platform
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      # 2016-era CMakeLists predates the minimum policy CMake 4.x accepts.
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    sources:
+      - type: archive
+        url: https://github.com/Pulse-Eight/platform/archive/refs/tags/p8-platform-2.1.0.1.tar.gz
+        sha256: 064f8d2c358895c7e0bea9ae956f8d46f3f057772cb97f2743a11d478a0f68a0
+
+  - name: libcec
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_PREFIX_PATH=/app
+      - -DSKIP_PYTHON_WRAPPER=ON
+    sources:
+      - type: archive
+        url: https://github.com/Pulse-Eight/libcec/archive/refs/tags/libcec-7.1.1.tar.gz
+        sha256: 7f7da95a4c1e7160d42ca37a3ac80cf6f389b317e14816949e0fa5e2edf4cc64
+
+  # mpv's ytdl_hook (all YouTube live/post-live playback) is a Lua script.
+  - name: luajit
+    buildsystem: simple
+    build-commands:
+      - make -j"$FLATPAK_BUILDER_N_JOBS" PREFIX=/app amalg
+      - make PREFIX=/app install
+    sources:
+      - type: archive
+        url: https://github.com/openresty/luajit2/archive/refs/tags/v2.1-20250826.tar.gz
+        sha256: 5a49743ad6ce4b7f19aac71b55a08052c1feb62750f051982082c12bf62f39c0
+
+  - name: libass
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/libass/libass/releases/download/0.17.5/libass-0.17.5.tar.xz
+        sha256: 2dca25c0e0c837ddf00b52011b3f82cac1e4ddd3ad018227806b0c2288864acc
+
+  # Build-time dependency of libplacebo's GLSL preprocessor.
+  - name: python3-jinja2
+    buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
+    build-commands:
+      - pip3 install --prefix=/app --no-cache-dir jinja2
+    sources: []
+
+  - name: libplacebo
+    buildsystem: meson
+    build-options:
+      env:
+        PYTHONPATH: /app/lib/python3.13/site-packages
+    config-opts:
+      - -Ddemos=false
+      - -Dtests=false
+    sources:
+      - type: archive
+        url: https://github.com/haasn/libplacebo/archive/refs/tags/v7.360.1.tar.gz
+        sha256: d05fdf90bea2f629eaa2d115e909fd356388ac639e54f77b87a018a6d76224bd
+      # The glad submodule pinned by the v7.360.1 tag, unpacked in place so no
+      # git/submodule access is needed at build time.
+      - type: archive
+        url: https://github.com/Dav1dde/glad/archive/73db193f853e2ee079bf3ca8a64aa2eaf6459043.tar.gz
+        sha256: 33dbeae44d8315ece57e14eba4b1b4a02ac5406d1c4f49cd20048c91522a6b9a
+        dest: 3rdparty/glad
+
+  # FFmpeg libs, headers, and the ffmpeg/ffprobe CLIs (thumb_cache,
+  # video_profile) come from the freedesktop runtime itself.
+
+  # Both the mpv binary (subprocess fallback) and libmpv (Qt shell ctypes).
+  - name: mpv
+    buildsystem: meson
+    config-opts:
+      - -Dlibmpv=true
+      - -Dlua=luajit
+    sources:
+      - type: archive
+        url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.41.0.tar.gz
+        sha256: ee21092a5ee427353392360929dc64645c54479aefdb5babc5cfbb5fad626209
+
+  # yt-dlp's sandboxed JavaScript runtime for YouTube challenge solving,
+  # pinned to the same version + checksums as app/Dockerfile.
+  - name: deno
+    buildsystem: simple
+    build-commands:
+      - python3 -m zipfile -e deno.zip /app/bin/
+      - chmod 0755 /app/bin/deno
+    sources:
+      - type: file
+        url: https://github.com/denoland/deno/releases/download/v2.9.1/deno-x86_64-unknown-linux-gnu.zip
+        sha256: 710c54d63477d1100844ef4818f19507ce0dbf40510903b1d883f19e394446a2
+        dest-filename: deno.zip
+        only-arches: [x86_64]
+      - type: file
+        url: https://github.com/denoland/deno/releases/download/v2.9.1/deno-aarch64-unknown-linux-gnu.zip
+        sha256: 0a60d079fa79635a59803074dbbfe86ccc35746dc2c4f8d73f2e50338b3283a9
+        dest-filename: deno.zip
+        only-arches: [aarch64]
+
+  # PySide6's Qt libraries link libgssapi_krb5 and libpcsclite, which the
+  # freedesktop runtime does not ship — bundle both client libraries.
+  - name: krb5
+    subdir: src
+    config-opts:
+      - --disable-static
+      - --disable-rpath
+      - --localstatedir=/app/var/lib
+    cleanup:
+      - /bin
+      - /share/et
+      - /share/examples
+      - /var
+    sources:
+      - type: archive
+        url: https://kerberos.org/dist/krb5/1.22/krb5-1.22.2.tar.gz
+        sha256: 3243ffbc8ea4d4ac22ddc7dd2a1dc54c57874c40648b60ff97009763554eaf13
+
+  - name: pcsc-lite
+    buildsystem: meson
+    config-opts:
+      - -Dlibudev=false
+      - -Dlibusb=false
+      - -Dpolkit=false
+      - -Dusb=false
+      - -Dserial=false
+      # Avoids the hard `systemd` pkg-config dependency for unit-dir lookup.
+      - -Dlibsystemd=false
+    cleanup:
+      - /bin
+      - /sbin
+      - /etc
+      - /lib/systemd
+    sources:
+      - type: archive
+        url: https://pcsclite.apdu.fr/files/pcsc-lite-2.5.1.tar.xz
+        sha256: bfcfe38a20afc49849c6bf55325e38f449fc4b26d3923fdc32b969ae41a8741b
+
+  # Pinned Python deps (PySide6 wheels bundle Qt6 incl. WebEngine). Network is
+  # enabled for pip; move to flatpak-pip-generator lockfiles for Flathub.
+  - name: python-deps
+    buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
+    build-commands:
+      - pip3 install --prefix=/app --no-cache-dir -r requirements.txt
+    sources:
+      - type: file
+        path: requirements.txt
+
+  - name: relaytv
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/relaytv
+      - cp -r app/relaytv_app /app/relaytv/
+      - install -Dm0755 packaging/flatpak/relaytv-launch.sh /app/bin/relaytv-launch.sh
+      - install -Dm0644 packaging/flatpak/io.github.mcgeezy.relaytv.desktop
+        /app/share/applications/io.github.mcgeezy.relaytv.desktop
+      - install -Dm0644 packaging/flatpak/io.github.mcgeezy.relaytv.metainfo.xml
+        /app/share/metainfo/io.github.mcgeezy.relaytv.metainfo.xml
+      - install -Dm0644 app/relaytv_app/static/brand/logo.svg
+        /app/share/icons/hicolor/scalable/apps/io.github.mcgeezy.relaytv.svg
+    sources:
+      - type: dir
+        path: ../..
+        skip:
+          - .git
+          - .flatpak-builder
+          - build-dir
+          - data

--- a/packaging/flatpak/io.github.mcgeezy.relaytv.yml
+++ b/packaging/flatpak/io.github.mcgeezy.relaytv.yml
@@ -183,6 +183,42 @@ modules:
         url: https://pcsclite.apdu.fr/files/pcsc-lite-2.5.1.tar.xz
         sha256: bfcfe38a20afc49849c6bf55325e38f449fc4b26d3923fdc32b969ae41a8741b
 
+  # Additional shared libraries required by PySide6's QtWebEngine wheels.
+  # Missing these causes the Flatpak idle/program web surface to disable itself
+  # and leave only the host desktop visible.
+  - name: snappy
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DSNAPPY_BUILD_TESTS=OFF
+      - -DSNAPPY_BUILD_BENCHMARKS=OFF
+      - -DSNAPPY_INSTALL=ON
+    cleanup:
+      - /include
+      - /lib/cmake
+    sources:
+      - type: archive
+        url: https://github.com/google/snappy/archive/refs/tags/1.2.2.tar.gz
+        sha256: 90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc
+
+  - name: minizip
+    buildsystem: simple
+    build-commands:
+      - cd contrib/minizip && autoreconf -fi
+      - cd contrib/minizip && ./configure --prefix=/app --disable-static
+      - make -C contrib/minizip -j"$FLATPAK_BUILDER_N_JOBS"
+      - make -C contrib/minizip install
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+    sources:
+      - type: archive
+        url: https://zlib.net/fossils/zlib-1.3.1.tar.gz
+        sha256: 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+
   # Pinned Python deps (PySide6 wheels bundle Qt6 incl. WebEngine). Network is
   # enabled for pip; move to flatpak-pip-generator lockfiles for Flathub.
   - name: python-deps

--- a/packaging/flatpak/relaytv-launch.sh
+++ b/packaging/flatpak/relaytv-launch.sh
@@ -14,6 +14,30 @@ if [ -f "$ENV_FILE" ]; then
   set +a
 fi
 
+# When started from SSH/TTY, Flatpak still exposes the desktop sockets but the
+# caller may not provide display env. Fill only missing/TTY-derived values so
+# explicit user config remains authoritative.
+if [ -z "${WAYLAND_DISPLAY:-}" ] && [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+  for relaytv_wayland_socket in "$XDG_RUNTIME_DIR"/wayland-*; do
+    if [ -S "$relaytv_wayland_socket" ]; then
+      export WAYLAND_DISPLAY="$(basename "$relaytv_wayland_socket")"
+      break
+    fi
+  done
+  unset relaytv_wayland_socket
+fi
+if [ -n "${WAYLAND_DISPLAY:-}" ]; then
+  if [ -z "${XDG_SESSION_TYPE:-}" ] || [ "${XDG_SESSION_TYPE:-}" = "tty" ]; then
+    export XDG_SESSION_TYPE=wayland
+  fi
+  if [ -z "${RELAYTV_HOST_SESSION_TYPE:-}" ] || [ "${RELAYTV_HOST_SESSION_TYPE:-}" = "tty" ]; then
+    export RELAYTV_HOST_SESSION_TYPE=wayland
+  fi
+  export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-wayland}"
+  export RELAYTV_MODE="${RELAYTV_MODE:-wayland}"
+  export RELAYTV_QT_RUNTIME_MODE="${RELAYTV_QT_RUNTIME_MODE:-auto}"
+fi
+
 # Persistent state lives in the app's private XDG data dir
 # (~/.var/app/io.github.mcgeezy.relaytv/data on the host).
 : "${RELAYTV_STATE_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}}"

--- a/packaging/flatpak/relaytv-launch.sh
+++ b/packaging/flatpak/relaytv-launch.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# RelayTV Flatpak launcher: maps the sandbox environment onto the same
+# env-driven configuration surface the Docker runtime uses, then hands off
+# to the shared container_entrypoint supervisor.
+set -eu
+
+# Optional user overrides (Flatpak analog of the Docker .env file):
+# ~/.var/app/io.github.mcgeezy.relaytv/config/relaytv/env
+ENV_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/relaytv/env"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+
+# Persistent state lives in the app's private XDG data dir
+# (~/.var/app/io.github.mcgeezy.relaytv/data on the host).
+: "${RELAYTV_STATE_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}}"
+export RELAYTV_STATE_DIR
+export RELAYTV_THUMB_DIR="${RELAYTV_THUMB_DIR:-$RELAYTV_STATE_DIR/thumbs}"
+export RELAYTV_UPLOADS_DIR="${RELAYTV_UPLOADS_DIR:-$RELAYTV_STATE_DIR/uploads}"
+
+# yt-dlp ships pinned in the bundle; the pip self-update path is off unless
+# explicitly re-enabled in the env file.
+export RELAYTV_YTDLP_AUTO_UPDATE="${RELAYTV_YTDLP_AUTO_UPDATE:-0}"
+
+export RELAYTV_PORT="${RELAYTV_PORT:-8787}"
+if [ "$RELAYTV_PORT" != "8787" ]; then
+  export RELAYTV_QT_OVERLAY_URL="${RELAYTV_QT_OVERLAY_URL:-http://127.0.0.1:$RELAYTV_PORT/x11/overlay}"
+  export RELAYTV_OVERLAY_URL="${RELAYTV_OVERLAY_URL:-http://127.0.0.1:$RELAYTV_PORT/x11/overlay}"
+  export RELAYTV_IDLE_URL="${RELAYTV_IDLE_URL:-http://127.0.0.1:$RELAYTV_PORT/idle}"
+fi
+
+# Chromium's own sandbox cannot nest inside the Flatpak sandbox; the Flatpak
+# provides the confinement (standard for pip-wheel QtWebEngine in Flatpak).
+export QTWEBENGINE_CHROMIUM_FLAGS="${QTWEBENGINE_CHROMIUM_FLAGS:---no-sandbox}"
+
+# App package plus pip-installed deps (path varies with the runtime Python).
+SITE_PACKAGES="$(ls -d /app/lib/python3.*/site-packages 2>/dev/null | head -n 1 || true)"
+export PYTHONPATH="/app/relaytv${SITE_PACKAGES:+:$SITE_PACKAGES}${PYTHONPATH:+:$PYTHONPATH}"
+
+exec python3 -m relaytv_app.container_entrypoint "$@"

--- a/packaging/flatpak/relaytv-launch.sh
+++ b/packaging/flatpak/relaytv-launch.sh
@@ -36,6 +36,12 @@ fi
 # provides the confinement (standard for pip-wheel QtWebEngine in Flatpak).
 export QTWEBENGINE_CHROMIUM_FLAGS="${QTWEBENGINE_CHROMIUM_FLAGS:---no-sandbox}"
 
+# Flatpak Wayland/libmpv stacks can freeze or black out video when a native Qt
+# toast surface is raised over playback. Keep native toasts override-only and
+# use the browser overlay notification path by default.
+export RELAYTV_QT_NATIVE_TOASTS="${RELAYTV_QT_NATIVE_TOASTS:-0}"
+export RELAYTV_QT_NATIVE_TOASTS_TOPLEVEL="${RELAYTV_QT_NATIVE_TOASTS_TOPLEVEL:-0}"
+
 # App package plus pip-installed deps (path varies with the runtime Python).
 SITE_PACKAGES="$(ls -d /app/lib/python3.*/site-packages 2>/dev/null | head -n 1 || true)"
 export PYTHONPATH="/app/relaytv${SITE_PACKAGES:+:$SITE_PACKAGES}${PYTHONPATH:+:$PYTHONPATH}"

--- a/packaging/flatpak/requirements.txt
+++ b/packaging/flatpak/requirements.txt
@@ -1,0 +1,8 @@
+# Pinned to the same versions as the published Docker image; bump alongside it.
+fastapi==0.139.0
+uvicorn[standard]==0.50.0
+python-multipart==0.0.32
+yt-dlp==2026.7.4
+zeroconf==0.150.0
+qrcode==8.2
+PySide6==6.11.1

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -328,6 +328,31 @@ def test_entrypoint_preserves_explicit_pi_mpv_args(monkeypatch: pytest.MonkeyPat
     assert env["RELAYTV_QT_SHELL_MPV_ARGS"] == ""
 
 
+def test_qt_shell_ensures_c_numeric_locale_for_libmpv() -> None:
+    import locale
+
+    qt_shell_app._ensure_c_numeric_locale()
+    assert locale.setlocale(locale.LC_NUMERIC) == "C"
+    assert locale.localeconv()["decimal_point"] == "."
+
+
+def test_flatpak_launcher_disables_native_qt_toasts_by_default() -> None:
+    text = (ROOT_DIR / "packaging/flatpak/relaytv-launch.sh").read_text()
+
+    assert 'RELAYTV_QT_NATIVE_TOASTS="${RELAYTV_QT_NATIVE_TOASTS:-0}"' in text
+    assert 'RELAYTV_QT_NATIVE_TOASTS_TOPLEVEL="${RELAYTV_QT_NATIVE_TOASTS_TOPLEVEL:-0}"' in text
+
+
+def test_qt_native_toasts_stack_inside_main_window_for_libmpv() -> None:
+    text = (ROOT_DIR / "app/relaytv_app/qt_shell_app.py").read_text()
+
+    assert "elif use_libmpv or overlay_parent_is_main_window:" in text
+    assert "native_toast_parent_is_main_window = True" in text
+    assert "native_toast_host.setAttribute(Qt.WA_AlwaysStackOnTop, True)" in text
+    assert "def fit_to_bounds(self, bounds) -> None:" in text
+    assert "native_toast_host.fit_to_bounds(win.rect())" in text
+
+
 def test_entrypoint_state_dir_precedence() -> None:
     assert container_entrypoint._state_dir({"RELAYTV_STATE_DIR": "/var/lib/relaytv"}) == Path("/var/lib/relaytv")
     assert container_entrypoint._state_dir({"BRAVECAST_STATE_DIR": "/legacy"}) == Path("/legacy")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -353,6 +353,17 @@ def test_qt_shell_initial_load_waits_for_presentation() -> None:
     assert "video_widget.frameSwapped.connect" in text
 
 
+def test_qt_shell_remaps_window_that_never_exposed() -> None:
+    # Boot-time mapping can corrupt mutter stacking (stack_position assertion)
+    # leaving the window permanently unexposed: black screen until re-mapped.
+    text = (ROOT_DIR / "app/relaytv_app/qt_shell_app.py").read_text()
+
+    assert "def _exposure_watchdog() -> None:" in text
+    assert "remapping fullscreen window" in text
+    assert 'exposure_state = {"ever_exposed": False, "remaps": 0}' in text
+    assert 'exposure_state["remaps"] >= 5' in text
+
+
 def test_qt_shell_initial_load_gate_timeout_covers_boot(monkeypatch: pytest.MonkeyPatch) -> None:
     # Boot can take well over the render-context wait; the fallback that
     # loads anyway must stay far enough out that a booting compositor

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -328,6 +328,49 @@ def test_entrypoint_preserves_explicit_pi_mpv_args(monkeypatch: pytest.MonkeyPat
     assert env["RELAYTV_QT_SHELL_MPV_ARGS"] == ""
 
 
+def test_entrypoint_state_dir_precedence() -> None:
+    assert container_entrypoint._state_dir({"RELAYTV_STATE_DIR": "/var/lib/relaytv"}) == Path("/var/lib/relaytv")
+    assert container_entrypoint._state_dir({"BRAVECAST_STATE_DIR": "/legacy"}) == Path("/legacy")
+    assert container_entrypoint._state_dir(
+        {"RELAYTV_STATE_DIR": "/new", "BRAVECAST_STATE_DIR": "/legacy"}
+    ) == Path("/new")
+    assert container_entrypoint._state_dir({}) == Path("/data")
+    assert container_entrypoint._state_dir({"RELAYTV_STATE_DIR": "  "}) == Path("/data")
+
+
+def test_entrypoint_brand_asset_seed_honors_state_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("RELAYTV_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("BRAVECAST_STATE_DIR", raising=False)
+
+    container_entrypoint._sync_legacy_brand_assets()
+
+    assets = tmp_path / "assets"
+    assert assets.is_dir()
+    assert (assets / "logo.svg").is_file()
+
+
+def test_entrypoint_ytdlp_update_state_path_anchors_at_state_dir() -> None:
+    env = {"RELAYTV_STATE_DIR": "/var/lib/relaytv"}
+    assert container_entrypoint._ytdlp_update_state_path(env) == Path(
+        "/var/lib/relaytv/.relaytv-ytdlp-update.json"
+    )
+    env["RELAYTV_YTDLP_AUTO_UPDATE_STATE_FILE"] = "custom.json"
+    assert container_entrypoint._ytdlp_update_state_path(env) == Path("/var/lib/relaytv/custom.json")
+    env["RELAYTV_YTDLP_AUTO_UPDATE_STATE_FILE"] = "/abs/state.json"
+    assert container_entrypoint._ytdlp_update_state_path(env) == Path("/abs/state.json")
+    assert container_entrypoint._ytdlp_update_state_path({}) == Path("/data/.relaytv-ytdlp-update.json")
+
+
+def test_entrypoint_server_port_honors_relaytv_port() -> None:
+    assert container_entrypoint._server_port({}) == 8787
+    assert container_entrypoint._server_port({"RELAYTV_PORT": "8790"}) == 8790
+    assert container_entrypoint._server_port({"RELAYTV_PORT": "bogus"}) == 8787
+    assert container_entrypoint._server_port({"RELAYTV_PORT": "0"}) == 8787
+    assert container_entrypoint._server_port({"RELAYTV_PORT": "70000"}) == 8787
+
+
 def test_entrypoint_enables_headless_remote_from_mode() -> None:
     env = {"RELAYTV_MODE": "headless"}
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -388,6 +388,19 @@ def test_flatpak_launcher_disables_native_qt_toasts_by_default() -> None:
     assert 'RELAYTV_QT_NATIVE_TOASTS_TOPLEVEL="${RELAYTV_QT_NATIVE_TOASTS_TOPLEVEL:-0}"' in text
 
 
+def test_flatpak_launcher_detects_wayland_socket_for_tty_launches() -> None:
+    text = (ROOT_DIR / "packaging/flatpak/relaytv-launch.sh").read_text()
+
+    assert '"$XDG_RUNTIME_DIR"/wayland-*' in text
+    assert 'export WAYLAND_DISPLAY="$(basename "$relaytv_wayland_socket")"' in text
+    assert '[ "${XDG_SESSION_TYPE:-}" = "tty" ]' in text
+    assert "export XDG_SESSION_TYPE=wayland" in text
+    assert "export RELAYTV_HOST_SESSION_TYPE=wayland" in text
+    assert 'QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-wayland}"' in text
+    assert 'RELAYTV_MODE="${RELAYTV_MODE:-wayland}"' in text
+    assert 'RELAYTV_QT_RUNTIME_MODE="${RELAYTV_QT_RUNTIME_MODE:-auto}"' in text
+
+
 def test_qt_native_toasts_stack_inside_main_window_for_libmpv() -> None:
     text = (ROOT_DIR / "app/relaytv_app/qt_shell_app.py").read_text()
 
@@ -1611,7 +1624,7 @@ def test_pwa_brand_banner_png_asset_resolves_with_logo_fallback() -> None:
     assert response.headers['content-type'].startswith(('image/png', 'image/svg+xml'))
 
 
-def test_pi_ytdlp_defaults_prefer_1080p_non_av1_without_progressive_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_pi_ytdlp_defaults_prefer_1080p_h264_without_progressive_stage(monkeypatch: pytest.MonkeyPatch) -> None:
     for key in (
         'YTDLP_FORMAT',
         'YTDLP_FORMAT_YOUTUBE',
@@ -1626,7 +1639,14 @@ def test_pi_ytdlp_defaults_prefer_1080p_non_av1_without_progressive_stage(monkey
     youtube_fmt = ytdlp_format_policy.effective_ytdlp_format({}, provider='youtube', profile=profile)
     rumble_fmt = ytdlp_format_policy.effective_ytdlp_format({}, provider='rumble', profile=profile)
 
-    assert youtube_fmt == 'bestvideo[vcodec!*=av01][height<=1080][fps<=60]+bestaudio/best[vcodec!*=av01][height<=1080]/best'
+    assert youtube_fmt == (
+        'bestvideo[vcodec^=avc1][height<=1080][fps<=30]+bestaudio[acodec^=mp4a]/'
+        'bestvideo[vcodec^=avc1][height<=1080][fps<=30]+bestaudio/'
+        'best*[vcodec^=avc1][height<=1080][fps<=30]/'
+        'best[height<=1080][fps<=30][vcodec^=avc1]/'
+        'best[height<=1080]/best'
+    )
+    assert 'vcodec!*=av01' not in youtube_fmt
     assert rumble_fmt == 'best*[height<=1080][fps<=60]/best*[height<=1080]/best[height<=1080][fps<=60]/best'
     assert ytdlp_format_policy.youtube_progressive_startup_enabled(profile) is False
 
@@ -1641,6 +1661,17 @@ def test_pi_ytdlp_safe_selector_remains_opt_in(monkeypatch: pytest.MonkeyPatch) 
     fmt = ytdlp_format_policy.effective_ytdlp_format({}, provider='youtube', profile=profile)
 
     assert fmt == 'best[height<=1080][fps<=30][vcodec^=avc1]/best[height<=1080][fps<=30]/best[height<=1080]/best'
+
+
+def test_pi_ytdlp_migrates_old_generated_non_av1_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv('YTDLP_FORMAT', raising=False)
+    monkeypatch.setattr('relaytv_app.state.platform.machine', lambda: 'aarch64')
+    old = 'bestvideo[vcodec!*=av01][height<=1080][fps<=60]+bestaudio/best[vcodec!*=av01][height<=1080]/best'
+
+    migrated = state._migrate_generated_ytdlp_default(old, 'auto_profile')
+
+    assert 'vcodec^=avc1' in migrated
+    assert 'vcodec!*=av01' not in migrated
 
 
 def test_pi_youtube_resolver_does_not_fall_back_to_auto_when_av1_disallowed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -4062,6 +4093,7 @@ def test_qt_shell_supervisor_recovers_active_audio_without_video(monkeypatch: py
     monkeypatch.setattr(player.state, 'set_session_state', lambda value: calls.append(('state', value)))
     monkeypatch.setattr(player.state, 'set_session_position', lambda value: calls.append(('position', value)))
 
+
     assert player._qt_shell_supervisor_tick() is True
 
     supervisor = player.qt_shell_supervisor_state()
@@ -4077,6 +4109,42 @@ def test_qt_shell_supervisor_recovers_active_audio_without_video(monkeypatch: py
     assert player.state.NOW_PLAYING['resume_pos'] == 42.5
     assert supervisor['last_action'] == 'restarted_active_playback'
     assert supervisor['last_reason'] == 'active_audio_without_video'
+
+
+def test_external_mpv_video_health_uses_mpv_ipc_not_native_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    native_calls: list[str] = []
+
+    monkeypatch.setattr(player, '_is_playing', lambda: True)
+    monkeypatch.setattr(player, '_qt_runtime_uses_external_mpv', lambda: True)
+    monkeypatch.setattr(
+        player,
+        '_qt_shell_runtime_output_state',
+        lambda **_: native_calls.append('native') or {'current_vo': '', 'current_ao': 'alsa'},
+    )
+    monkeypatch.setattr(
+        player,
+        'mpv_get_many',
+        lambda props: {'current-vo': 'gpu', 'video-params': {'w': 854, 'h': 480}, 'audio-params': {'samplerate': 48000}},
+    )
+
+    assert player._video_output_healthy(timeout=0.2) is True
+    assert native_calls == []
+
+
+def test_flatpak_arm_wayland_external_mpv_defaults_to_wlshm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv('RELAYTV_QT_EXTERNAL_WAYLAND_PROFILE', raising=False)
+    monkeypatch.setattr(player.os.path, 'exists', lambda path: path == '/.flatpak-info')
+    monkeypatch.setattr(player.platform, 'machine', lambda: 'aarch64')
+
+    assert player._qt_external_wayland_mode_args() == ['--vo=wlshm']
+
+
+def test_flatpak_arm_wayland_external_mpv_honors_explicit_baseline_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('RELAYTV_QT_EXTERNAL_WAYLAND_PROFILE', 'baseline')
+    monkeypatch.setattr(player.os.path, 'exists', lambda path: path == '/.flatpak-info')
+    monkeypatch.setattr(player.platform, 'machine', lambda: 'aarch64')
+
+    assert player._qt_external_wayland_mode_args() == ['--vo=gpu', '--gpu-context=wayland']
 
 
 def test_stop_mpv_persists_live_runtime_volume(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -353,6 +353,23 @@ def test_qt_shell_initial_load_waits_for_presentation() -> None:
     assert "video_widget.frameSwapped.connect" in text
 
 
+def test_qt_shell_initial_load_gate_timeout_covers_boot(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Boot can take well over the render-context wait; the fallback that
+    # loads anyway must stay far enough out that a booting compositor
+    # normally settles first (a too-early load wedges presentation).
+    monkeypatch.delenv("RELAYTV_QT_LIBMPV_PRESENT_GATE_TIMEOUT_SEC", raising=False)
+    assert qt_shell_app._initial_load_gate_timeout_sec() == 90.0
+
+    monkeypatch.setenv("RELAYTV_QT_LIBMPV_PRESENT_GATE_TIMEOUT_SEC", "30")
+    assert qt_shell_app._initial_load_gate_timeout_sec() == 30.0
+
+    monkeypatch.setenv("RELAYTV_QT_LIBMPV_PRESENT_GATE_TIMEOUT_SEC", "1")
+    assert qt_shell_app._initial_load_gate_timeout_sec() == 6.0
+
+    monkeypatch.setenv("RELAYTV_QT_LIBMPV_PRESENT_GATE_TIMEOUT_SEC", "bogus")
+    assert qt_shell_app._initial_load_gate_timeout_sec() == 90.0
+
+
 def test_flatpak_launcher_disables_native_qt_toasts_by_default() -> None:
     text = (ROOT_DIR / "packaging/flatpak/relaytv-launch.sh").read_text()
 
@@ -1961,8 +1978,9 @@ def test_qt_libmpv_initial_stream_waits_for_render_context() -> None:
 
     assert 'Initial media is loaded after QOpenGLWidget.initializeGL() creates the' in text
     assert 'def render_context_ready(self) -> bool:' in text
-    assert 'if not libmpv_player.render_context_ready():' in text
-    assert 'QTimer.singleShot(50, _load_initial_libmpv_stream)' in text
+    assert 'ctx_ready = bool(libmpv_player.render_context_ready())' in text
+    assert 'raise RuntimeError("libmpv render context not ready")' in text
+    assert 'QTimer.singleShot(50 if waited < 6.0 else 500, _load_initial_libmpv_stream)' in text
     assert 'self.load_stream((stream or "").strip()' not in text
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -336,6 +336,23 @@ def test_qt_shell_ensures_c_numeric_locale_for_libmpv() -> None:
     assert locale.localeconv()["decimal_point"] == "."
 
 
+def test_qt_shell_initial_load_waits_for_presentation() -> None:
+    # Loading the first video before the fullscreen Wayland surface settles
+    # wedges presentation into an audio-only frozen frame; the gate requires
+    # a mapped window, real frame swaps, and quiet geometry.
+    ready = qt_shell_app._initial_load_presentation_ready
+
+    assert ready(True, 3, 0.25) is True
+    assert ready(True, 10, 5.0) is True
+    assert ready(False, 10, 5.0) is False
+    assert ready(True, 2, 5.0) is False
+    assert ready(True, 10, 0.1) is False
+
+    text = (ROOT_DIR / "app/relaytv_app/qt_shell_app.py").read_text()
+    assert "_window_presentation_ready()" in text
+    assert "video_widget.frameSwapped.connect" in text
+
+
 def test_flatpak_launcher_disables_native_qt_toasts_by_default() -> None:
     text = (ROOT_DIR / "packaging/flatpak/relaytv-launch.sh").read_text()
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -396,6 +396,21 @@ def test_entrypoint_server_port_honors_relaytv_port() -> None:
     assert container_entrypoint._server_port({"RELAYTV_PORT": "70000"}) == 8787
 
 
+def test_host_urls_advertise_relaytv_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The connect QR and /x11/host_urls must advertise the port the server
+    # actually listens on when RELAYTV_PORT overrides the default.
+    monkeypatch.setenv("RELAYTV_PORT", "8790")
+    monkeypatch.delenv("PORT", raising=False)
+
+    urls = routes._host_urls()
+
+    assert urls[0] == "http://127.0.0.1:8790/ui"
+    assert all(":8790/" in u for u in urls)
+
+    monkeypatch.setenv("RELAYTV_PORT", "not-a-port")
+    assert routes._host_urls()[0] == "http://127.0.0.1:8787/ui"
+
+
 def test_entrypoint_enables_headless_remote_from_mode() -> None:
     env = {"RELAYTV_MODE": "headless"}
 


### PR DESCRIPTION
## Summary

Adds host-native Flatpak packaging as an install option alongside Docker: a single-file `.flatpak` bundle attached to each GitHub Release, scoped to core playback + HDMI-CEC for the v1 packaging path.

- **App groundwork**: `container_entrypoint.py` no longer hardcodes `/data`; brand-asset seeding and yt-dlp update state anchor at `RELAYTV_STATE_DIR`, the seeding source resolves package-relative, and default uvicorn args honor `RELAYTV_PORT`. Docker behavior is unchanged when these are unset.
- **`packaging/flatpak/`**: flatpak-builder manifest on `org.freedesktop.Platform//25.08` bundling mpv/libmpv with luajit, libcec + cec-client, libass, libplacebo, deno, pinned Python deps including PySide6, and runtime-linked support libs. The launcher maps XDG dirs plus an optional Flatpak env file onto the `RELAYTV_*` env surface.
- **CI/release flow**: PRs touching Flatpak/app surfaces build an x86_64 bundle artifact; releases build x86_64 + aarch64 bundles, attach them to the draft release, and only un-draft after the image push and bundle upload succeed.
- **Flatpak notification safety**: native Qt toast surfaces are disabled by default in the Flatpak (`RELAYTV_QT_NATIVE_TOASTS=0`) after Wayland/libmpv testing showed top-level and child Qt toast windows can black out or freeze playback. Toasts route through the browser overlay by default, with native Qt toasts left as a diagnostic override only.
- **Runtime hardening**: the Qt libmpv path forces `LC_NUMERIC=C` before `mpv_create()` so desktop session locale settings do not break embedded libmpv startup.
- **Docs**: adds `docs/FLATPAK_OPERATIONS.md` covering permissions, config, data locations, autostart, yt-dlp update policy, notification mode, limitations, and Docker coexistence, plus README/INSTALL pointers and third-party license notes.

## User Impact

Users get a native Flatpak install option for RelayTV while keeping the existing Docker path. On Wayland/libmpv Flatpak installs, toast notifications no longer create native Qt overlay surfaces that can freeze playback or show black backgrounds.

## Operator Impact

Operators can configure the Flatpak through the documented env file under the app config directory. Native Qt toasts remain available only by explicitly setting `RELAYTV_QT_NATIVE_TOASTS=1` for diagnostics; the supported default is browser overlay delivery.

## Breaking Changes

None.

## Verification

- `ruff check app tests`
- `PYTHONPATH=app pytest -q` (`348 passed`)
- `git diff --check`
- Local x86_64 Flatpak build installed with `flatpak-builder --disable-rofiles-fuse`; `relaytv.service` restarted and active.
- Runtime confirmed `RELAYTV_QT_NATIVE_TOASTS=0`, `RELAYTV_QT_NATIVE_TOASTS_TOPLEVEL=0`, `/notifications/capabilities` reports `notification_strategy: overlay`, and `/toast` returns `delivery_mode: overlay`.

BEGIN_COMMIT_OVERRIDE
feat: host-native flatpak packaging with safe overlay toasts

Adds a Flatpak install option alongside Docker: packaging/flatpak manifest
(freedesktop 25.08; bundled mpv/libmpv+luajit, libcec, libass,
libplacebo, deno, pinned Python deps incl. PySide6, krb5/pcsc-lite),
a launcher mapping XDG dirs and an optional env file onto the RELAYTV_*
surface, desktop/metainfo/icon integration, CI jobs that build PR bundle
artifacts and attach x86_64+aarch64 bundles to each release,
docs/FLATPAK_OPERATIONS.md, and entrypoint groundwork for
RELAYTV_STATE_DIR/RELAYTV_PORT. Flatpak native Qt toasts now default off
because Wayland/libmpv testing showed native Qt toast surfaces can black
out or freeze playback; browser overlay toasts are the supported default
and native Qt toasts remain diagnostic override-only. The Qt libmpv path
also forces LC_NUMERIC=C before mpv_create() for desktop session locale
compatibility.
END_COMMIT_OVERRIDE
