### PR TITLE
fix: hand the winning yt-dlp strategy to mpv for live playback and skip unready replays

### DIFF
--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -43,6 +43,14 @@ _NATURAL_IDLE_ENSURE_TIMER: threading.Timer | None = None
 _HISTORY_PROGRESS_LAST_PERSIST: dict[str, float] = {}
 
 
+class YouTubePostLiveProcessingError(HTTPException):
+    """YouTube has ended the live stream but has not processed its replay."""
+
+    def __init__(self, title: str) -> None:
+        self.title = str(title or "").strip()
+        super().__init__(status_code=409, detail="YouTube replay is still processing")
+
+
 def _idle_dashboard_enabled() -> bool:
     try:
         settings = state.get_settings() if hasattr(state, "get_settings") else {}
@@ -1016,7 +1024,14 @@ def _stop_qt_shell() -> None:
         QT_SHELL_PROC = None
 
 
-def _start_qt_shell(stream_url: str | None = None, audio_url: str | None = None, start_pos: float | None = None) -> bool:
+def _start_qt_shell(
+    stream_url: str | None = None,
+    audio_url: str | None = None,
+    start_pos: float | None = None,
+    *,
+    ytdl_format_override: str | None = None,
+    ytdl_raw_options_override: str | None = None,
+) -> bool:
     global QT_SHELL_PROC
     settings = getattr(state, "get_settings", lambda: {})()
     shell_module = (os.getenv("RELAYTV_QT_SHELL_MODULE") or "relaytv_app.qt_shell_app").strip()
@@ -1041,8 +1056,16 @@ def _start_qt_shell(stream_url: str | None = None, audio_url: str | None = None,
     if ytdl_enabled and stream_url and _should_force_ytdl_off(stream_url, provider_hint):
         ytdl_enabled = False
     ytdl_path = (os.getenv("RELAYTV_MPV_YTDL_PATH") or "yt-dlp").strip()
-    ytdl_format = _effective_ytdl_format(settings, provider=provider_hint)
-    ytdl_raw_options = (os.getenv("RELAYTV_MPV_YTDL_RAW_OPTIONS") or "").strip()
+    ytdl_format = (
+        str(ytdl_format_override).strip()
+        if ytdl_format_override is not None
+        else _effective_ytdl_format(settings, provider=provider_hint)
+    )
+    ytdl_raw_options = (
+        str(ytdl_raw_options_override).strip()
+        if ytdl_raw_options_override is not None
+        else (os.getenv("RELAYTV_MPV_YTDL_RAW_OPTIONS") or "").strip()
+    )
     args = [
         sys.executable,
         "-m",
@@ -1230,10 +1253,19 @@ def _build_qt_external_mpv_args(
     *,
     fallback_to_x11: bool = False,
     start_pos: float | None = None,
+    ytdl_format_override: str | None = None,
+    ytdl_raw_options_override: str | None = None,
 ) -> list[str]:
     # Start from the standard app-managed args, then append external runtime
     # renderer hints. Keep first-wins semantics for singleton options.
-    args = _build_mpv_args(stream_url, audio_url, "x11", start_pos=start_pos)
+    args = _build_mpv_args(
+        stream_url,
+        audio_url,
+        "x11",
+        start_pos=start_pos,
+        ytdl_format_override=ytdl_format_override,
+        ytdl_raw_options_override=ytdl_raw_options_override,
+    )
     base = _strip_mpv_renderer_args(args[:-1])
     extra = _qt_external_mpv_mode_args(fallback_to_x11=fallback_to_x11)
     out = base + extra + [stream_url]
@@ -1265,9 +1297,18 @@ def _start_qt_external_mpv(
     fallback_to_x11: bool = False,
     fallback_reason: str = "",
     start_pos: float | None = None,
+    ytdl_format_override: str | None = None,
+    ytdl_raw_options_override: str | None = None,
 ) -> subprocess.Popen:
     _stop_qt_shell()
-    args = _build_qt_external_mpv_args(stream_url, audio_url, fallback_to_x11=fallback_to_x11, start_pos=start_pos)
+    args = _build_qt_external_mpv_args(
+        stream_url,
+        audio_url,
+        fallback_to_x11=fallback_to_x11,
+        start_pos=start_pos,
+        ytdl_format_override=ytdl_format_override,
+        ytdl_raw_options_override=ytdl_raw_options_override,
+    )
     mode_args = _qt_external_mpv_mode_args(fallback_to_x11=fallback_to_x11)
     _set_qt_external_runtime_state(
         fallback_to_x11=fallback_to_x11,
@@ -2470,7 +2511,15 @@ def _x11_mode_active(selected_mode: str | None = None) -> bool:
     return _has_x11_display()
 
 
-def _build_mpv_args(stream_url: str, audio_url: str | None, mode: str, start_pos: float | None = None) -> list[str]:
+def _build_mpv_args(
+    stream_url: str,
+    audio_url: str | None,
+    mode: str,
+    start_pos: float | None = None,
+    *,
+    ytdl_format_override: str | None = None,
+    ytdl_raw_options_override: str | None = None,
+) -> list[str]:
     """Build mpv command line with minimal app-managed options.
 
     Keep mpv mostly default-driven and only set options required for RelayTV
@@ -2557,11 +2606,19 @@ def _build_mpv_args(stream_url: str, audio_url: str | None, mode: str, start_pos
         mpv_args.append("--ytdl=yes")
         ytdl_path = (os.getenv("RELAYTV_MPV_YTDL_PATH") or "yt-dlp").strip()
         mpv_args.append(f"--script-opts=ytdl_hook-ytdl_path={ytdl_path}")
-        ytdl_format = _effective_ytdl_format(settings, provider=provider_hint)
+        ytdl_format = (
+            str(ytdl_format_override).strip()
+            if ytdl_format_override is not None
+            else _effective_ytdl_format(settings, provider=provider_hint)
+        )
 
         if ytdl_format:
             mpv_args.append(f"--ytdl-format={ytdl_format}")
-        ytdl_raw = (os.getenv("RELAYTV_MPV_YTDL_RAW_OPTIONS") or "").strip()
+        ytdl_raw = (
+            str(ytdl_raw_options_override).strip()
+            if ytdl_raw_options_override is not None
+            else (os.getenv("RELAYTV_MPV_YTDL_RAW_OPTIONS") or "").strip()
+        )
         if ytdl_raw:
             mpv_args.append(f"--ytdl-raw-options={ytdl_raw}")
     else:
@@ -2731,7 +2788,14 @@ def _apply_startup_mpv_runtime_settings() -> None:
         pass
 
 
-def _load_stream_in_existing_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | None = None) -> bool:
+def _load_stream_in_existing_mpv(
+    stream_url: str,
+    audio_url: str | None = None,
+    start_pos: float | None = None,
+    *,
+    ytdl_format_override: str | None = None,
+    ytdl_raw_options_override: str | None = None,
+) -> bool:
     """Try seamless in-process stream replacement on an already-running mpv."""
     if not _env_bool("RELAYTV_MPV_SEAMLESS_REPLACE", True):
         return False
@@ -2802,6 +2866,18 @@ def _load_stream_in_existing_mpv(stream_url: str, audio_url: str | None = None, 
     if not control_available:
         return False
 
+    if ytdl_format_override is not None or ytdl_raw_options_override is not None:
+        for prop, value in (
+            ("ytdl-format", ytdl_format_override or ""),
+            ("ytdl-raw-options", ytdl_raw_options_override or ""),
+        ):
+            try:
+                response = mpv_command(["set_property", prop, value])
+            except Exception:
+                return False
+            if not isinstance(response, dict) or response.get("error") != "success":
+                return False
+
     if _qt_shell_runtime_accepts_mpv_commands():
         try:
             if _normalize_start_pos(start_pos) is not None:
@@ -2832,7 +2908,14 @@ def _load_stream_in_existing_mpv(stream_url: str, audio_url: str | None = None, 
     return True
 
 
-def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | None = None):
+def start_mpv(
+    stream_url: str,
+    audio_url: str | None = None,
+    start_pos: float | None = None,
+    *,
+    ytdl_format_override: str | None = None,
+    ytdl_raw_options_override: str | None = None,
+):
     """Start mpv fullscreen with an IPC socket so we can control it.
 
     Video mode:
@@ -2875,6 +2958,8 @@ def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | 
                 fallback_to_x11=False,
                 fallback_reason="",
                 start_pos=start_pos,
+                ytdl_format_override=ytdl_format_override,
+                ytdl_raw_options_override=ytdl_raw_options_override,
             )
             if not wait_for_ipc_ready(timeout=startup_timeout):
                 raise HTTPException(status_code=500, detail="qt external mpv started but IPC not ready")
@@ -2892,6 +2977,8 @@ def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | 
                         fallback_to_x11=True,
                         fallback_reason="video_unhealthy",
                         start_pos=start_pos,
+                        ytdl_format_override=ytdl_format_override,
+                        ytdl_raw_options_override=ytdl_raw_options_override,
                     )
                     if not wait_for_ipc_ready(timeout=startup_timeout):
                         raise HTTPException(status_code=500, detail="qt external mpv x11 fallback started but IPC not ready")
@@ -2902,7 +2989,13 @@ def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | 
             _recover_audio_output_if_needed(settings)
             return
 
-        _start_qt_shell(stream_url, audio_url=audio_url, start_pos=start_pos)
+        _start_qt_shell(
+            stream_url,
+            audio_url=audio_url,
+            start_pos=start_pos,
+            ytdl_format_override=ytdl_format_override,
+            ytdl_raw_options_override=ytdl_raw_options_override,
+        )
         if not wait_for_ipc_ready(timeout=startup_timeout):
             raise HTTPException(status_code=500, detail="qt shell started but mpv IPC not ready")
         _set_mpv_process_start_option_active(process_start_option_active)
@@ -2911,7 +3004,14 @@ def start_mpv(stream_url: str, audio_url: str | None = None, start_pos: float | 
         return
 
     def _spawn(mode_to_use: str) -> subprocess.Popen:
-        args = _build_mpv_args(stream_url, audio_url, mode_to_use, start_pos=start_pos)
+        args = _build_mpv_args(
+            stream_url,
+            audio_url,
+            mode_to_use,
+            start_pos=start_pos,
+            ytdl_format_override=ytdl_format_override,
+            ytdl_raw_options_override=ytdl_raw_options_override,
+        )
         if debug:
             logger.info("starting_mpv mode=%s args=%s", mode_to_use, " ".join(shlex.quote(a) for a in args))
         return subprocess.Popen(args)
@@ -3549,10 +3649,34 @@ def _store_prefetched_stream(item: dict[str, Any], url: str, stream: str, audio:
     item["_resolved_at"] = float(time.time())
 
 
+def _clear_prefetched_stream(item: dict[str, Any]) -> None:
+    for key in ("_resolved_source_url", "_resolved_stream", "_resolved_audio", "_resolved_at"):
+        item.pop(key, None)
+
+
+def _resolved_playback_source(
+    item: dict[str, Any],
+    url: str,
+    result: object,
+) -> tuple[str, str | None, str | None, str | None]:
+    stream, audio = result
+    if str(getattr(result, "transport", "direct") or "direct") == "mpv_ytdl":
+        _clear_prefetched_stream(item)
+        ytdl_format = str(getattr(result, "ytdl_format", "") or "").strip()
+        ytdl_raw = str(getattr(result, "ytdl_raw_options", "") or "").strip()
+        operator_raw = (os.getenv("RELAYTV_MPV_YTDL_RAW_OPTIONS") or "").strip()
+        if operator_raw:
+            ytdl_raw = ",".join(part for part in (operator_raw, ytdl_raw) if part)
+        return str(stream), (str(audio) if audio else None), ytdl_format, ytdl_raw
+    else:
+        _store_prefetched_stream(item, url, stream, audio)
+    return str(stream), (str(audio) if audio else None), None, None
+
+
 def _prefetch_queue_item_worker(item: dict[str, Any], url: str) -> None:
     try:
-        stream, audio = resolve_streams(url)
-        _store_prefetched_stream(item, url, stream, audio)
+        result = resolve_streams(url)
+        _resolved_playback_source(item, url, result)
         debug_log("player", f"queue prefetch resolved provider={item.get('provider') or provider_from_url(url)} url={url!r}")
     except Exception as exc:
         debug_log("player", f"queue prefetch failed url={url!r} err={exc}")
@@ -3907,6 +4031,18 @@ def _notify_bot_check_skip(item: object) -> None:
     _notify_bot_check_toast(text)
 
 
+def _notify_post_live_processing(item: object) -> None:
+    title = ""
+    if isinstance(item, dict):
+        title = str(item.get("title") or item.get("url") or "").strip()
+    else:
+        title = str(item or "").strip()
+    text = "YouTube is processing this live stream. Replay is not currently available."
+    if title:
+        text = f"{text}\n\n{title}"
+    _notify_warn_toast(text)
+
+
 def _playback_start_timeout_sec() -> float:
     raw = (os.getenv("RELAYTV_PLAYBACK_START_TIMEOUT_SEC") or "45").strip()
     try:
@@ -4068,7 +4204,8 @@ def advance_queue_playback(
                 # A bot check will not clear on retry, so skip the item in
                 # every mode; re-queueing it makes auto-next retry it forever.
                 bot_check = isinstance(exc, YouTubeBotCheckError)
-                skip_unplayable = bot_check or (
+                post_live_processing = isinstance(exc, YouTubePostLiveProcessingError)
+                skip_unplayable = bot_check or post_live_processing or (
                     allow_skip_unplayable
                     and isinstance(exc, HTTPException)
                     and int(getattr(exc, "status_code", 0) or 0) == 400
@@ -4076,10 +4213,11 @@ def advance_queue_playback(
                 if skip_unplayable:
                     skipped_unplayable += 1
                     logger.warning(
-                        "queue_skip_unplayable mode=%s skipped=%s bot_check=%s title=%s error=%s",
+                        "queue_skip_unplayable mode=%s skipped=%s bot_check=%s post_live_processing=%s title=%s error=%s",
                         mode,
                         skipped_unplayable,
                         bot_check,
+                        post_live_processing,
                         str(next_item.get("title") or next_item.get("url") or "") if isinstance(next_item, dict) else str(next_item or ""),
                         exc,
                     )
@@ -4497,7 +4635,18 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
     item_is_live = _provider_item_is_live_stream(item, raw, provider)
     force_resolve_provider = provider in _providers_forced_to_resolve() and (not item_is_live)
     prefetched = _fresh_prefetched_stream(item)
-    should_resolve = use_resolver and (not trusted_local_stream) and (not prefer_mpv_ytdl or is_youtube_url(raw) or force_resolve_provider or prefetched is not None)
+    should_resolve = use_resolver and (not trusted_local_stream) and (
+        not prefer_mpv_ytdl
+        or is_youtube_url(raw)
+        or force_resolve_provider
+        or prefetched is not None
+    )
+    ytdl_format_override = None
+    ytdl_raw_options_override = None
+    transient_handoff = item.pop("_transient_mpv_ytdl_handoff", None)
+    if isinstance(transient_handoff, dict):
+        ytdl_format_override = str(transient_handoff.get("format") or "").strip()
+        ytdl_raw_options_override = str(transient_handoff.get("raw_options") or "").strip()
     if force_resolve_provider:
         debug_log("player", f"forcing resolver for provider={provider}")
     if trusted_local_stream:
@@ -4536,16 +4685,32 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
         if prefetched is not None:
             stream, audio = prefetched
             debug_log("player", "using prefetched resolved stream")
+        elif isinstance(transient_handoff, dict):
+            stream, audio = raw, None
+            debug_log("player", "using preflighted mpv yt-dlp handoff")
         else:
             t_resolve = time.monotonic()
-            stream, audio = resolve_streams(raw)
+            result = resolve_streams(raw)
+            if str(getattr(result, "live_status", "") or "").strip().lower() == "post_live":
+                _clear_prefetched_stream(item)
+                _notify_post_live_processing(item)
+                raise YouTubePostLiveProcessingError(str(title or raw))
+            stream, audio, ytdl_format_override, ytdl_raw_options_override = (
+                _resolved_playback_source(item, raw, result)
+            )
             debug_log("player", f"resolve_streams finished in {int((time.monotonic() - t_resolve) * 1000)}ms")
-            if isinstance(item, dict):
-                _store_prefetched_stream(item, raw, stream, audio)
 
     debug_log("player", f"resolved_stream={stream!r} audio={audio!r}")
 
     resume_start_pos = _normalize_start_pos(start_pos)
+    ytdl_handoff_kwargs = (
+        {
+            "ytdl_format_override": ytdl_format_override,
+            "ytdl_raw_options_override": ytdl_raw_options_override,
+        }
+        if ytdl_format_override is not None or ytdl_raw_options_override is not None
+        else {}
+    )
     with MPV_LOCK:
         t_mpv = time.monotonic()
         # Resolver work can outlast the initial transition window. Refresh it
@@ -4558,7 +4723,12 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
                 x11_overlay.stop_overlay()
             except Exception:
                 pass
-        reused_runtime = _load_stream_in_existing_mpv(stream, audio_url=audio, start_pos=resume_start_pos)
+        reused_runtime = _load_stream_in_existing_mpv(
+            stream,
+            audio_url=audio,
+            start_pos=resume_start_pos,
+            **ytdl_handoff_kwargs,
+        )
         if (not reused_runtime) and _qt_shell_backend_enabled():
             # ARM hosts can expose a brief control-gap at EOF; retry a couple
             # of times before escalating to full player restart.
@@ -4574,7 +4744,12 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
             delay_sec = max(0.01, min(1.0, delay_sec))
             for _ in range(retries):
                 time.sleep(delay_sec)
-                reused_runtime = _load_stream_in_existing_mpv(stream, audio_url=audio, start_pos=resume_start_pos)
+                reused_runtime = _load_stream_in_existing_mpv(
+                    stream,
+                    audio_url=audio,
+                    start_pos=resume_start_pos,
+                    **ytdl_handoff_kwargs,
+                )
                 if reused_runtime:
                     break
         if reused_runtime:
@@ -4582,7 +4757,12 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
             # transitions from idle surface to the newly loaded stream.
             _mark_playback_transition()
         if not reused_runtime:
-            start_mpv(stream, audio_url=audio, start_pos=resume_start_pos)
+            start_mpv(
+                stream,
+                audio_url=audio,
+                start_pos=resume_start_pos,
+                **ytdl_handoff_kwargs,
+            )
         debug_log(
             "player",
             f"{'seamless_replace' if reused_runtime else 'start_mpv'} finished in "
@@ -5750,14 +5930,25 @@ def restart_current(apply_mode: str | None = None) -> dict | None:
                 if val:
                     item[key] = val
             try:
-                stream, audio = resolve_streams(inp)
+                result = resolve_streams(inp)
             except Exception as resolve_exc:
                 if isinstance(resolve_exc, YouTubeBotCheckError):
                     label = str(item.get("title") or inp)
                     _notify_bot_check_toast(f"Settings not applied (YouTube bot check): {label}")
                 logger.warning("restart_current_resolve_failed error=%s", resolve_exc)
                 return None
-            _store_prefetched_stream(item, inp, stream, audio)
+            if str(getattr(result, "live_status", "") or "").strip().lower() == "post_live":
+                _notify_post_live_processing(item)
+                logger.info("restart_current_skipped_post_live_processing title=%s", str(item.get("title") or inp)[:120])
+                return None
+            _stream, _audio, ytdl_format, ytdl_raw = _resolved_playback_source(
+                item, inp, result
+            )
+            if ytdl_format is not None or ytdl_raw is not None:
+                item["_transient_mpv_ytdl_handoff"] = {
+                    "format": ytdl_format or "",
+                    "raw_options": ytdl_raw or "",
+                }
             target = item
         # capture position if possible
         pos = None

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -26,6 +26,7 @@ from .integrations import jellyfin_receiver
 from .debug import debug_log, get_logger
 from .resolver import (
     YouTubeBotCheckError,
+    YouTubePostLiveProcessingError,
     enrich_item_metadata,
     is_youtube_url,
     make_item,
@@ -41,14 +42,6 @@ logger = get_logger("player")
 _NATURAL_IDLE_RESET_UNTIL = 0.0
 _NATURAL_IDLE_ENSURE_TIMER: threading.Timer | None = None
 _HISTORY_PROGRESS_LAST_PERSIST: dict[str, float] = {}
-
-
-class YouTubePostLiveProcessingError(HTTPException):
-    """YouTube has ended the live stream but has not processed its replay."""
-
-    def __init__(self, title: str) -> None:
-        self.title = str(title or "").strip()
-        super().__init__(status_code=409, detail="YouTube replay is still processing")
 
 
 def _idle_dashboard_enabled() -> bool:
@@ -4690,8 +4683,18 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
             debug_log("player", "using preflighted mpv yt-dlp handoff")
         else:
             t_resolve = time.monotonic()
-            result = resolve_streams(raw)
+            try:
+                result = resolve_streams(raw)
+            except YouTubePostLiveProcessingError:
+                _clear_prefetched_stream(item)
+                _notify_post_live_processing(item)
+                raise
             if str(getattr(result, "live_status", "") or "").strip().lower() == "post_live":
+                # post_live resolves, but while YouTube processes the replay
+                # it serves only the live-edge fragment feed (no manifest, no
+                # fragment durations for mpv's hook), so playback would start
+                # seconds from the end and die. Skip until processing ends
+                # and the video plays as a normal VOD (verified on-device).
                 _clear_prefetched_stream(item)
                 _notify_post_live_processing(item)
                 raise YouTubePostLiveProcessingError(str(title or raw))
@@ -5932,12 +5935,19 @@ def restart_current(apply_mode: str | None = None) -> dict | None:
             try:
                 result = resolve_streams(inp)
             except Exception as resolve_exc:
+                if isinstance(resolve_exc, YouTubePostLiveProcessingError):
+                    _notify_post_live_processing(item)
+                    logger.info("restart_current_skipped_post_live_processing title=%s", str(item.get("title") or inp)[:120])
+                    return None
                 if isinstance(resolve_exc, YouTubeBotCheckError):
                     label = str(item.get("title") or inp)
                     _notify_bot_check_toast(f"Settings not applied (YouTube bot check): {label}")
                 logger.warning("restart_current_resolve_failed error=%s", resolve_exc)
                 return None
             if str(getattr(result, "live_status", "") or "").strip().lower() == "post_live":
+                # See play_item: a successfully resolved post_live stream is
+                # only watchable at the live edge, so restarting it would
+                # tear playback down for a stream that dies in seconds.
                 _notify_post_live_processing(item)
                 logger.info("restart_current_skipped_post_live_processing title=%s", str(item.get("title") or inp)[:120])
                 return None

--- a/app/relaytv_app/resolver.py
+++ b/app/relaytv_app/resolver.py
@@ -65,9 +65,12 @@ def _mpv_ytdl_raw_options(args: list[str]) -> str:
                 idx += 1
         if key in {"no-playlist"}:
             continue
-        # mpv's key/value-list parser uses commas as separators. These yt-dlp
-        # values normally contain no commas; escape any operator-provided ones.
-        value = value.replace("\\", "\\\\").replace(",", "\\,")
+        # mpv's key/value-list parser splits pairs on commas and has no
+        # backslash escaping (a `\,` makes option parsing fail outright);
+        # length-prefixed quoting (%n%value) is the only way to carry a
+        # comma, and a bare leading % would be read as a quote marker.
+        if value and ("," in value or value.startswith("%")):
+            value = f"%{len(value)}%{value}"
         options.append(f"{key}={value}")
     return ",".join(options)
 
@@ -79,6 +82,25 @@ class YouTubeBotCheckError(HTTPException):
     unchanged; queue advancement catches this type to skip the item instead
     of retrying, since a bot check will not clear on its own.
     """
+
+
+class YouTubePostLiveProcessingError(HTTPException):
+    """YouTube has ended the live stream but has not processed its replay.
+
+    Raised only when yt-dlp fails with YouTube's own playability reason for
+    an unready replay; an ended stream that still resolves keeps playing
+    through mpv's yt-dlp hook like a live one.
+    """
+
+    def __init__(self, title: str) -> None:
+        self.title = str(title or "").strip()
+        super().__init__(status_code=409, detail="YouTube replay is still processing")
+
+
+def _youtube_error_is_postlive_processing(low_err: str) -> bool:
+    """Match YouTube's playability reason for an ended stream awaiting replay."""
+    return "live stream recording is not available" in low_err
+
 
 # Compact resolver runtime telemetry for /status and /runtime/capabilities.
 _RESOLVER_RUNTIME_LOCK = threading.Lock()
@@ -648,6 +670,8 @@ def resolve_streams_ytdlp(url: str):
             success=False,
         )
         logger.warning("ytdlp_failed provider=%s format=%s error=%s", provider or "unknown", selected_format, err[:1200])
+        if is_youtube_url(u) and _youtube_error_is_postlive_processing(err.lower()):
+            raise YouTubePostLiveProcessingError(u)
         if is_youtube_url(u) and _youtube_error_is_botcheck(err.lower()):
             raise YouTubeBotCheckError(
                 status_code=400,

--- a/app/relaytv_app/resolver.py
+++ b/app/relaytv_app/resolver.py
@@ -7,6 +7,7 @@ import json
 import time
 import urllib.request
 import shutil
+from dataclasses import dataclass
 
 from .config import runtime_config
 import platform
@@ -22,6 +23,53 @@ from . import ytdlp_format_policy
 
 
 logger = get_logger("resolver")
+
+
+@dataclass(frozen=True)
+class ResolvedStreams:
+    """Playback source plus optional instructions for mpv's yt-dlp hook.
+
+    Iteration deliberately yields only stream/audio so existing resolver
+    callers can continue unpacking this result as a two-tuple.
+    """
+
+    stream: str
+    audio: str | None = None
+    transport: str = "direct"
+    ytdl_format: str = ""
+    ytdl_raw_options: str = ""
+    live_status: str = ""
+
+    def __iter__(self):
+        yield self.stream
+        yield self.audio
+
+
+def _mpv_ytdl_raw_options(args: list[str]) -> str:
+    """Translate the successful yt-dlp strategy into mpv hook options."""
+    options: list[str] = []
+    idx = 1 if args and not str(args[0]).startswith("-") else 0
+    while idx < len(args):
+        token = str(args[idx] or "").strip()
+        idx += 1
+        if not token.startswith("--"):
+            continue
+        key_value = token[2:]
+        if "=" in key_value:
+            key, value = key_value.split("=", 1)
+        else:
+            key = key_value
+            value = ""
+            if idx < len(args) and not str(args[idx]).startswith("-"):
+                value = str(args[idx])
+                idx += 1
+        if key in {"no-playlist"}:
+            continue
+        # mpv's key/value-list parser uses commas as separators. These yt-dlp
+        # values normally contain no commas; escape any operator-provided ones.
+        value = value.replace("\\", "\\\\").replace(",", "\\,")
+        options.append(f"{key}={value}")
+    return ",".join(options)
 
 
 class YouTubeBotCheckError(HTTPException):
@@ -517,10 +565,14 @@ def resolve_streams_ytdlp(url: str):
             or "only images are available" in low_err
         )
 
-    def _run_strategies(strategy_list: list[tuple[list[str], list[str]]]) -> tuple[object, str, str]:
+    def _run_strategies(
+        strategy_list: list[tuple[list[str], list[str]]],
+    ) -> tuple[object, str, str, str, list[str]]:
         p_local = None
         err_local = ""
         selected_format = fmt or "auto"
+        selected_candidate = fmt or ""
+        selected_args: list[str] = list(base)
         for args_base, strategy_candidates in strategy_list:
             debug_log("youtube", f"Trying yt-dlp strategy: {' '.join(args_base)} (host_arch={host_arch or 'unknown'})")
             _log_resolve(f"yt-dlp strategy start host_arch={host_arch or 'unknown'} args={' '.join(args_base)}")
@@ -528,6 +580,8 @@ def resolve_streams_ytdlp(url: str):
                 t_attempt = time.monotonic()
                 cmd = [*args_base, *output_args, u] if not cand else [*args_base, "-f", cand, *output_args, u]
                 selected_format = cand or "auto"
+                selected_candidate = cand
+                selected_args = list(args_base)
                 p_local = run(cmd, check=False)
                 elapsed_ms = int((time.monotonic() - t_attempt) * 1000)
                 debug_log(
@@ -536,7 +590,7 @@ def resolve_streams_ytdlp(url: str):
                 )
                 _log_resolve(f"yt-dlp attempt format={cand or 'auto'} rc={p_local.returncode} elapsed_ms={elapsed_ms}")
                 if p_local.returncode == 0 and (p_local.stdout or "").strip():
-                    return p_local, "", selected_format
+                    return p_local, "", selected_format, selected_candidate, selected_args
 
                 err_local = (p_local.stderr or "").strip()
                 low_err = err_local.lower()
@@ -554,17 +608,23 @@ def resolve_streams_ytdlp(url: str):
                 if _format_related_retry(low_err):
                     continue
                 break
-        return p_local, err_local, selected_format
+        return p_local, err_local, selected_format, selected_candidate, selected_args
 
     p = None
     err = ""
     selected_format = fmt or "auto"
+    selected_candidate = fmt or ""
+    selected_args = list(base)
     t0 = time.monotonic()
     if is_youtube_url(u) and ytdlp_format_policy.youtube_progressive_startup_enabled(profile):
         _log_resolve("youtube arm-safe staged resolver enabled")
-        p, err, selected_format = _run_strategies(_build_youtube_arm_safe_strategies(base, candidates))
+        p, err, selected_format, selected_candidate, selected_args = _run_strategies(
+            _build_youtube_arm_safe_strategies(base, candidates)
+        )
     else:
-        p, err, selected_format = _run_strategies(strategies)
+        p, err, selected_format, selected_candidate, selected_args = _run_strategies(
+            strategies
+        )
 
     if not p:
         _update_resolver_runtime_state(
@@ -619,7 +679,13 @@ def resolve_streams_ytdlp(url: str):
         # no data without per-segment parameters. Hand mpv the page URL so
         # its yt-dlp hook drives the manifest instead.
         logger.info("ytdlp_live_stream_deferred_to_mpv live_status=%s url=%s", live_status, u)
-        return u, None
+        return ResolvedStreams(
+            stream=u,
+            transport="mpv_ytdl",
+            ytdl_format=selected_candidate,
+            ytdl_raw_options=_mpv_ytdl_raw_options(selected_args),
+            live_status=live_status,
+        )
     if not lines:
         raise HTTPException(status_code=400, detail="yt-dlp returned no stream URLs")
     if len(lines) == 1:

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -1858,7 +1858,7 @@ _X11_OVERLAY_HTML = r"""<!doctype html>
     .toast.success{--accent:var(--ok)} .toast.warn{--accent:var(--warn)} .toast.error{--accent:var(--err)}
     .toastTop{display:flex;align-items:center;gap:var(--toast-top-gap);}
     .ico{width:var(--toast-icon-size);height:var(--toast-icon-size);border-radius:999px;background:rgba(255,255,255,.08);display:grid;place-items:center;font-size:var(--toast-icon-font);}
-    .tTxt{font-size:var(--toast-text-font);line-height:1.28;}
+    .tTxt{font-size:var(--toast-text-font);line-height:1.28;white-space:pre-line;}
     .toast a{color:inherit;text-decoration:underline;font-weight:600;font-size:var(--toast-link-font);display:inline-block;margin-top:var(--toast-link-gap);pointer-events:auto;}
     .toast .img{margin-top:var(--toast-image-gap);width:100%;height:var(--toast-image-height);display:none;object-fit:cover;border-radius:var(--toast-image-radius);border:1px solid rgba(130,170,220,.25);background:rgba(255,255,255,.04)}
     .toast .img.ready{display:block;}

--- a/app/relaytv_app/routes/playback.py
+++ b/app/relaytv_app/routes/playback.py
@@ -325,6 +325,32 @@ def play_now(req: PlayNowReq):
         else:
             now = playback_service.play_now(req.url, use_resolver=True, cec=False, clear_queue=False, mode=(req.reason or "play_now"))
     except Exception as exc:
+        if isinstance(exc, player.YouTubePostLiveProcessingError):
+            try:
+                handoff = playback_service.advance_queue(
+                    mode="play_next",
+                    prefer_playlist_next=False,
+                )
+                now = handoff.get("now_playing") if isinstance(handoff, dict) else None
+            except playback_service.QueueAdvanceEmptyError:
+                player._handle_playback_idle_no_queue()
+                now = None
+            with state.QUEUE_LOCK:
+                qlen = len(state.QUEUE)
+                queue_snapshot = list(state.QUEUE)
+            _ui_event_push_queue(
+                "play_now",
+                queue=queue_snapshot,
+                queue_length=qlen,
+                source="post_live_skip",
+            )
+            return {
+                "ok": True,
+                "action": "skipped_post_live_processing",
+                "now_playing": now,
+                "preserved": preserved,
+                "queue_length": qlen,
+            }
         _rollback_play_now_preserve(preserved)
         if isinstance(exc, player.YouTubeBotCheckError):
             # The 400 detail only reaches the requesting client; the TV

--- a/tests/test_playback_routes.py
+++ b/tests/test_playback_routes.py
@@ -327,6 +327,35 @@ def test_play_now_bot_check_failure_pushes_warn_toast(monkeypatch) -> None:
     assert toasts[0]["level"] == "warn"
 
 
+def test_play_now_post_live_processing_advances_queue(monkeypatch) -> None:
+    queued = {"url": "https://example.com/next.mp4", "title": "Next Video"}
+    routes.state.QUEUE = [queued]
+
+    def unavailable(*args, **kwargs):
+        raise routes.player.YouTubePostLiveProcessingError("Processing Live")
+
+    def advance(*, mode, prefer_playlist_next):
+        assert mode == "play_next"
+        assert prefer_playlist_next is False
+        routes.state.QUEUE.pop(0)
+        return {"status": "playing_next", "now_playing": queued}
+
+    monkeypatch.setattr(routes.playback_service, "play_now", unavailable)
+    monkeypatch.setattr(routes.playback_service, "advance_queue", advance)
+    monkeypatch.setattr(routes, "_ui_event_push_queue", lambda *args, **kwargs: None)
+
+    client = TestClient(create_app(testing=True))
+    response = client.post(
+        "/play_now",
+        json={"url": "https://youtube.com/watch?v=processing", "title": "Processing Live"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["action"] == "skipped_post_live_processing"
+    assert response.json()["now_playing"] == queued
+    assert response.json()["queue_length"] == 0
+
+
 def test_play_now_non_botcheck_failure_does_not_toast(monkeypatch) -> None:
     toasts: list[dict] = []
     monkeypatch.setattr(routes, "_push_overlay_toast", lambda **kwargs: toasts.append(dict(kwargs)))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3115,6 +3115,35 @@ def test_auto_next_skips_bot_checked_video_instead_of_retrying(monkeypatch: pyte
     assert toasted == [bot_item]
 
 
+def test_auto_next_skips_post_live_processing_video(monkeypatch: pytest.MonkeyPatch) -> None:
+    processing = {'url': 'https://youtube.com/watch?v=processing', 'title': 'Processing Live'}
+    ready = {'url': 'https://example.com/ready.mp4', 'title': 'Ready'}
+    played: list[dict] = []
+
+    monkeypatch.setattr(player.state, 'NOW_PLAYING', None, raising=False)
+    monkeypatch.setattr(player.state, 'QUEUE', [processing, ready], raising=False)
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'playing', raising=False)
+    monkeypatch.setattr(player.state, 'AUTO_NEXT_SUPPRESS_UNTIL', 0.0, raising=False)
+    monkeypatch.setattr(player.state, 'persist_queue_payload', lambda payload: None)
+    monkeypatch.setattr(player, 'update_history_progress', lambda *args, **kwargs: None)
+    monkeypatch.setattr(player, '_emit_jellyfin_stopped_from_now', lambda now: None)
+
+    def fake_play(item, **kwargs):
+        if item is processing:
+            raise player.YouTubePostLiveProcessingError('Processing Live')
+        played.append(dict(item))
+        return {'url': item['url']}
+
+    monkeypatch.setattr(player, 'play_item', fake_play)
+
+    result = player.advance_queue_playback(mode='auto_next', prefer_playlist_next=False)
+
+    assert result['status'] == 'playing_next'
+    assert result['skipped_unplayable'] == 1
+    assert played == [ready]
+    assert player.state.QUEUE == []
+
+
 def test_auto_next_drops_bot_checked_last_item_without_requeue(monkeypatch: pytest.MonkeyPatch) -> None:
     bot_item = {'url': 'https://www.youtube.com/watch?v=botcheck', 'title': 'Bot Checked'}
 
@@ -3183,6 +3212,19 @@ def test_bot_check_skip_toast_names_video_and_reason(monkeypatch: pytest.MonkeyP
     assert toasts[0]['level'] == 'warn'
 
 
+def test_post_live_processing_toast_has_blank_line_and_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    toasts: list[str] = []
+    monkeypatch.setattr(player, '_notify_warn_toast', lambda text: toasts.append(text))
+
+    player._notify_post_live_processing(
+        {'url': 'https://youtube.com/watch?v=processing', 'title': 'Processing Live'}
+    )
+
+    assert toasts == [
+        'YouTube is processing this live stream. Replay is not currently available.\n\nProcessing Live'
+    ]
+
+
 def test_restart_current_keeps_playback_when_bot_check_blocks_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
     toasts: list[str] = []
     monkeypatch.setattr(player.state, 'SESSION_STATE', 'playing', raising=False)
@@ -3208,6 +3250,47 @@ def test_restart_current_keeps_playback_when_bot_check_blocks_resolve(monkeypatc
     assert len(toasts) == 1
     assert 'bot check' in toasts[0].lower()
     assert 'Current Video' in toasts[0]
+
+
+def test_restart_current_keeps_playback_when_post_live_is_processing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    toasted: list[object] = []
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'playing', raising=False)
+    monkeypatch.setattr(
+        player.state,
+        'NOW_PLAYING',
+        {'url': 'https://youtube.com/watch?v=processing', 'title': 'Processing Live'},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        player,
+        'resolve_streams',
+        lambda url: resolver.ResolvedStreams(
+            stream=url,
+            transport='mpv_ytdl',
+            live_status='post_live',
+        ),
+    )
+    monkeypatch.setattr(player, '_notify_post_live_processing', lambda item: toasted.append(item))
+    monkeypatch.setattr(
+        player,
+        'stop_mpv',
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError('must keep playback running')),
+    )
+    monkeypatch.setattr(
+        player,
+        'play_item',
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError('must not replay post-live')),
+    )
+
+    assert player.restart_current() is None
+    assert toasted == [
+        {
+            'url': 'https://youtube.com/watch?v=processing',
+            'title': 'Processing Live',
+        }
+    ]
 
 
 def test_restart_current_resolves_before_stopping_and_reuses_stream(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3291,7 +3374,8 @@ def test_resolver_defers_postlive_youtube_to_mpv_ytdl_hook(monkeypatch: pytest.M
         'post_live\n',
     )
 
-    stream, audio = resolver.resolve_streams_ytdlp(url)
+    result = resolver.resolve_streams_ytdlp(url)
+    stream, audio = result
 
     # Segmented live formats 204 without per-segment params, so the page URL
     # goes to mpv and its yt-dlp hook drives the manifest.
@@ -3300,6 +3384,62 @@ def test_resolver_defers_postlive_youtube_to_mpv_ytdl_hook(monkeypatch: pytest.M
     assert '--print' in calls[0]
     assert 'live_status' in calls[0]
     assert '-g' not in calls[0]
+    assert result.transport == 'mpv_ytdl'
+    assert result.live_status == 'post_live'
+    assert result.ytdl_format.startswith('bestvideo[')
+    assert result.ytdl_format != 'auto'
+    assert 'cookies=' not in result.ytdl_raw_options
+
+
+def test_resolver_live_default_candidate_does_not_pass_auto_format(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = 'https://www.youtube.com/watch?v=postlive-default'
+    _patch_resolver_ytdlp_env(
+        monkeypatch,
+        'https://segments.example/videoplayback?a=1\npost_live\n',
+    )
+    monkeypatch.setattr(
+        'relaytv_app.video_profile.get_profile',
+        lambda: {'decode_profile': 'default', 'display_cap_height': 1080, 'av1_allowed': True},
+    )
+
+    result = resolver.resolve_streams_ytdlp(url)
+
+    # An empty candidate means yt-dlp's default selection. Do not translate
+    # the resolver telemetry label "auto" into the invalid `--format auto`.
+    assert result.ytdl_format == ''
+
+
+def test_resolver_live_handoff_preserves_cookie_and_challenge_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = 'https://www.youtube.com/watch?v=live1'
+    calls = _patch_resolver_ytdlp_env(
+        monkeypatch,
+        'https://segments.example/videoplayback?a=1\nis_live\n',
+    )
+    monkeypatch.setattr(
+        resolver,
+        'build_ytdlp_base_args',
+        lambda: [
+            'yt-dlp',
+            '--cookies',
+            '/data/cookies.txt',
+            '--js-runtimes',
+            'deno',
+            '--no-playlist',
+        ],
+    )
+
+    result = resolver.resolve_streams_ytdlp(url)
+
+    assert tuple(result) == (url, None)
+    assert result.transport == 'mpv_ytdl'
+    assert 'cookies=/data/cookies.txt' in result.ytdl_raw_options
+    assert 'js-runtimes=deno' in result.ytdl_raw_options
+    assert 'remote-components=ejs:github' in result.ytdl_raw_options
+    assert calls
 
 
 def test_resolver_keeps_resolved_urls_for_vod_youtube(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3516,6 +3656,82 @@ def test_play_item_reuses_fresh_resolved_stream_without_ytdlp(monkeypatch: pytes
     assert now['stream'] == 'https://video.example/resolved.mp4'
     assert now['_resolved_stream'] == 'https://video.example/resolved.mp4'
     assert now_values[-1]['_resolved_at'] == 999.0
+
+
+def test_play_item_forwards_live_ytdl_handoff_without_caching_page_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = 'https://youtube.com/watch?v=live1'
+    load_calls: list[dict[str, object]] = []
+    start_calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(player, 'update_history_progress', lambda *a, **k: None)
+    monkeypatch.setattr(player, '_mark_playback_transition', lambda *a, **k: None)
+    monkeypatch.setattr(player, 'cec_auto_on_switch', lambda cec: False)
+    monkeypatch.setattr(player, '_qt_shell_backend_enabled', lambda: False)
+    monkeypatch.setattr(
+        player,
+        '_load_stream_in_existing_mpv',
+        lambda stream_url, audio_url=None, start_pos=None, **kwargs: load_calls.append(
+            {
+                'stream': stream_url,
+                'audio': audio_url,
+                'start_pos': start_pos,
+                **kwargs,
+            }
+        )
+        or False,
+    )
+    monkeypatch.setattr(
+        player,
+        'start_mpv',
+        lambda stream_url, audio_url=None, start_pos=None, **kwargs: start_calls.append(
+            {
+                'stream': stream_url,
+                'audio': audio_url,
+                'start_pos': start_pos,
+                **kwargs,
+            }
+        ),
+    )
+    monkeypatch.setattr(player, '_add_history_entry', lambda now: None)
+    monkeypatch.setattr(player, '_prime_mpv_up_next_from_queue', lambda force=False: False)
+    monkeypatch.setattr(player.state, 'NOW_PLAYING', None, raising=False)
+    monkeypatch.setattr(player.state, 'get_tv_state', lambda: {})
+    monkeypatch.setattr(player.state, 'set_now_playing', lambda value: None)
+    monkeypatch.setattr(player.state, 'set_session_state', lambda value: None)
+    monkeypatch.setattr(player.state, 'set_pause_reason', lambda value: None)
+    monkeypatch.setattr(player.state, 'set_session_position', lambda value: None)
+    monkeypatch.setattr(
+        player,
+        'resolve_streams',
+        lambda requested_url: resolver.ResolvedStreams(
+            stream=requested_url,
+            transport='mpv_ytdl',
+            ytdl_format='best',
+            ytdl_raw_options='cookies=/data/cookies.txt,js-runtimes=deno',
+        ),
+    )
+
+    now = player.play_item(
+        {'url': url, 'title': 'Live stream', 'provider': 'youtube'},
+        use_resolver=True,
+        cec=False,
+        clear_queue=False,
+        mode='play',
+    )
+
+    expected_handoff = {
+        'stream': url,
+        'audio': None,
+        'start_pos': None,
+        'ytdl_format_override': 'best',
+        'ytdl_raw_options_override': 'cookies=/data/cookies.txt,js-runtimes=deno',
+    }
+    assert load_calls == [expected_handoff]
+    assert start_calls == [expected_handoff]
+    assert now['stream'] == url
+    assert '_resolved_stream' not in now
 
 
 def test_persistable_history_item_keeps_resolved_stream_hint() -> None:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3252,8 +3252,10 @@ def test_restart_current_keeps_playback_when_bot_check_blocks_resolve(monkeypatc
     assert 'Current Video' in toasts[0]
 
 
+@pytest.mark.parametrize('resolve_outcome', ['resolves_post_live', 'raises_processing'])
 def test_restart_current_keeps_playback_when_post_live_is_processing(
     monkeypatch: pytest.MonkeyPatch,
+    resolve_outcome: str,
 ) -> None:
     toasted: list[object] = []
     monkeypatch.setattr(player.state, 'SESSION_STATE', 'playing', raising=False)
@@ -3263,15 +3265,13 @@ def test_restart_current_keeps_playback_when_post_live_is_processing(
         {'url': 'https://youtube.com/watch?v=processing', 'title': 'Processing Live'},
         raising=False,
     )
-    monkeypatch.setattr(
-        player,
-        'resolve_streams',
-        lambda url: resolver.ResolvedStreams(
-            stream=url,
-            transport='mpv_ytdl',
-            live_status='post_live',
-        ),
-    )
+
+    def resolve(url):
+        if resolve_outcome == 'raises_processing':
+            raise resolver.YouTubePostLiveProcessingError(url)
+        return resolver.ResolvedStreams(stream=url, transport='mpv_ytdl', live_status='post_live')
+
+    monkeypatch.setattr(player, 'resolve_streams', resolve)
     monkeypatch.setattr(player, '_notify_post_live_processing', lambda item: toasted.append(item))
     monkeypatch.setattr(
         player,
@@ -3389,6 +3389,51 @@ def test_resolver_defers_postlive_youtube_to_mpv_ytdl_hook(monkeypatch: pytest.M
     assert result.ytdl_format.startswith('bestvideo[')
     assert result.ytdl_format != 'auto'
     assert 'cookies=' not in result.ytdl_raw_options
+
+
+def test_resolver_raises_post_live_processing_when_replay_is_unready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = 'https://www.youtube.com/watch?v=stillcooking'
+    calls: list[list[str]] = []
+
+    class Proc:
+        returncode = 1
+        stdout = ''
+        stderr = 'ERROR: [youtube] stillcooking: This live stream recording is not available.'
+
+    monkeypatch.setattr('relaytv_app.state.get_settings', lambda: {})
+    monkeypatch.setattr(
+        'relaytv_app.video_profile.get_profile',
+        lambda: {'decode_profile': 'default', 'display_cap_height': 1080, 'av1_allowed': False},
+    )
+    monkeypatch.setattr(resolver.shutil, 'which', lambda name: None)
+
+    def fake_run(cmd, check=False):
+        calls.append(list(cmd))
+        return Proc()
+
+    monkeypatch.setattr(resolver, 'run', fake_run)
+
+    with pytest.raises(resolver.YouTubePostLiveProcessingError):
+        resolver.resolve_streams_ytdlp(url)
+    assert calls
+
+
+def test_mpv_ytdl_raw_options_quotes_comma_values() -> None:
+    value = 'youtube:player_client=default,web_safari'
+    out = resolver._mpv_ytdl_raw_options([
+        'yt-dlp',
+        '--cookies',
+        '/data/cookies.txt',
+        '--extractor-args',
+        value,
+        '--no-playlist',
+    ])
+
+    # mpv's key/value-list parser has no escape character; comma-bearing
+    # values must use its %n% length-prefixed quoting to survive parsing.
+    assert out == f'cookies=/data/cookies.txt,extractor-args=%{len(value)}%{value}'
 
 
 def test_resolver_live_default_candidate_does_not_pass_auto_format(
@@ -3710,6 +3755,7 @@ def test_play_item_forwards_live_ytdl_handoff_without_caching_page_url(
             transport='mpv_ytdl',
             ytdl_format='best',
             ytdl_raw_options='cookies=/data/cookies.txt,js-runtimes=deno',
+            live_status='is_live',
         ),
     )
 
@@ -3732,6 +3778,57 @@ def test_play_item_forwards_live_ytdl_handoff_without_caching_page_url(
     assert start_calls == [expected_handoff]
     assert now['stream'] == url
     assert '_resolved_stream' not in now
+
+
+@pytest.mark.parametrize('resolve_outcome', ['resolves_post_live', 'raises_processing'])
+def test_play_item_toasts_and_clears_prefetch_when_replay_is_unready(
+    monkeypatch: pytest.MonkeyPatch,
+    resolve_outcome: str,
+) -> None:
+    url = 'https://youtube.com/watch?v=stillcooking'
+    toasted: list[object] = []
+
+    monkeypatch.setattr(player, 'update_history_progress', lambda *a, **k: None)
+    monkeypatch.setattr(player, 'cec_auto_on_switch', lambda cec: False)
+    monkeypatch.setattr(player, '_qt_shell_backend_enabled', lambda: False)
+    monkeypatch.setattr(player.state, 'NOW_PLAYING', None, raising=False)
+    monkeypatch.setattr(player.state, 'get_tv_state', lambda: {})
+    monkeypatch.setattr(player, '_notify_post_live_processing', lambda item: toasted.append(item))
+    monkeypatch.setattr(
+        player,
+        'start_mpv',
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError('must not start playback')),
+    )
+
+    def resolve(requested_url):
+        if resolve_outcome == 'raises_processing':
+            raise resolver.YouTubePostLiveProcessingError(requested_url)
+        # A resolved post_live stream is only watchable at the live edge, so
+        # play_item must skip it exactly like a resolver-raised processing
+        # error instead of starting playback that dies within seconds.
+        return resolver.ResolvedStreams(
+            stream=requested_url,
+            transport='mpv_ytdl',
+            live_status='post_live',
+        )
+
+    monkeypatch.setattr(player, 'resolve_streams', resolve)
+
+    item = {
+        'url': url,
+        'title': 'Still cooking',
+        'provider': 'youtube',
+        '_resolved_source_url': url,
+        '_resolved_stream': 'https://stale.example/segments',
+        '_resolved_audio': None,
+        '_resolved_at': 0.0,
+    }
+    with pytest.raises(resolver.YouTubePostLiveProcessingError):
+        player.play_item(item, use_resolver=True, cec=False, clear_queue=False, mode='play')
+
+    assert len(toasted) == 1
+    assert toasted[0]['url'] == url
+    assert '_resolved_stream' not in toasted[0]
 
 
 def test_persistable_history_item_keeps_resolved_stream_hint() -> None:


### PR DESCRIPTION
## Summary

Live/post-live YouTube playback goes through mpv's yt-dlp hook (PR #29), but the hook re-ran yt-dlp with **default arguments** — no cookies, no JS challenge runtime, no remote components — so a live stream that RelayTV's resolver had just resolved successfully could still bot-check or mis-resolve inside mpv. This PR closes that gap and hardens what happens while YouTube is still processing a just-ended stream:

- **The winning resolver strategy now travels with the handoff.** `resolve_streams` returns a `ResolvedStreams` result (iterates as the old two-tuple, so existing callers are untouched) carrying the successful strategy's format candidate and its args translated into mpv `ytdl-raw-options` (cookies, `js-runtimes`, `remote-components`, extractor args). The overrides flow through every playback path: fresh mpv spawn, Qt shell, external-mpv fallback, and seamless in-place replacement (set via IPC before `loadfile`), plus a transient handoff so a settings-apply restart doesn't resolve twice.
- **Raw-option values are quoted with mpv's `%n%` length-prefixed syntax.** mpv's key/value-list parser has no escape character — a backslash-escaped comma makes mpv **exit at startup** (CLI) or rejects the property set (IPC). Comma-bearing values (e.g. an operator `--extractor-args youtube:player_client=a,b`) now survive both paths, verified against real mpv v0.41.
- **Just-ended streams skip with an honest toast instead of pretending to play.** While YouTube processes a replay (`live_status=post_live`), the only transport it serves is the live-edge fragment feed — no manifest, no fragment durations for mpv's hook — so "playback" starts seconds from the end and dies (verified on-device: mpv joined a 4900-second replay at 4899s). Post-live now pushes the "YouTube is processing this live stream" warn toast and skips: direct plays advance the queue, auto-next skips without requeueing, and a settings-apply restart keeps the current video running. The resolver also raises the same skip when yt-dlp fails with YouTube's "live stream recording is not available" reason. The replay plays as a normal VOD once processing completes.

## Test plan

- [x] 353 tests pass (`pytest tests/ -q`), including new coverage for the strategy→raw-options translation (cookie/challenge propagation, `%n%` comma quoting, no `--format auto` leakage), handoff forwarding without caching the page URL, post-live skip on both resolver outcomes (resolved `post_live` and the "recording is not available" failure), queue auto-advance, and restart-keeps-playing semantics
- [x] Verified the generated `ytdl-raw-options` string round-trips through real mpv (v0.41) on both the command line and IPC `set_property`, with comma-bearing extractor-args intact; the previous backslash escape reproduces mpv exiting with `Error parsing option`
- [x] Live-verified on this host (Docker runtime): a real `post_live` video skips with the processing toast and the queue advances to the next item; live-edge diagnosis confirmed empirically (only the `tv` client serves post-live formats; `ios`/`android`/`web_safari` refuse; fragments carry no durations, so `live_start_index=0`, `--live-from-start`, and a synthesized EDL timeline were all tested and rejected)

## Release notes

BEGIN_COMMIT_OVERRIDE
fix: live YouTube streams keep your cookies and bot-challenge settings when handed to mpv, so a stream that resolves no longer hits a bot check the moment playback starts

fix: a just-ended YouTube stream now shows "YouTube is processing this live stream" and moves on to the next video instead of playing its final seconds and stopping — the replay plays normally once YouTube finishes processing it
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)