### PR TITLE
fix: wait for YouTube media URL availability

### DIFF
--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -3614,6 +3614,26 @@ def _item_needs_metadata_prefetch(item: object) -> bool:
     return (not title) or title == url or (not thumb)
 
 
+def _wait_for_resolved_media_availability(item: object) -> None:
+    """Honor yt-dlp's delay before opening a newly signed media URL."""
+    if not isinstance(item, dict):
+        return
+    try:
+        available_at = float(
+            item.get("_playback_available_at")
+            or item.get("_resolved_available_at")
+            or 0.0
+        )
+    except (TypeError, ValueError):
+        return
+    wait_sec = available_at - int(time.time())
+    if wait_sec <= 0.0:
+        return
+    wait_sec = min(15.0, wait_sec) + 0.2
+    logger.info("resolved_media_availability_wait wait_sec=%.2f", wait_sec)
+    time.sleep(wait_sec)
+
+
 def _fresh_prefetched_stream(item: object) -> tuple[str, str | None] | None:
     if not isinstance(item, dict):
         return None
@@ -3635,15 +3655,35 @@ def _fresh_prefetched_stream(item: object) -> tuple[str, str | None] | None:
     return stream, audio
 
 
-def _store_prefetched_stream(item: dict[str, Any], url: str, stream: str, audio: str | None) -> None:
+def _store_prefetched_stream(
+    item: dict[str, Any],
+    url: str,
+    stream: str,
+    audio: str | None,
+    available_at: object = None,
+) -> None:
     item["_resolved_source_url"] = str(url or "").strip()
     item["_resolved_stream"] = str(stream or "").strip()
     item["_resolved_audio"] = str(audio or "").strip() if audio else ""
     item["_resolved_at"] = float(time.time())
+    try:
+        available_ts = float(available_at or 0.0)
+    except (TypeError, ValueError):
+        available_ts = 0.0
+    if available_ts > 0.0:
+        item["_resolved_available_at"] = available_ts
+    else:
+        item.pop("_resolved_available_at", None)
 
 
 def _clear_prefetched_stream(item: dict[str, Any]) -> None:
-    for key in ("_resolved_source_url", "_resolved_stream", "_resolved_audio", "_resolved_at"):
+    for key in (
+        "_resolved_source_url",
+        "_resolved_stream",
+        "_resolved_audio",
+        "_resolved_at",
+        "_resolved_available_at",
+    ):
         item.pop(key, None)
 
 
@@ -3653,6 +3693,14 @@ def _resolved_playback_source(
     result: object,
 ) -> tuple[str, str | None, str | None, str | None]:
     stream, audio = result
+    try:
+        available_at = float(getattr(result, "available_at", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        available_at = 0.0
+    if available_at > 0.0:
+        item["_playback_available_at"] = available_at
+    else:
+        item.pop("_playback_available_at", None)
     if str(getattr(result, "transport", "direct") or "direct") == "mpv_ytdl":
         _clear_prefetched_stream(item)
         ytdl_format = str(getattr(result, "ytdl_format", "") or "").strip()
@@ -3662,7 +3710,7 @@ def _resolved_playback_source(
             ytdl_raw = ",".join(part for part in (operator_raw, ytdl_raw) if part)
         return str(stream), (str(audio) if audio else None), ytdl_format, ytdl_raw
     else:
-        _store_prefetched_stream(item, url, stream, audio)
+        _store_prefetched_stream(item, url, stream, audio, available_at)
     return str(stream), (str(audio) if audio else None), None, None
 
 
@@ -4714,6 +4762,7 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
         if ytdl_format_override is not None or ytdl_raw_options_override is not None
         else {}
     )
+    _wait_for_resolved_media_availability(item)
     with MPV_LOCK:
         t_mpv = time.monotonic()
         # Resolver work can outlast the initial transition window. Refresh it

--- a/app/relaytv_app/resolver.py
+++ b/app/relaytv_app/resolver.py
@@ -39,6 +39,7 @@ class ResolvedStreams:
     ytdl_format: str = ""
     ytdl_raw_options: str = ""
     live_status: str = ""
+    available_at: float = 0.0
 
     def __iter__(self):
         yield self.stream
@@ -575,7 +576,20 @@ def resolve_streams_ytdlp(url: str):
     # just-ended (post_live) videos only expose segmented formats whose bare
     # URLs return 204 No Content, so they must not be handed to mpv directly.
     resolve_live_status = is_youtube_url(u)
-    output_args = ["--print", "urls", "--print", "live_status"] if resolve_live_status else ["-g"]
+    output_args = (
+        [
+            "--print",
+            "urls",
+            "--print",
+            "relaytv_format_available_at:%(requested_formats.0.available_at)s",
+            "--print",
+            "relaytv_available_at:%(available_at)s",
+            "--print",
+            "live_status",
+        ]
+        if resolve_live_status
+        else ["-g"]
+    )
 
     strategies: list[tuple[list[str], list[str]]] = [(base, candidates)]
     if is_youtube_url(u):
@@ -685,9 +699,25 @@ def resolve_streams_ytdlp(url: str):
 
     lines = [ln.strip() for ln in (p.stdout or "").splitlines() if ln.strip()]
     live_status = ""
-    if resolve_live_status and lines and not lines[-1].lower().startswith(("http://", "https://")):
-        live_status = lines[-1].strip().lower()
-        lines = lines[:-1]
+    available_at = 0.0
+    if resolve_live_status:
+        media_lines: list[str] = []
+        for line in lines:
+            if line.startswith(("relaytv_format_available_at:", "relaytv_available_at:")):
+                raw_available_at = line.split(":", 1)[1].strip()
+                if raw_available_at and raw_available_at != "NA":
+                    try:
+                        candidate_available_at = float(raw_available_at)
+                    except (TypeError, ValueError):
+                        candidate_available_at = 0.0
+                    if candidate_available_at > 0.0:
+                        available_at = candidate_available_at
+                continue
+            media_lines.append(line)
+        lines = media_lines
+        if lines and not lines[-1].lower().startswith(("http://", "https://")):
+            live_status = lines[-1].strip().lower()
+            lines = lines[:-1]
     total_ms = int((time.monotonic() - t0) * 1000)
     debug_log("youtube", f"yt-dlp resolve succeeded in {total_ms}ms with {len(lines)} stream line(s)")
     _log_resolve(f"yt-dlp resolve succeeded total_ms={total_ms} stream_lines={len(lines)}")
@@ -709,12 +739,24 @@ def resolve_streams_ytdlp(url: str):
             ytdl_format=selected_candidate,
             ytdl_raw_options=_mpv_ytdl_raw_options(selected_args),
             live_status=live_status,
+            available_at=available_at,
         )
     if not lines:
         raise HTTPException(status_code=400, detail="yt-dlp returned no stream URLs")
     if len(lines) == 1:
-        return lines[0], None
-    return lines[0], lines[1]
+        return ResolvedStreams(
+            stream=lines[0],
+            transport="yt-dlp",
+            live_status=live_status,
+            available_at=available_at,
+        )
+    return ResolvedStreams(
+        stream=lines[0],
+        audio=lines[1],
+        transport="yt-dlp",
+        live_status=live_status,
+        available_at=available_at,
+    )
 
 
 def resolve_streams_invidious(youtube_url: str, base: str | None = None):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3562,14 +3562,47 @@ def test_resolver_live_handoff_preserves_cookie_and_challenge_options(
 def test_resolver_keeps_resolved_urls_for_vod_youtube(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = _patch_resolver_ytdlp_env(
         monkeypatch,
-        'https://cdn.example/video.mp4\nhttps://cdn.example/audio.m4a\nnot_live\n',
+        'https://cdn.example/video.mp4\n'
+        'https://cdn.example/audio.m4a\n'
+        'relaytv_format_available_at:1234\n'
+        'relaytv_available_at:NA\n'
+        'not_live\n',
     )
 
-    stream, audio = resolver.resolve_streams_ytdlp('https://www.youtube.com/watch?v=vod1')
+    result = resolver.resolve_streams_ytdlp('https://www.youtube.com/watch?v=vod1')
+    stream, audio = result
 
     assert stream == 'https://cdn.example/video.mp4'
     assert audio == 'https://cdn.example/audio.m4a'
+    assert result.available_at == 1234.0
     assert calls
+
+
+def test_resolved_media_wait_honors_extractor_availability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slept: list[float] = []
+    monkeypatch.setattr(player.time, 'time', lambda: 1000.4)
+    monkeypatch.setattr(player.time, 'sleep', lambda seconds: slept.append(seconds))
+
+    player._wait_for_resolved_media_availability(
+        {'_playback_available_at': 1004.0}
+    )
+
+    assert slept == [pytest.approx(4.2)]
+
+
+def test_resolved_media_wait_ignores_expired_or_invalid_availability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slept: list[float] = []
+    monkeypatch.setattr(player.time, 'time', lambda: 1000.4)
+    monkeypatch.setattr(player.time, 'sleep', lambda seconds: slept.append(seconds))
+
+    player._wait_for_resolved_media_availability({'_resolved_available_at': 999.0})
+    player._wait_for_resolved_media_availability({'_resolved_available_at': 'invalid'})
+
+    assert slept == []
 
 
 def test_resolver_non_youtube_keeps_plain_url_output(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3727,17 +3760,27 @@ def test_session_tracker_does_not_reopen_closed_session(monkeypatch: pytest.Monk
 def test_play_item_reuses_fresh_resolved_stream_without_ytdlp(monkeypatch: pytest.MonkeyPatch) -> None:
     start_calls: list[dict[str, object]] = []
     now_values: list[dict] = []
+    events: list[object] = []
 
     monkeypatch.setattr(player, 'update_history_progress', lambda *a, **k: None)
     monkeypatch.setattr(player, '_mark_playback_transition', lambda *a, **k: None)
     monkeypatch.setattr(player, 'cec_auto_on_switch', lambda cec: False)
-    monkeypatch.setattr(player, '_load_stream_in_existing_mpv', lambda *a, **k: False)
+    monkeypatch.setattr(
+        player,
+        '_load_stream_in_existing_mpv',
+        lambda *a, **k: events.append('load') or False,
+    )
+
+    def start_mpv(stream_url, audio_url=None, start_pos=None):
+        events.append('start')
+        start_calls.append(
+            {'stream': stream_url, 'audio': audio_url, 'start_pos': start_pos}
+        )
+
     monkeypatch.setattr(
         player,
         'start_mpv',
-        lambda stream_url, audio_url=None, start_pos=None: start_calls.append(
-            {'stream': stream_url, 'audio': audio_url, 'start_pos': start_pos}
-        ),
+        start_mpv,
     )
     monkeypatch.setattr(player, 'mpv_set', lambda *a, **k: None)
     monkeypatch.setattr(player, '_add_history_entry', lambda now: None)
@@ -3750,6 +3793,11 @@ def test_play_item_reuses_fresh_resolved_stream_without_ytdlp(monkeypatch: pytes
     monkeypatch.setattr(player.state, 'set_session_position', lambda value: None)
     monkeypatch.setattr(player, 'resolve_streams', lambda url: (_ for _ in ()).throw(AssertionError('yt-dlp should not run')))
     monkeypatch.setattr(player.time, 'time', lambda: 1000.0)
+    monkeypatch.setattr(
+        player.time,
+        'sleep',
+        lambda seconds: events.append(('sleep', seconds)),
+    )
 
     now = player.play_item(
         {
@@ -3761,6 +3809,7 @@ def test_play_item_reuses_fresh_resolved_stream_without_ytdlp(monkeypatch: pytes
             '_resolved_stream': 'https://video.example/resolved.mp4',
             '_resolved_audio': 'https://audio.example/resolved.m4a',
             '_resolved_at': 999.0,
+            '_resolved_available_at': 1004.0,
         },
         use_resolver=True,
         cec=False,
@@ -3773,6 +3822,9 @@ def test_play_item_reuses_fresh_resolved_stream_without_ytdlp(monkeypatch: pytes
     assert now['stream'] == 'https://video.example/resolved.mp4'
     assert now['_resolved_stream'] == 'https://video.example/resolved.mp4'
     assert now_values[-1]['_resolved_at'] == 999.0
+    assert events[0] == ('sleep', pytest.approx(4.2))
+    assert events[1] == 'load'
+    assert events[-1] == 'start'
 
 
 def test_play_item_forwards_live_ytdl_handoff_without_caching_page_url(


### PR DESCRIPTION
## Summary

Capture yt-dlp's selected-format `available_at` timestamp and wait until the signed YouTube media URL is usable before handing it to mpv. Preserve that timestamp through queue prefetch so prefetched playback follows the same timing contract.

Root cause: YouTube returned a fresh signed URL before it was available. RelayTV opened it immediately and received HTTP 403, while yt-dlp waited several seconds before downloading successfully.

## Changelog

Type: fix

User impact: YouTube videos no longer fail immediately with HTTP 403 when Google delays access to a newly generated media URL.

Operator/deployment impact: None. No configuration or dependency changes.

Breaking change: no

## Tests

- `ruff check app tests`
- `PYTHONPATH=app pytest -q` (377 passed)
- `git diff --check`
- Rebuilt the native Qt container and replayed the previously failing YouTube video. RelayTV logged a 4.20-second availability wait and playback advanced normally without a 403.

BEGIN_COMMIT_OVERRIDE
fix: wait for YouTube media URL availability
END_COMMIT_OVERRIDE