### PR TITLE
feat: redesign the remote UI as a neon-glass control system

### DIFF
--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3316,7 +3316,7 @@ def ui():
   <link rel="shortcut icon" href="/pwa/brand/logo.svg?v=2" />
   <link rel="apple-touch-icon" href="/pwa/brand/logo.svg?v=2" />
   <title>RelayTV</title>
-  <link rel="stylesheet" href="/static/ui/app.css" />
+  <link rel="stylesheet" href="/static/ui/app.css?v=__UI_ASSET_V__" />
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
@@ -3637,7 +3637,7 @@ def ui():
   </div>
 
   <script>window.RELAYTV_IDLE_PANEL_CATALOG = __IDLE_PANEL_CATALOG__;</script>
-  <script src="/static/ui/app.js" defer></script>
+  <script src="/static/ui/app.js?v=__UI_ASSET_V__" defer></script>
 </body>
 </html>
 <!-- Settings modal -->
@@ -3947,4 +3947,19 @@ def ui():
 
 """
     html = html.replace("__IDLE_PANEL_CATALOG__", _json.dumps(_idle_panel_catalog(), separators=(",", ":"), ensure_ascii=False))
-    return HTMLResponse(content=html)
+    html = html.replace("__UI_ASSET_V__", _ui_asset_version())
+    # The shell must never be cached: it carries the asset version stamp that
+    # busts the hour-long static cache on app.js/app.css after a deploy.
+    return HTMLResponse(content=html, headers={"Cache-Control": "no-cache"})
+
+
+def _ui_asset_version() -> str:
+    stamp = 0
+    for name in ("app.css", "app.js"):
+        path = _resolve_static_asset("ui", name)
+        try:
+            if path:
+                stamp = max(stamp, int(os.path.getmtime(path)))
+        except OSError:
+            pass
+    return str(stamp or int(time.time()))

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3331,19 +3331,22 @@ def ui():
 <body>
   <div class="wrap">
     <header>
-      <h1 id="appBrandName">RelayTV</h1>
+      <div class="hdrBrand">
+        <span class="hdrKicker" aria-hidden="true">RelayTV</span>
+        <h1 id="appBrandName">RelayTV</h1>
+      </div>
       <div class="hdrRight">
-        <button id="jellyfinOpenBtn" class="jfLaunch" title="Open Jellyfin" aria-label="Open Jellyfin"><span class="jfBrand">Jellyfin</span></button>
-        <button id="addUrlBtn" class="hdrAddBtn" title="Add URL">＋</button>
+        <button id="jellyfinOpenBtn" class="jfLaunch" title="Open Jellyfin" aria-label="Open Jellyfin"><span class="jfDot" aria-hidden="true"></span><span class="jfBrand">Jellyfin</span></button>
+        <button id="addUrlBtn" class="hdrAddBtn" title="Add URL" aria-label="Add URL">＋</button>
         <div id="hdrMenuWrap" class="hdrMenuWrap">
           <button id="hdrMenuBtn" class="hdrMenuBtn" title="Menu" aria-label="Menu" aria-expanded="false" aria-haspopup="menu" aria-controls="hdrMenuPanel">
-            <span class="menuLabel">MENU</span>
-            <span class="menuIcon">☰</span>
+            <svg class="menuGlyph" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>
           </button>
           <div id="hdrMenuPanel" class="hdrMenuPanel hidden" role="menu" aria-label="Header menu">
-            <button id="histBtn" class="hdrMenuItem" role="menuitem" title="History">History</button>
-            <button id="aboutBtn" class="hdrMenuItem" role="menuitem" title="About RelayTV">About</button>
-            <button id="settingsBtn" class="hdrMenuItem" role="menuitem" title="Settings">Settings</button>
+            <button id="histBtn" class="hdrMenuItem" role="menuitem" title="History"><svg class="miIcon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 5v4H8.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M5.2 9a8 8 0 1 1-1.1 4.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/><path d="M12 8.5V12l2.6 1.7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>History</button>
+            <button id="aboutBtn" class="hdrMenuItem" role="menuitem" title="About RelayTV"><svg class="miIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="8.6" stroke="currentColor" stroke-width="1.8" fill="none"/><path d="M12 11.2v5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/><circle cx="12" cy="7.9" r="1.15" fill="currentColor"/></svg>About</button>
+            <button id="settingsBtn" class="hdrMenuItem" role="menuitem" title="Settings"><svg class="miIcon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h8m6 0h2M4 12h2m6 0h8M4 17h10m6 0h0" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/><circle cx="15" cy="7" r="2" stroke="currentColor" stroke-width="1.8" fill="none"/><circle cx="9" cy="12" r="2" stroke="currentColor" stroke-width="1.8" fill="none"/><circle cx="17" cy="17" r="2" stroke="currentColor" stroke-width="1.8" fill="none"/></svg>Settings</button>
+            <div class="hdrMenuFoot"><span id="menuDeviceName">RelayTV</span><span id="menuAppVersion"></span></div>
           </div>
         </div>
       </div>

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3346,6 +3346,14 @@ def ui():
             <button id="histBtn" class="hdrMenuItem" role="menuitem" title="History"><svg class="miIcon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 5v4H8.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M5.2 9a8 8 0 1 1-1.1 4.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/><path d="M12 8.5V12l2.6 1.7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>History</button>
             <button id="aboutBtn" class="hdrMenuItem" role="menuitem" title="About RelayTV"><svg class="miIcon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="8.6" stroke="currentColor" stroke-width="1.8" fill="none"/><path d="M12 11.2v5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/><circle cx="12" cy="7.9" r="1.15" fill="currentColor"/></svg>About</button>
             <button id="settingsBtn" class="hdrMenuItem" role="menuitem" title="Settings"><svg class="miIcon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h8m6 0h2M4 12h2m6 0h8M4 17h10m6 0h0" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/><circle cx="15" cy="7" r="2" stroke="currentColor" stroke-width="1.8" fill="none"/><circle cx="9" cy="12" r="2" stroke="currentColor" stroke-width="1.8" fill="none"/><circle cx="17" cy="17" r="2" stroke="currentColor" stroke-width="1.8" fill="none"/></svg>Settings</button>
+            <div class="hdrMenuTheme" role="group" aria-label="Theme">
+              <span class="mtLabel">Theme</span>
+              <div class="mtSeg">
+                <button type="button" class="mtBtn" data-theme-mode="auto" role="menuitemradio" aria-checked="true">Auto</button>
+                <button type="button" class="mtBtn" data-theme-mode="dark" role="menuitemradio" aria-checked="false">Dark</button>
+                <button type="button" class="mtBtn" data-theme-mode="light" role="menuitemradio" aria-checked="false">Light</button>
+              </div>
+            </div>
             <div class="hdrMenuFoot"><span id="menuDeviceName">RelayTV</span><span id="menuAppVersion"></span></div>
           </div>
         </div>

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3427,12 +3427,12 @@ def ui():
 
     <!-- Hidden by default: history modal (opened via 🕘 button) -->
     <div id="histBackdrop" class="modalBackdrop hidden" role="dialog" aria-modal="true">
-      <div class="modal">
+      <div class="modal histModal">
         <div class="modalTop">
           <div class="modalTitle">History</div>
           <div class="modalBtns">
             <button id="histClearBtn" class="danger" title="Clear history">Clear</button>
-            <button id="histCloseBtn" title="Close">Close</button>
+            <button id="histCloseBtn" class="iconBtn sm" title="Close" aria-label="Close">✕</button>
           </div>
         </div>
         <div id="histList" class="histList"></div>

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3578,12 +3578,15 @@ def ui():
       </section>
     </div>
 
-      <aside class="card">
-        <div class="sectionTitle">QUEUE</div>
+      <aside class="card queueCard">
+        <div class="qHead">
+          <span class="qHeadTitle">Queue</span>
+          <span id="queueCount" class="qCount">0</span>
+          <button id="queueClearBtn" class="qClearBtn hidden" title="Clear queue" onclick="post('/clear')">Clear</button>
+        </div>
         <ol id="queue" class="queueList"></ol>
         <div class="footerRow">
           <span>Tip: Share again while playing to enqueue</span>
-          <span><a class="link" href="#" onclick="post('/clear');return false;">clear</a></span>
         </div>
       </aside>
     </div>

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3364,35 +3364,34 @@ def ui():
 
     <!-- Hidden by default: manual URL modal (opened via ＋ button) -->
     <div id="addBackdrop" class="modalBackdrop hidden" role="dialog" aria-modal="true">
-      <div class="modal">
+      <div class="modal addModal">
         <div class="modalTop">
-          <div class="modalTitle">Add URL</div>
+          <div class="modalTitle">Send to TV</div>
           <div class="modalBtns">
             <button id="addCloseBtn" class="iconBtn sm" title="Close" aria-label="Close">✕</button>
           </div>
         </div>
 
-        <div class="fieldRow">
-          <input id="addUrlInput" class="urlInput" type="url" inputmode="url" autocomplete="off" spellcheck="false" placeholder="Paste a video URL…" />
-          <button id="addPasteBtn" class="iconBtn sm" title="Paste from clipboard" aria-label="Paste">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <path d="M9 4h6a2 2 0 0 1 2 2v2H7V6a2 2 0 0 1 2-2Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
-              <path d="M7 8H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2h-1" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </button>
-        </div>
+        <section class="amSection">
+          <div class="amHead"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10 14a5 5 0 0 0 7.07 0l2.83-2.83a5 5 0 0 0-7.07-7.07L11.5 5.43" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/><path d="M14 10a5 5 0 0 0-7.07 0L4.1 12.83a5 5 0 0 0 7.07 7.07l1.32-1.33" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/></svg><span>Play a link</span></div>
+          <div class="fieldRow">
+            <input id="addUrlInput" class="urlInput" type="url" inputmode="url" autocomplete="off" spellcheck="false" placeholder="Paste a video URL…" />
+            <button id="addPasteBtn" class="iconBtn sm" title="Paste from clipboard" aria-label="Paste">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M9 4h6a2 2 0 0 1 2 2v2H7V6a2 2 0 0 1 2-2Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+                <path d="M7 8H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2h-1" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+            </button>
+          </div>
+          <div class="modalBtns amActions">
+            <button id="addQueueBtn" title="Add to queue">Queue</button>
+            <button id="addPlayBtn" class="good" title="Play now">Play</button>
+          </div>
+          <div id="addHelperTxt" class="helperTxt" data-default="Tip: Clipboard paste works automatically on modern browsers (https/PWA/localhost only). “Queue” keeps the current playback.">Tip: Clipboard paste works automatically on modern browsers (https/PWA/localhost only). “Queue” keeps the current playback.</div>
+        </section>
 
-        <div class="modalBtns" style="margin-top: 12px; justify-content:flex-end;">
-          <button id="addQueueBtn" title="Add to queue">Queue</button>
-          <button id="addPlayBtn" class="good" title="Play now">Play</button>
-        </div>
-
-        <div id="addHelperTxt" class="helperTxt" data-default="Tip: Clipboard paste works automatically on modern browsers (https/PWA/localhost only). “Queue” keeps the current playback.">Tip: Clipboard paste works automatically on modern browsers (https/PWA/localhost only). “Queue” keeps the current playback.</div>
-
-        <div class="addDivider" aria-hidden="true"></div>
-
-        <div id="notifySection" class="notifySection">
-          <div class="notifyTitle">Send Toast Notification</div>
+        <section id="notifySection" class="amSection">
+          <div class="amHead"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13.7 21a2 2 0 0 1-3.4 0" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/></svg><span>Toast notification</span></div>
           <div class="notifyField">
             <label for="notifyTextInput">Text</label>
             <textarea id="notifyTextInput" class="notifyInput" maxlength="500" placeholder="Notification text…"></textarea>
@@ -3422,7 +3421,7 @@ def ui():
             <div id="notifyHelperTxt" class="helperTxt" aria-live="polite"></div>
             <button id="notifySendBtn" class="good" title="Send notification">Send</button>
           </div>
-        </div>
+        </section>
       </div>
     </div>
 

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3301,7 +3301,7 @@ def ui():
 <html lang="en">
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <meta name="theme-color" content="#0b0f19" />
+  <meta name="theme-color" content="#05070d" />
   <link rel="manifest" href="/manifest.json" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -3529,22 +3529,51 @@ def ui():
       </section>
 
       <section id="remoteCard" class="card remoteCard">
-        <div class="sectionTitle">REMOTE</div>
-
-        <div class="controls" style="margin-top:12px; grid-template-columns: repeat(2, minmax(0, 1fr));">
-          <button onclick="post('/playback/toggle')"><span class="bIcon">⏯️</span><span>Play/Pause</span></button>
-          <button onclick="post('/next')"><span class="bIcon">⏭️</span><span>Next</span></button>
-          <button onclick="post('/mute')" id="muteBtn"><span class="bIcon">🔇</span><span>Mute</span></button>
-          <button class="danger" onclick="post('/close')" id="closeBtn"><span class="bIcon">✖️</span><span>Close</span></button>
-        </div>
-
-        <div class="controls2">
-          <button onclick="post('/seek',{sec:-10})"><span class="bIcon">↩️</span><span>-10s</span></button>
-          <button onclick="post('/seek',{sec:+30})"><span class="bIcon">↪️</span><span>+30s</span></button>
+        <div class="rGrid">
+          <button id="playPauseBtn" class="rTile rBig" onclick="post('/playback/toggle')" aria-label="Play or pause">
+            <span class="rRing">
+              <svg class="rGlyph rGlyphPlay" viewBox="0 0 24 24" aria-hidden="true"><path d="M8.6 5.9v12.2a.9.9 0 0 0 1.37.77l9.6-6.1a.9.9 0 0 0 0-1.52l-9.6-6.1a.9.9 0 0 0-1.37.75z" fill="currentColor"/></svg>
+              <svg class="rGlyph rGlyphPause" viewBox="0 0 24 24" aria-hidden="true"><rect x="7" y="5" width="3.6" height="14" rx="1.3" fill="currentColor"/><rect x="13.4" y="5" width="3.6" height="14" rx="1.3" fill="currentColor"/></svg>
+            </span>
+            <span class="rLabel">Play/Pause</span>
+          </button>
+          <button class="rTile rBig" onclick="post('/next')" aria-label="Play next">
+            <span class="rRing">
+              <svg class="rGlyph" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6.6v10.8a.85.85 0 0 0 1.3.72l8.2-5.4a.85.85 0 0 0 0-1.44L7.3 5.88A.85.85 0 0 0 6 6.6z" fill="currentColor"/><rect x="16.6" y="5.6" width="2.6" height="12.8" rx="1.1" fill="currentColor"/></svg>
+            </span>
+            <span class="rLabel">Next</span>
+          </button>
+          <button id="muteBtn" class="rTile rWide rMute" onclick="post('/mute')" aria-label="Toggle mute">
+            <span class="rRing">
+              <svg class="rGlyph" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9.6v4.8h3.1l4.6 4V5.6l-4.6 4H4z" fill="currentColor"/><path d="M15.6 9.9l4.2 4.2m0-4.2l-4.2 4.2" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/></svg>
+            </span>
+            <span class="rLabel">Mute</span>
+          </button>
+          <button id="closeBtn" class="rTile rWide rClose" onclick="post('/close')" aria-label="Close playback">
+            <span class="rRing">
+              <svg class="rGlyph" viewBox="0 0 24 24" aria-hidden="true"><path d="M7.2 7.2l9.6 9.6m0-9.6l-9.6 9.6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            </span>
+            <span class="rLabel">Close</span>
+          </button>
+          <button class="rTile rSeek" onclick="post('/seek',{sec:-10})" aria-label="Back 10 seconds">
+            <span class="rRing rRingSeek">
+              <svg class="rGlyph rGlyphSeek" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3.8a8.2 8.2 0 1 1-7.5 4.9" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M4.9 3.2v5h5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><text x="12" y="15.4" text-anchor="middle" font-size="8.2" font-weight="700" fill="currentColor">10</text></svg>
+            </span>
+            <span class="rLabel">−10s</span>
+          </button>
+          <button class="rTile rSeek" onclick="post('/seek',{sec:+30})" aria-label="Forward 30 seconds">
+            <span class="rRing rRingSeek">
+              <svg class="rGlyph rGlyphSeek" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3.8a8.2 8.2 0 1 0 7.5 4.9" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M19.1 3.2v5h-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><text x="12" y="15.4" text-anchor="middle" font-size="8.2" font-weight="700" fill="currentColor">30</text></svg>
+            </span>
+            <span class="rLabel">+30s</span>
+          </button>
         </div>
         <div class="remoteVolumeRow">
-          <div id="remoteVolValue" class="remoteVolumeValue">--%</div>
+          <span class="rVolIcon" aria-hidden="true">
+            <svg viewBox="0 0 24 24"><path d="M4 9.6v4.8h3.1l4.6 4V5.6l-4.6 4H4z" fill="currentColor"/><path d="M15.3 9.2a4.4 4.4 0 0 1 0 5.6m2.5-8a8 8 0 0 1 0 10.4" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>
+          </span>
           <input id="remoteVolSlider" class="remoteVolumeSlider" type="range" min="0" max="200" step="1" value="100" aria-label="Volume" />
+          <div id="remoteVolValue" class="remoteVolumeValue">--%</div>
         </div>
       </section>
     </div>

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3263,14 +3263,20 @@ async def _ui_events_sse(request: Request) -> object:
                     last_queue_length = queue_length
                     last_has_now_playing = has_now_playing
 
-                if (time.time() - last_emit_ts) >= 15.0:
+                # Idle ping cadence must stay well inside the client's health
+                # window (app.js _uiEventHealthy) or a quiet stream reads as dead.
+                if (time.time() - last_emit_ts) >= 5.0:
                     ping = _json.dumps({"type": "ping", "ts": time.time()}, separators=(",", ":"), ensure_ascii=False)
                     yield f"event: ping\ndata: {ping}\n\n"
                     last_emit_ts = time.time()
         finally:
             _UI_EVENT_SUBS.discard(q)
 
-    return StreamingResponse(gen(), media_type="text/event-stream")
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 @router.get("/ui/events")
@@ -3339,6 +3345,8 @@ def ui():
         </div>
       </div>
     </header>
+
+    <div id="connBadge" class="connBadge hidden" role="status" aria-live="polite">Reconnecting…</div>
 
     <!-- Hidden by default: manual URL modal (opened via ＋ button) -->
     <div id="addBackdrop" class="modalBackdrop hidden" role="dialog" aria-modal="true">

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3174,6 +3174,9 @@ def _status_payload() -> dict[str, object]:
         "jellyfin_playback_mode": _effective_jellyfin_playback_mode(settings_snapshot),
         "pause_reason": state.get_pause_reason() if hasattr(state, "get_pause_reason") else None,
         "resume_available": resume_avail,
+        # Same authoritative signal the fast snapshot carries; without it the
+        # client's fast/full views can disagree at idle and flap the UI.
+        "has_now_playing": isinstance(now_playing, dict),
         "playing": playing,
         "paused": paused,
         "playback_telemetry_source": playback_telemetry_source,

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3510,30 +3510,36 @@ def ui():
 
     <div class="topgrid">
       <div class="nowCol">
-      <section id="nowTopCard" class="card">
-        <div class="sectionTitle">NOW PLAYING <button id="nowSkipBtn" class="nowSkipBtn hidden" title="Stop current and play next up" aria-label="Play next up">✕</button></div>
+      <section id="nowTopCard" class="card nowCard">
+        <div class="nHead">
+          <span class="nHeadTitle">Now Playing</span>
+          <span id="nowStateDot" class="nStateDot" aria-hidden="true"></span>
+          <span id="nowStateTag" class="nStateTag hidden">Paused</span>
+          <button id="nowSkipBtn" class="nSkipBtn hidden" title="Stop current and play next up" aria-label="Play next up">Skip</button>
+        </div>
 
-        <div class="nowTitle">
-          <div class="scrim" style="min-width:0;">
-            <div id="now">Ready</div>
-            <div class="nowSubRow">
+        <div class="nHero">
+          <div id="nHeroArt" class="nHeroArt" aria-hidden="true"></div>
+          <div class="nHeroFade" aria-hidden="true"></div>
+          <div class="nHeroBody">
+            <div id="now" class="nTitle">Ready</div>
+            <div class="nMetaRow">
               <span id="picon" class="providerIcon">🎞️</span>
-              <div id="nowSub" class="muted" style="min-width:0;"></div>
+              <div id="nowSub" class="nChan" style="min-width:0;"></div>
+              <div class="nTrackBtns">
+                <button id="nowLangBtn" class="nGhostBtn hidden" title="Audio language" aria-label="Audio language">Audio</button>
+                <button id="nowSubLangBtn" class="nGhostBtn hidden" title="Subtitle language" aria-label="Subtitle language">Subs</button>
+              </div>
             </div>
           </div>
         </div>
 
+        <div class="nIdleMsg" aria-hidden="true">Nothing playing — share a link or pick from the queue</div>
+
         <div id="progress" class="progress" title="Drag to seek (or tap)">
           <div id="progFill" class="progressFill"></div>
         </div>
-        <div class="nowBottomBar">
-          <span class="chip nowPosChip" title="Playback time">⏱ <span id="pos">--:--</span> <span class="chipSep">/</span> <span id="dur">--:--</span></span>
-          <div class="nowMetaActions">
-            <span class="chip" title="Queue length">📥 <span id="qlen">0</span> queued</span>
-            <button id="nowLangBtn" class="nowLangBtn hidden" title="Audio language" aria-label="Audio language">Audio</button>
-            <button id="nowSubLangBtn" class="nowLangBtn hidden" title="Subtitle language" aria-label="Subtitle language">Subs</button>
-          </div>
-        </div>
+        <div class="nTimeRow"><span id="pos">--:--</span><span id="dur">--:--</span></div>
       </section>
 
       <section id="remoteCard" class="card remoteCard">

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -951,16 +951,6 @@
       backdrop-filter: blur(6px);
       -webkit-backdrop-filter: blur(6px);
     }
-    /* Apply scrim to queue text block when a thumbnail background is present */
-    li.hasBg .qBody{
-      background: rgba(0,0,0,.30);
-      border: 1px solid rgba(255,255,255,.16);
-      border-radius: 14px;
-      padding: 8px 10px;
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
-    }
-
 @media (prefers-color-scheme: light){
   /* Keep metadata containers on image-backed cards dark-glass in light mode too. */
   .scrim{
@@ -968,27 +958,16 @@
     border-color: rgba(255,255,255,.18);
     color: #f7fbff;
   }
-  li.hasBg .qBody{
-    background: rgba(8, 13, 24, .42);
-    border-color: rgba(255,255,255,.18);
-    color: #f7fbff;
-  }
   .scrim #now,
   .scrim .nowSubRow,
-  .scrim .muted,
-  li.hasBg .qTitle,
-  li.hasBg .qTitleText,
-  li.hasBg .qChan,
-  li.hasBg .qUrl{
+  .scrim .muted{
     color: #f7fbff;
   }
-  .scrim .muted,
-  li.hasBg .qChan,
-  li.hasBg .qUrl{
+  .scrim .muted{
     color: rgba(234,240,255,.84);
   }
-  .hasBg .nowTitle, .hasBg .qTitle{ text-shadow: 0 3px 12px rgba(0,0,0,.72); }
-  .hasBg .muted, .hasBg .qUrl{ text-shadow: 0 2px 10px rgba(0,0,0,.60); }
+  .hasBg .nowTitle{ text-shadow: 0 3px 12px rgba(0,0,0,.72); }
+  .hasBg .muted{ text-shadow: 0 2px 10px rgba(0,0,0,.60); }
 }
 
     .muted{
@@ -1186,14 +1165,60 @@
     .qTile{
       position: relative;
       display:flex;
-      align-items: stretch;
-      gap: 10px;
-      padding: 12px;
-      border-radius: 18px;
+      align-items: center;
+      gap: 12px;
+      min-height: 76px;
+      padding: 10px;
+      border-radius: 16px;
       background: linear-gradient(180deg, rgba(24,38,72,.55), rgba(12,20,42,.60));
       border: 1px solid rgba(120,180,255,.22);
       box-shadow: inset 0 1px 0 rgba(190,220,255,.10);
       user-select: none;
+    }
+    .qThumb{
+      position: relative;
+      flex: 0 0 auto;
+      width: 104px;
+      aspect-ratio: 16 / 9;
+      border-radius: 10px;
+      overflow: hidden;
+      border: 1px solid rgba(120,180,255,.18);
+      background:
+        radial-gradient(80% 80% at 30% 20%, rgba(43,108,231,.30), transparent 60%),
+        linear-gradient(150deg, rgba(20,34,66,.85), rgba(8,14,30,.90));
+    }
+    .qThumbImg{
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    .qThumbFav{
+      position: absolute;
+      left: 4px;
+      bottom: 4px;
+      width: 16px;
+      height: 16px;
+      border-radius: 4px;
+      box-shadow: 0 1px 4px rgba(0,0,0,.55), 0 0 0 1px rgba(0,0,0,.35);
+      background: rgba(10,16,30,.65);
+    }
+    .qUnavailTag{
+      display: inline-block;
+      margin-left: 7px;
+      padding: 1px 6px;
+      border-radius: 6px;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      color: rgba(255,205,130,.92);
+      border: 1px solid rgba(255,190,110,.40);
+      background: rgba(90,60,18,.35);
+    }
+    @media (max-width: 420px){
+      .qThumb{ width: 88px; }
+      .qTile{ gap: 10px; }
     }
     .qTile:hover{
       border-color: rgba(140,200,255,.36);
@@ -1207,24 +1232,6 @@
     .qTile.dragOver{
       outline: 2px solid rgba(120,180,255,.55);
       outline-offset: 2px;
-    }
-
-    .qProvBg{
-      position:absolute;
-      inset: 0;
-      pointer-events:none;
-      opacity: .12;
-      filter: blur(.2px);
-      display:flex;
-      align-items:center;
-      justify-content:flex-start;
-      padding-left: 10px;
-    }
-    .qProvBg img{
-      width: 84px;
-      height: 84px;
-      border-radius: 22px;
-      border: 1px solid rgba(255,255,255,.10);
     }
 
     .qHandle{
@@ -1313,8 +1320,9 @@
 
     .qTitle{
       color: var(--text);
+      font-size: 14px;
       font-weight: 650;
-      line-height: 1.2;
+      line-height: 1.25;
       display:flex;
       align-items:flex-start;
       gap: 8px;

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -326,28 +326,181 @@
       color: var(--text);
       outline: none;
     }
-    @media (prefers-color-scheme: light){
-      .urlInput,
-      .notifyInput{ background: rgba(255,255,255,.92); }
-    }
     .helperTxt{ font-size: 12px; color: var(--muted2); margin-top: 8px; min-height: 16px; }
     .helperTxt.err{ color: #ff9aa8; }
     .helperTxt.ok{ color: #9df6b7; }
-    .addDivider{
-      height: 1px;
-      margin: 16px 0 14px;
-      background: linear-gradient(90deg, transparent, rgba(125,211,252,.42), transparent);
-    }
-    .notifySection{
+
+    /* Send-to-TV modal: opaque glass slab with one contained panel per tool.
+       .modal.addModal outranks the generic .modal shell that follows later. */
+    .modal.addModal{
+      width: min(720px, 100%);
+      background: linear-gradient(165deg, rgba(13,22,44,.97), rgba(5,9,20,.985));
+      border: 1px solid rgba(148,180,255,.28);
+      border-radius: 22px;
+      box-shadow:
+        0 0 42px rgba(56,130,246,.14),
+        0 24px 60px rgba(0,0,0,.60),
+        inset 0 1px 0 rgba(190,220,255,.12);
+      padding: 16px;
       display: grid;
-      gap: 10px;
+      gap: 14px;
     }
-    .notifyTitle{
-      font-size: 12px;
-      font-weight: 800;
-      letter-spacing: .08em;
+    .addModal .modalTitle{
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: .14em;
       text-transform: uppercase;
-      color: var(--muted);
+      color: #dceaff;
+    }
+    .amSection{
+      display: grid;
+      gap: 12px;
+      padding: 14px;
+      border-radius: 16px;
+      border: 1px solid rgba(148,180,255,.16);
+      background: linear-gradient(180deg, rgba(148,178,255,.07), rgba(96,130,255,.03));
+    }
+    .amHead{
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      color: rgba(170, 198, 255, .85);
+      padding-bottom: 10px;
+      border-bottom: 1px solid rgba(148,180,255,.12);
+    }
+    .amHead svg{
+      width: 15px;
+      height: 15px;
+      flex: 0 0 auto;
+      color: rgba(120, 180, 255, .85);
+    }
+    .addModal .fieldRow{ margin-top: 0; }
+    .addModal .helperTxt{ margin-top: 0; }
+    .amActions{ justify-content: flex-end; }
+    .addModal .iconBtn{
+      background: linear-gradient(180deg, rgba(148,178,255,.14), rgba(96,130,255,.06));
+      border: 1px solid rgba(148,180,255,.30);
+      color: #dceaff;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.10);
+    }
+    .addModal .iconBtn:hover{
+      transform: none;
+      border-color: rgba(148,180,255,.55);
+      background: linear-gradient(180deg, rgba(148,178,255,.20), rgba(96,130,255,.10));
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.12), 0 0 0 2px rgba(120,180,255,.14);
+    }
+    .addModal .urlInput,
+    .addModal .notifyInput{
+      background: rgba(4, 8, 18, .55);
+      border: 1px solid rgba(148,180,255,.22);
+      border-radius: 12px;
+      transition: border-color .15s ease, box-shadow .15s ease;
+    }
+    .addModal .urlInput:focus,
+    .addModal .notifyInput:focus{
+      border-color: rgba(125,211,252,.65);
+      box-shadow: 0 0 0 2px rgba(56,140,248,.18);
+    }
+    #addQueueBtn{
+      min-height: 42px;
+      padding: 10px 16px;
+      border-radius: 12px;
+      font-weight: 700;
+      background: linear-gradient(180deg, rgba(148,178,255,.14), rgba(96,130,255,.06));
+      border: 1px solid rgba(148,180,255,.30);
+      color: #dceaff;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.10);
+    }
+    #addQueueBtn:hover{
+      transform: none;
+      border-color: rgba(148,180,255,.55);
+      background: linear-gradient(180deg, rgba(148,178,255,.20), rgba(96,130,255,.10));
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.12), 0 0 0 2px rgba(120,180,255,.14);
+    }
+    #addPlayBtn,
+    #notifySendBtn{
+      min-height: 42px;
+      padding: 10px 20px;
+      border-radius: 12px;
+      font-weight: 800;
+      letter-spacing: .04em;
+      border: 1px solid rgba(125,211,252,.62);
+      background: linear-gradient(180deg, rgba(56,189,248,.82), rgba(37,99,235,.74));
+      color: #f0f9ff;
+      text-shadow: 0 1px 2px rgba(2,6,23,.35);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.28), 0 4px 14px rgba(37,99,235,.32);
+    }
+    #addPlayBtn:hover,
+    #notifySendBtn:hover{
+      transform: none;
+      background: linear-gradient(180deg, rgba(94,207,255,.9), rgba(59,120,246,.82));
+      border-color: rgba(165,225,255,.75);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.32), 0 4px 16px rgba(37,99,235,.42);
+    }
+    #addPlayBtn:active,
+    #notifySendBtn:active,
+    #addQueueBtn:active{ transform: translateY(1px); }
+    @media (prefers-color-scheme: light){
+      .modal.addModal{
+        background: linear-gradient(165deg, rgba(255,255,255,.97), rgba(233, 241, 255, .98));
+        border-color: rgba(37, 99, 235, .20);
+        box-shadow: 0 24px 54px rgba(37, 99, 235, .18), inset 0 1px 0 rgba(255,255,255,.9);
+      }
+      .addModal .modalTitle{ color: #0c1324; }
+      .amSection{
+        border-color: rgba(37, 99, 235, .14);
+        background: linear-gradient(180deg, rgba(255,255,255,.65), rgba(223, 238, 255, .45));
+      }
+      .amHead{
+        color: rgba(30, 64, 175, .75);
+        border-bottom-color: rgba(37, 99, 235, .12);
+      }
+      .amHead svg{ color: rgba(37, 99, 235, .70); }
+      .addModal .urlInput,
+      .addModal .notifyInput{
+        background: rgba(255,255,255,.92);
+        border-color: rgba(37, 99, 235, .18);
+        color: #0c1324;
+      }
+      .addModal .urlInput:focus,
+      .addModal .notifyInput:focus{
+        border-color: rgba(56, 140, 248, .55);
+        box-shadow: 0 0 0 2px rgba(56, 140, 248, .16);
+      }
+      .addModal .iconBtn,
+      #addQueueBtn{
+        background: linear-gradient(180deg, rgba(255,255,255,.92), rgba(223, 238, 255, .88));
+        border-color: rgba(37, 99, 235, .22);
+        color: #0c1324;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,.85);
+      }
+      .addModal .iconBtn:hover,
+      #addQueueBtn:hover{
+        background: linear-gradient(180deg, rgba(255,255,255,.98), rgba(210, 232, 255, .95));
+        border-color: rgba(37, 99, 235, .40);
+        box-shadow: inset 0 1px 0 rgba(255,255,255,.9), 0 0 0 2px rgba(56,140,248,.14);
+      }
+      .addModal .notifyFile{ color: rgba(12, 19, 36, .60); }
+      .addModal .notifyFile::file-selector-button{
+        background: linear-gradient(180deg, rgba(255,255,255,.92), rgba(223, 238, 255, .88));
+        border-color: rgba(37, 99, 235, .22);
+        color: #0c1324;
+      }
+      #addPlayBtn,
+      #notifySendBtn{
+        background: linear-gradient(180deg, rgb(56, 152, 248), rgb(29, 78, 216));
+        border-color: rgba(29, 78, 216, .55);
+        box-shadow: inset 0 1px 0 rgba(255,255,255,.30), 0 4px 14px rgba(37, 99, 235, .28);
+      }
+      #addPlayBtn:hover,
+      #notifySendBtn:hover{
+        background: linear-gradient(180deg, rgb(76, 165, 250), rgb(37, 90, 230));
+        border-color: rgba(29, 78, 216, .70);
+      }
     }
     .notifyGrid{
       display: grid;
@@ -385,7 +538,18 @@
     }
     .notifyFile{
       font-size: 12px;
-      color: var(--muted);
+      color: rgba(200, 216, 255, .60);
+    }
+    .notifyFile::file-selector-button{
+      margin-right: 10px;
+      padding: 7px 12px;
+      border-radius: 10px;
+      border: 1px solid rgba(148,180,255,.30);
+      background: linear-gradient(180deg, rgba(148,178,255,.15), rgba(96,130,255,.07));
+      color: #eaf3ff;
+      font-weight: 700;
+      font-size: 12px;
+      cursor: pointer;
     }
     .notifyActions{
       display:flex;

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -56,6 +56,9 @@
       display: grid;
       gap: 14px;
     }
+    /* Grid items refuse to shrink below min-content by default, so one long
+       nowrap title would widen the shared column past the viewport. */
+    .wrap > *, .topgrid > *{ min-width: 0; }
 
     header{
       display:flex;
@@ -64,120 +67,187 @@
       gap: 10px;
       padding: 2px 2px 6px;
     }
+    .hdrBrand{
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+      min-width: 0;
+    }
+    .hdrKicker{
+      font-size: 10px;
+      font-weight: 800;
+      letter-spacing: .32em;
+      text-transform: uppercase;
+      color: rgba(148, 180, 255, .58);
+    }
     h1{
       margin: 0;
-      font-weight: 700;
+      font-weight: 800;
       letter-spacing: .2px;
-      font-size: clamp(18px, 2.6vw, 26px);
+      font-size: clamp(19px, 2.6vw, 26px);
+      line-height: 1.12;
+      background: linear-gradient(180deg, #f2f7ff, #b9ccf2);
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+      filter: drop-shadow(0 0 14px rgba(96, 165, 250, .22));
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
-    .pill{
-      display:flex;
-      align-items:center;
-      gap: 8px;
-      padding: 8px 10px;
-      border-radius: 999px;
-      background: var(--card2);
-      border: 1px solid var(--stroke);
-      backdrop-filter: blur(10px);
-      -webkit-backdrop-filter: blur(10px);
-      font-size: 13px;
-      color: var(--muted);
-    }
+    .hdrRight{ display:flex; align-items:center; gap: 9px; }
 
-    .hdrRight{ display:flex; align-items:center; gap: 10px; }
-    .jfLaunch{
-      display: none;
+    /* Header controls share one glass-chip material */
+    .jfLaunch, .hdrAddBtn, .hdrMenuBtn{
       min-height: 0 !important;
+      height: 36px;
       width: auto !important;
-      padding: 8px 12px !important;
+      padding: 0 12px !important;
       border-radius: 12px !important;
-      font-size: 12px;
-      font-weight: 800;
-      letter-spacing: .04em;
-      text-transform: uppercase;
-    }
-    .jfLaunch.show{ display: inline-flex; }
-    .hdrAddBtn{
-      min-height: 0 !important;
-      width: auto !important;
-      padding: 8px 12px !important;
-      border-radius: 12px !important;
-      font-size: 20px;
-      line-height: 1;
-      font-weight: 800;
       display: inline-flex;
       align-items: center;
       justify-content: center;
+      gap: 7px;
+      background: linear-gradient(180deg, rgba(148,178,255,.15), rgba(96,130,255,.07));
+      border: 1px solid rgba(148,180,255,.30);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.10);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      color: var(--text);
     }
+    .jfLaunch:hover, .hdrAddBtn:hover, .hdrMenuBtn:hover{
+      transform: none;
+      border-color: rgba(148,180,255,.55);
+      background: linear-gradient(180deg, rgba(148,178,255,.22), rgba(96,130,255,.11));
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.12), 0 0 0 2px rgba(120,180,255,.14);
+    }
+    .jfLaunch:active, .hdrAddBtn:active, .hdrMenuBtn:active{ transform: none; }
+
+    .jfLaunch{
+      display: none;
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }
+    .jfLaunch.show{ display: inline-flex; }
+    .jfDot{
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex: 0 0 auto;
+      background: linear-gradient(135deg, #aa5cc3, #00a4dc);
+      box-shadow: 0 0 8px rgba(0, 164, 220, .55);
+    }
+
+    /* Add is the primary header action: the one accented chip */
+    .hdrAddBtn{
+      padding: 0 13px !important;
+      font-size: 19px;
+      line-height: 1;
+      font-weight: 800;
+      background: linear-gradient(180deg, rgba(56,189,248,.82), rgba(37,99,235,.74));
+      border-color: rgba(125,211,252,.62);
+      color: #f0f9ff;
+      text-shadow: 0 1px 2px rgba(2,6,23,.35);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.28), 0 4px 14px rgba(37,99,235,.32);
+    }
+    .hdrAddBtn:hover{
+      background: linear-gradient(180deg, rgba(94,207,255,.9), rgba(59,120,246,.82));
+      border-color: rgba(165,225,255,.75);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.32), 0 4px 16px rgba(37,99,235,.42);
+    }
+
     .hdrMenuWrap{
       position: relative;
       display: inline-flex;
       align-items: center;
     }
-    .hdrMenuBtn{
-      min-height: 0 !important;
-      width: auto !important;
-      border-radius: 12px !important;
-      padding: 8px 10px !important;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 8px;
-      font-size: 12px;
-      color: var(--muted);
-      background: var(--card2);
-      border: 1px solid var(--stroke);
-      backdrop-filter: blur(10px);
-      -webkit-backdrop-filter: blur(10px);
-    }
-    .hdrMenuBtn .menuLabel{
-      text-transform: uppercase;
-      letter-spacing: .05em;
-      font-weight: 700;
-      font-size: 12px;
-      color: var(--muted2);
-    }
-    .hdrMenuBtn .menuIcon{
-      font-size: 16px;
-      line-height: 1;
-      opacity: .9;
+    .hdrMenuBtn{ padding: 0 10px !important; }
+    .hdrMenuBtn .menuGlyph{
+      width: 18px;
+      height: 18px;
+      color: rgba(190, 208, 255, .92);
     }
     .hdrMenuBtn[aria-expanded="true"]{
       border-color: rgba(120,180,255,.72);
-      box-shadow: 0 0 0 2px rgba(120,180,255,.20), 0 10px 24px rgba(0,0,0,.28);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.12), 0 0 0 2px rgba(120,180,255,.20);
     }
+
     .hdrMenuPanel{
       position: absolute;
       right: 0;
-      top: calc(100% + 8px);
-      min-width: 176px;
+      top: calc(100% + 10px);
+      min-width: 216px;
+      max-width: calc(100vw - 28px);
       z-index: 60;
       display: grid;
-      gap: 6px;
-      padding: 8px;
-      border-radius: 12px;
-      background: rgba(8, 16, 34, .96);
-      border: 1px solid var(--stroke);
-      box-shadow: 0 16px 38px rgba(0,0,0,.40);
+      padding: 6px;
+      border-radius: 16px;
+      background: linear-gradient(165deg, rgba(13,22,44,.97), rgba(5,9,20,.98));
+      border: 1px solid rgba(148,180,255,.26);
+      box-shadow: 0 22px 48px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,255,255,.06);
+      backdrop-filter: blur(14px);
+      -webkit-backdrop-filter: blur(14px);
+      transform-origin: top right;
+      animation: menuPop .14s ease;
+    }
+    @keyframes menuPop{
+      from{ opacity: 0; transform: scale(.94) translateY(-4px); }
+      to{ opacity: 1; transform: none; }
     }
     .hdrMenuItem{
       min-height: 0 !important;
       width: 100% !important;
       justify-content: flex-start;
+      gap: 11px;
+      border: 0;
       border-radius: 10px !important;
-      padding: 9px 10px !important;
-      font-size: 13px;
-      font-weight: 700;
+      padding: 11px 12px !important;
+      font-size: 14px;
+      font-weight: 600;
+      letter-spacing: .01em;
       box-shadow: none !important;
-      background: rgba(255,255,255,.08);
-      border: 1px solid var(--stroke);
+      background: transparent;
+      color: var(--text);
+    }
+    .hdrMenuItem + .hdrMenuItem{
+      border-top: 1px solid rgba(148,180,255,.10);
+      border-top-left-radius: 0 !important;
+      border-top-right-radius: 0 !important;
+    }
+    .hdrMenuItem .miIcon{
+      width: 17px;
+      height: 17px;
+      flex: 0 0 auto;
+      color: rgba(148, 180, 255, .85);
     }
     .hdrMenuItem:hover{
       transform: none;
-      background: rgba(120,180,255,.22);
-      border-color: rgba(120,180,255,.52);
+      background: rgba(120,180,255,.14);
     }
     .hdrMenuItem:active{ transform: none; }
+    .hdrMenuFoot{
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 9px 12px 7px;
+      margin-top: 2px;
+      border-top: 1px solid rgba(148,180,255,.12);
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      color: rgba(148, 180, 255, .55);
+      white-space: nowrap;
+    }
+    .hdrMenuFoot > span{
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .hdrMenuFoot #menuAppVersion{ flex: 0 0 auto; }
     .iconBtn{
       height: 36px;
       width: 40px;
@@ -1225,6 +1295,7 @@
       display: grid;
       gap: 10px;
     }
+    .queueList > *{ min-width: 0; }
     .queueList:empty::after{
       content: "Queue is empty";
       display: block;
@@ -1732,28 +1803,37 @@
   box-shadow: 0 8px 20px rgba(30, 64, 175, .28), inset 0 1px 0 rgba(255, 255, 255, .16);
 }
 @media (prefers-color-scheme: light){
-  .hdrMenuPanel{
-    background: linear-gradient(180deg, rgba(186, 227, 255, .96), rgba(145, 202, 255, .92));
-    border-color: rgba(37, 99, 235, .24);
-    box-shadow: 0 18px 36px rgba(37, 99, 235, .18);
+  .hdrKicker{ color: rgba(37, 99, 235, .60); }
+  h1{
+    background: linear-gradient(180deg, #111c38, #31456f);
+    -webkit-background-clip: text;
+    background-clip: text;
+    filter: none;
   }
-  .hdrMenuItem{
-    background: rgba(255,255,255,.72);
-    border-color: rgba(37, 99, 235, .16);
-    color: #0c1324;
-  }
-  .hdrMenuItem:hover{
-    background: rgba(219, 239, 255, .92);
-    border-color: rgba(56, 189, 248, .48);
-  }
-  .hdrMenuBtn{
+  .jfLaunch, .hdrMenuBtn{
     background: linear-gradient(180deg, rgba(255,255,255,.92), rgba(223, 238, 255, .88));
-    border-color: rgba(37, 99, 235, .16);
+    border-color: rgba(37, 99, 235, .22);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.85);
     color: #0c1324;
   }
-  .hdrMenuBtn .menuLabel,
-  .hdrMenuBtn .menuIcon{
-    color: rgba(12,19,36,.72);
+  .jfLaunch:hover, .hdrMenuBtn:hover{
+    background: linear-gradient(180deg, rgba(255,255,255,.98), rgba(210, 232, 255, .95));
+    border-color: rgba(37, 99, 235, .40);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.9), 0 0 0 2px rgba(56,140,248,.14);
+  }
+  .hdrMenuBtn .menuGlyph{ color: rgba(30, 58, 138, .78); }
+  .hdrMenuPanel{
+    background: linear-gradient(165deg, rgba(255,255,255,.97), rgba(233, 241, 255, .98));
+    border-color: rgba(37, 99, 235, .20);
+    box-shadow: 0 22px 44px rgba(37, 99, 235, .16), inset 0 1px 0 rgba(255,255,255,.9);
+  }
+  .hdrMenuItem{ color: #0c1324; }
+  .hdrMenuItem + .hdrMenuItem{ border-top-color: rgba(37, 99, 235, .12); }
+  .hdrMenuItem .miIcon{ color: rgba(37, 99, 235, .72); }
+  .hdrMenuItem:hover{ background: rgba(56, 140, 248, .12); }
+  .hdrMenuFoot{
+    border-top-color: rgba(37, 99, 235, .14);
+    color: rgba(37, 99, 235, .58);
   }
   .settingsGroup{
     background: linear-gradient(180deg, rgba(191, 228, 255, .62), rgba(227, 241, 255, .54));

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -607,6 +607,31 @@
       margin-left: auto;
     }
 
+    /* ===== Connection indicator ===== */
+    .connBadge{
+      position: fixed;
+      top: max(10px, env(safe-area-inset-top));
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 10000;
+      padding: 7px 14px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      white-space: nowrap;
+      color: #ffe3b0;
+      border: 1px solid rgba(255,200,120,.45);
+      background: linear-gradient(180deg, rgba(60,42,18,.94), rgba(38,26,10,.96));
+      box-shadow: 0 0 18px rgba(255,180,80,.20), 0 10px 24px rgba(0,0,0,.45);
+    }
+    body.connLost .remoteCard,
+    body.connLost .queueCard{
+      filter: saturate(.55) brightness(.78);
+      transition: filter .3s ease;
+    }
+
     /* ===== Remote: neon-glass panel (always dark, both themes) ===== */
     .remoteCard{
       background-image: none !important;

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -442,13 +442,6 @@
     border-color: rgba(15,23,42,.14);
     box-shadow: inset 0 1px 0 rgba(255,255,255,.82);
   }
-  .metaRow .chip,
-  .nowBottomBar .chip{
-    background: linear-gradient(180deg, rgba(59, 130, 246, .82), rgba(37, 99, 235, .76));
-    border-color: rgba(29, 78, 216, .34);
-    color: #f8fbff;
-    box-shadow: inset 0 1px 0 rgba(255,255,255,.18), 0 8px 18px rgba(30, 64, 175, .16);
-  }
   .progress{
     background: rgba(255,255,255,.70);
     border-color: rgba(15,23,42,.12);
@@ -518,62 +511,206 @@
       display:grid;
       gap: 14px;
     }
-    .nowSkipBtn{
-      margin-left: auto;
-      width: 28px;
-      height: 28px;
-      flex: 0 0 auto;
-      min-height: 0;
-      border-radius: 999px;
-      padding: 0;
-      font-size: 14px;
-      font-weight: 800;
-      line-height: 1;
-      border: 1px solid rgba(248, 113, 113, .72);
-      background: rgba(220, 38, 38, .88);
-      color: #fff;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      box-shadow: 0 8px 16px rgba(127, 29, 29, .45);
+    /* ===== Now Playing: hero glass panel (always dark, both themes) ===== */
+    .nowCard{
+      background-image: none !important;
+      background: linear-gradient(165deg, rgba(13,22,44,.94), rgba(5,9,20,.97)) !important;
+      border: 1px solid rgba(120,180,255,.30);
+      border-radius: 26px;
+      padding: 16px;
+      box-shadow:
+        0 0 28px rgba(56,130,246,.12),
+        0 18px 48px rgba(0,0,0,.50),
+        inset 0 1px 0 rgba(190,220,255,.14);
     }
-    .nowSkipBtn:hover{ background: rgba(239, 68, 68, .92); transform: none; }
-    .nowSkipBtn:active{ transform: none; }
-    .nowBottomBar{
-      margin-top: 10px;
+    .nHead{
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 2px 2px 12px;
+      margin-bottom: 12px;
+      border-bottom: 1px solid rgba(140,190,255,.16);
+    }
+    .nHeadTitle{
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      color: #dceaff;
+      text-shadow: 0 1px 6px rgba(4,12,38,.60);
+    }
+    .nStateDot{
+      width: 9px;
+      height: 9px;
+      border-radius: 999px;
+      background: rgba(150,190,240,.35);
+      box-shadow: none;
+      flex: 0 0 auto;
+    }
+    .nStateDot.playing{
+      background: rgba(96,180,255,.95);
+      box-shadow: 0 0 8px rgba(96,180,255,.80);
+      animation: nDotPulse 2.2s ease-in-out infinite;
+    }
+    @keyframes nDotPulse{
+      0%, 100%{ box-shadow: 0 0 4px rgba(96,180,255,.55); opacity: .75; }
+      50%{ box-shadow: 0 0 12px rgba(96,180,255,.95); opacity: 1; }
+    }
+    .nStateTag{
+      padding: 1px 8px;
+      border-radius: 6px;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: .10em;
+      text-transform: uppercase;
+      color: rgba(255,205,130,.92);
+      border: 1px solid rgba(255,190,110,.40);
+      background: rgba(90,60,18,.35);
+    }
+    .nSkipBtn,
+    .nGhostBtn{
+      min-height: 0;
+      padding: 5px 12px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      color: rgba(210,228,255,.80);
+      border: 1px solid rgba(140,190,255,.28);
+      background: rgba(20,32,62,.45);
+      box-shadow: none;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+    .nSkipBtn{ margin-left: auto; }
+    .nSkipBtn:hover,
+    .nGhostBtn:hover{
+      color: #eaf3ff;
+      border-color: rgba(150,210,255,.55);
+      background: rgba(34,60,120,.60);
+      box-shadow: 0 0 12px rgba(72,150,255,.22);
+      transform: none;
+    }
+    .nSkipBtn:active,
+    .nGhostBtn:active{ background: rgba(24,44,92,.70); transform: translateY(1px); }
+    .nHero{
+      position: relative;
+      border-radius: 14px;
+      overflow: hidden;
+      aspect-ratio: 16 / 9;
+      max-height: 250px;
+      width: 100%;
+      border: 1px solid rgba(120,180,255,.18);
+      background:
+        radial-gradient(80% 80% at 30% 20%, rgba(43,108,231,.28), transparent 60%),
+        linear-gradient(150deg, rgba(20,34,66,.85), rgba(8,14,30,.90));
+    }
+    .nHeroArt{
+      position: absolute;
+      inset: 0;
+    }
+    .nHeroFade{
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(180deg, rgba(5,9,20,0) 30%, rgba(5,9,20,.45) 62%, rgba(5,9,20,.90) 100%);
+      pointer-events: none;
+    }
+    .nHeroBody{
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      padding: 12px 14px;
+      min-width: 0;
+    }
+    .nTitle{
+      font-size: clamp(15px, 2.4vw, 18px);
+      font-weight: 700;
+      line-height: 1.25;
+      color: #f2f7ff;
+      text-shadow: 0 2px 10px rgba(0,0,0,.80);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+    }
+    .nMetaRow{
+      margin-top: 6px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+    .nChan{
+      font-size: 12px;
+      color: rgba(220,232,252,.80);
+      text-shadow: 0 1px 8px rgba(0,0,0,.75);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
+    .nHeroBody .providerIcon{
+      background: rgba(10,16,30,.65);
+      border-color: rgba(255,255,255,.18);
+    }
+    .nTrackBtns{
+      margin-left: auto;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex: 0 0 auto;
+    }
+    .nTimeRow{
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 10px;
-      flex-wrap: wrap;
+      margin-top: 7px;
+      padding: 0 2px;
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: .04em;
+      color: #9fd0ff;
+      font-variant-numeric: tabular-nums;
     }
-    .nowPosChip{
-      margin-right: auto;
+    .nIdleMsg{
+      display: none;
+      padding: 26px 10px;
+      text-align: center;
+      font-size: 13px;
+      letter-spacing: .04em;
+      color: rgba(210,225,250,.45);
     }
-    .nowMetaActions{
-      display:flex;
-      align-items:center;
-      justify-content:flex-end;
-      gap: 10px;
-      flex-wrap: wrap;
-      margin-left: auto;
+    .nowCard.isIdle .nHero,
+    .nowCard.isIdle .progress,
+    .nowCard.isIdle .nTimeRow{ display: none; }
+    .nowCard.isIdle .nIdleMsg{ display: block; }
+    .nowCard .progress{
+      margin-top: 14px;
+      height: 8px;
+      background: linear-gradient(180deg, rgba(140,180,255,.20), rgba(120,165,250,.14));
+      border: 1px solid rgba(160,200,255,.16);
     }
-    .nowLangBtn{
-      min-height: 0 !important;
-      height: 36px;
-      padding: 0 12px !important;
-      border-radius: 12px !important;
-      font-size: 13px !important;
-      font-weight: 700 !important;
-      letter-spacing: .2px;
-      background: rgba(56, 189, 248, .20);
-      border-color: rgba(56, 189, 248, .55);
-      box-shadow: 0 8px 18px rgba(7, 89, 133, .25) !important;
+    .nowCard .progressFill{
+      position: relative;
+      background: linear-gradient(90deg, rgba(96,176,255,.96), rgba(56,122,246,.96));
+      box-shadow: 0 0 10px rgba(96,176,255,.45);
+      min-width: 0;
     }
-    .nowLangBtn:hover{
-      background: rgba(56, 189, 248, .26);
-      border-color: rgba(56, 189, 248, .7);
-      transform: none;
+    .nowCard .progressFill::after{
+      content: "";
+      position: absolute;
+      right: -6px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 15px;
+      height: 15px;
+      border-radius: 999px;
+      border: 1px solid rgba(170,220,255,.85);
+      background: radial-gradient(circle at 40% 32%, rgba(220,240,255,.95), rgba(96,176,255,.95) 55%, rgba(56,122,246,.95));
+      box-shadow: 0 0 10px rgba(120,190,255,.70);
     }
     .langModal{
       width: min(560px, 100%);
@@ -871,35 +1008,11 @@
         background: linear-gradient(180deg, rgba(255,255,255,.98), rgba(255,255,255,.86));
         box-shadow: 0 10px 22px rgba(2,6,23,.10);
       }
-      #nowTopCard.hasBg .sectionTitle{
-        background: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.06));
-        border-color: rgba(255,255,255,.18);
-        box-shadow: 0 10px 26px rgba(0,0,0,.22);
-        color: #f7fbff;
-      }
-      #nowTopCard:not(.hasBg) .sectionTitle{
-        background: linear-gradient(180deg, rgba(255,255,255,.97), rgba(243,248,255,.90));
-        border-color: rgba(15,23,42,.14);
-        box-shadow: 0 10px 22px rgba(2,6,23,.10);
-        color: #0c1324;
-      }
       .sectionTitle::before{
         box-shadow: 0 0 0 6px rgba(120,180,255,.16);
       }
     }
 
-    .nowTitle{
-      font-size: clamp(14px, 2.2vw, 18px);
-      font-weight: 650;
-      line-height: 1.25;
-      margin: 0 0 6px 0;
-    }
-    .nowSubRow{
-      display:flex;
-      align-items:center;
-      gap: 8px;
-      min-width: 0;
-    }
     .providerIcon{
       flex: 0 0 auto;
       width: 18px;
@@ -934,41 +1047,6 @@
       background-size: cover !important;
       background-position: center !important;
     }
-    /* Text scrim for readability over dark/busy thumbnails */
-    .scrim{
-      background: rgba(0,0,0,.30);
-      border: 1px solid rgba(255,255,255,.16);
-      border-radius: 14px;
-      padding: 8px 10px;
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
-    }
-    .hasBg .nowTitle, .hasBg .qTitle{ text-shadow: 0 3px 12px rgba(0,0,0,.85); }
-    .hasBg .muted, .hasBg .qUrl{ text-shadow: 0 2px 10px rgba(0,0,0,.85); }
-    .hasBg .chip{
-      background: rgba(0,0,0,.35);
-      border-color: rgba(255,255,255,.18);
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
-    }
-@media (prefers-color-scheme: light){
-  /* Keep metadata containers on image-backed cards dark-glass in light mode too. */
-  .scrim{
-    background: rgba(8, 13, 24, .42);
-    border-color: rgba(255,255,255,.18);
-    color: #f7fbff;
-  }
-  .scrim #now,
-  .scrim .nowSubRow,
-  .scrim .muted{
-    color: #f7fbff;
-  }
-  .scrim .muted{
-    color: rgba(234,240,255,.84);
-  }
-  .hasBg .nowTitle{ text-shadow: 0 3px 12px rgba(0,0,0,.72); }
-  .hasBg .muted{ text-shadow: 0 2px 10px rgba(0,0,0,.60); }
-}
 
     .muted{
       color: var(--muted);

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -1,6 +1,6 @@
     :root{
-      --bg0:#070a12;
-      --bg1:#0b0f19;
+      --bg0:#04060c;
+      --bg1:#080c16;
       --card: rgba(255,255,255,.08);
       --card2: rgba(255,255,255,.06);
       --stroke: rgba(255,255,255,.22);
@@ -43,9 +43,9 @@
       font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
       color: var(--text);
       background:
-        radial-gradient(1200px 600px at 10% 0%, rgba(120,180,255,.22), transparent 55%),
-        radial-gradient(900px 520px at 90% 10%, rgba(180,120,255,.16), transparent 60%),
-        radial-gradient(800px 600px at 50% 110%, rgba(120,255,190,.12), transparent 55%),
+        radial-gradient(1200px 600px at 10% 0%, rgba(120,180,255,.12), transparent 55%),
+        radial-gradient(900px 520px at 90% 10%, rgba(180,120,255,.08), transparent 60%),
+        radial-gradient(800px 600px at 50% 110%, rgba(120,255,190,.06), transparent 55%),
         linear-gradient(180deg, var(--bg0), var(--bg1));
       padding: max(14px, env(safe-area-inset-top)) 14px max(16px, env(safe-area-inset-bottom));
     }
@@ -607,55 +607,189 @@
       margin-left: auto;
     }
 
-    /* Keep thumbnail backgrounds off the remote buttons tile */
+    /* ===== Remote: neon-glass panel (always dark, both themes) ===== */
     .remoteCard{
       background-image: none !important;
+      background: linear-gradient(165deg, rgba(13,22,44,.94), rgba(5,9,20,.97)) !important;
+      border: 1px solid rgba(120,180,255,.36);
+      border-radius: 26px;
+      padding: 16px;
+      box-shadow:
+        0 0 36px rgba(56,130,246,.16),
+        0 18px 48px rgba(0,0,0,.55),
+        inset 0 1px 0 rgba(190,220,255,.16);
     }
-    .remoteCard button:not(.danger){
-      border-color: rgba(56, 189, 248, .58);
-      background: linear-gradient(180deg, rgba(56, 189, 248, .96), rgba(37, 99, 235, .94));
-      color: #eff6ff;
-      box-shadow: 0 10px 22px rgba(30, 64, 175, .40);
+    .rGrid{
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 14px;
     }
-    .remoteCard button:not(.danger):hover{
-      background: linear-gradient(180deg, rgba(56, 189, 248, .99), rgba(29, 78, 216, .96));
-      box-shadow: 0 14px 28px rgba(30, 64, 175, .45);
+    .rTile{
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+      gap: 14px;
+      min-height: 64px;
+      padding: 14px;
+      border-radius: 20px;
+      color: #eaf3ff;
+      border: 1px solid rgba(96,170,255,.55);
+      background:
+        radial-gradient(130% 100% at 18% 0%, rgba(96,180,255,.50), rgba(37,99,235,0) 55%),
+        linear-gradient(180deg, rgba(43,108,231,.94), rgba(22,56,142,.96));
+      box-shadow:
+        0 0 18px rgba(56,130,246,.26),
+        0 10px 26px rgba(2,8,26,.55),
+        inset 0 1px 0 rgba(200,228,255,.32),
+        inset 0 0 22px rgba(56,130,246,.18);
+      text-shadow: 0 1px 6px rgba(4,12,38,.60);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+    .rTile:hover{
+      background:
+        radial-gradient(130% 100% at 18% 0%, rgba(120,196,255,.58), rgba(37,99,235,0) 58%),
+        linear-gradient(180deg, rgba(56,124,246,.97), rgba(26,64,158,.97));
+      box-shadow:
+        0 0 26px rgba(72,150,255,.36),
+        0 14px 30px rgba(2,8,26,.60),
+        inset 0 1px 0 rgba(210,234,255,.38),
+        inset 0 0 24px rgba(72,150,255,.22);
       transform: translateY(-1px);
     }
-    .remoteCard button:not(.danger):active{
-      background: linear-gradient(180deg, rgba(37, 99, 235, .95), rgba(29, 78, 216, .92));
+    .rTile:active{
+      background:
+        radial-gradient(130% 100% at 18% 0%, rgba(80,160,240,.40), rgba(37,99,235,0) 55%),
+        linear-gradient(180deg, rgba(34,88,200,.95), rgba(18,46,120,.96));
       transform: translateY(1px);
     }
-    .remoteCard button:not(.danger) .bIcon{
-      background: rgba(7, 31, 71, .35);
-      border-color: rgba(191, 219, 254, .34);
+    .rTile > span,
+    .rTile > span:last-child{ flex: 0 0 auto; }
+    .rBig{
+      flex-direction: column;
+      gap: 12px;
+      aspect-ratio: 1.15 / 1;
+      padding: 18px 12px 14px;
+    }
+    .rWide{ grid-column: 1 / -1; }
+    .rSeek{ min-height: 76px; }
+    .rLabel{
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 100%;
+      min-width: 0;
+    }
+    .rRing{
+      display: grid;
+      place-items: center;
+      width: clamp(58px, 44%, 96px);
+      aspect-ratio: 1;
+      border-radius: 999px;
+      border: 2px solid rgba(190,222,255,.72);
+      background: radial-gradient(circle at 50% 35%, rgba(120,190,255,.16), rgba(10,24,60,.08));
+      box-shadow: 0 0 14px rgba(96,170,255,.32), inset 0 0 12px rgba(96,170,255,.20);
+    }
+    .rWide .rRing{ width: 58px; }
+    .rGlyph{
+      display: block;
+      width: 56%;
+      height: 56%;
+    }
+    .rRingSeek{
+      width: 54px;
+      border: 0;
+      background: none;
+      box-shadow: none;
+    }
+    .rRingSeek .rGlyphSeek{ width: 100%; height: 100%; }
+    .rGlyphSeek text{ font-family: inherit; }
+    .rGlyphPause{ display: none; }
+    #playPauseBtn.isPlaying .rGlyphPlay{ display: none; }
+    #playPauseBtn.isPlaying .rGlyphPause{ display: block; }
+    /* Mute: concept's bright sweep-lit bar is the muted-active state */
+    #muteBtn.muted{
+      border-color: rgba(150,210,255,.85);
+      background:
+        linear-gradient(115deg, rgba(190,235,255,.50), rgba(120,190,255,0) 48%),
+        linear-gradient(180deg, rgba(74,152,255,.98), rgba(30,84,204,.97));
+      box-shadow:
+        0 0 30px rgba(90,170,255,.45),
+        0 12px 28px rgba(2,8,26,.55),
+        inset 0 1px 0 rgba(226,242,255,.55),
+        inset 0 0 26px rgba(120,190,255,.30);
+    }
+    /* Close: neutral charcoal glass; destructive hint only on hover/press */
+    .rClose{
+      border-color: rgba(255,255,255,.14);
+      background: linear-gradient(180deg, rgba(31,37,54,.88), rgba(15,19,31,.94));
+      color: rgba(225,232,246,.85);
+      box-shadow: 0 10px 24px rgba(0,0,0,.50), inset 0 1px 0 rgba(255,255,255,.08);
+      text-shadow: none;
+    }
+    .rClose .rRing{
+      border-color: rgba(255,255,255,.30);
+      background: none;
+      box-shadow: none;
+    }
+    .rClose:hover{
+      background: linear-gradient(180deg, rgba(37,43,62,.90), rgba(18,22,36,.95));
+      border-color: rgba(255,130,150,.42);
+      box-shadow: 0 0 18px rgba(255,120,140,.16), 0 12px 26px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,255,255,.10);
+      transform: translateY(-1px);
+    }
+    .rClose:hover .rRing{ border-color: rgba(255,150,165,.55); }
+    .rClose:active{
+      background: linear-gradient(180deg, rgba(26,30,44,.92), rgba(12,15,25,.96));
+      transform: translateY(1px);
+    }
+    @media (max-width: 420px){
+      .rGrid{ gap: 11px; }
+      .rBig{ aspect-ratio: auto; min-height: 112px; gap: 8px; padding: 12px 10px; }
+      .rRing{ width: clamp(48px, 38%, 64px); }
+      .rWide .rRing{ width: 50px; }
+      .rSeek{ min-height: 64px; }
+      .rRingSeek{ width: 44px; }
+      .rLabel{ font-size: 12px; letter-spacing: .11em; }
     }
     .remoteVolumeRow{
-      margin-top: 10px;
+      margin-top: 16px;
       display: grid;
-      grid-template-columns: auto minmax(0, 1fr);
+      grid-template-columns: auto minmax(0, 1fr) auto;
       align-items: center;
-      gap: 12px;
-      padding: 10px 12px;
-      border-radius: 16px;
-      border: 1px solid rgba(56, 189, 248, .32);
-      background: linear-gradient(180deg, rgba(9, 20, 42, .34), rgba(9, 20, 42, .24));
+      gap: 14px;
+      padding: 6px 8px 2px;
+      border: 0;
+      border-radius: 0;
+      background: none;
     }
+    .rVolIcon{
+      width: 24px;
+      height: 24px;
+      color: #dceaff;
+      opacity: .92;
+    }
+    .rVolIcon svg{ display: block; width: 100%; height: 100%; }
     .remoteVolumeValue{
-      min-width: 58px;
-      font-size: 14px;
-      font-weight: 800;
-      letter-spacing: .02em;
-      color: #eef6ff;
-      text-align: left;
+      min-width: 52px;
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: .04em;
+      color: #9fd0ff;
+      text-align: right;
     }
     .remoteVolumeSlider{
       --remote-vol-pct: 50%;
-      --remote-vol-fill-start: rgba(12, 74, 164, .98);
-      --remote-vol-fill-end: rgba(30, 64, 175, .94);
-      --remote-vol-track-start: rgba(191, 219, 254, .34);
-      --remote-vol-track-end: rgba(96, 165, 250, .28);
-      --remote-vol-track-border: rgba(191, 219, 254, .24);
+      --remote-vol-fill-start: rgba(96, 176, 255, .96);
+      --remote-vol-fill-end: rgba(56, 122, 246, .96);
+      --remote-vol-track-start: rgba(140, 180, 255, .20);
+      --remote-vol-track-end: rgba(120, 165, 250, .14);
+      --remote-vol-track-border: rgba(160, 200, 255, .16);
       width: 100%;
       margin: 0;
       appearance: none;
@@ -679,13 +813,13 @@
     .remoteVolumeSlider::-webkit-slider-thumb{
       -webkit-appearance: none;
       appearance: none;
-      margin-top: -5px;
-      width: 18px;
-      height: 18px;
+      margin-top: -7px;
+      width: 21px;
+      height: 21px;
       border-radius: 999px;
-      border: 1px solid rgba(125, 211, 252, .72);
-      background: linear-gradient(180deg, rgba(56, 189, 248, .98), rgba(37, 99, 235, .95));
-      box-shadow: 0 4px 12px rgba(30, 64, 175, .40), inset 0 1px 0 rgba(255,255,255,.28);
+      border: 1px solid rgba(170, 220, 255, .85);
+      background: radial-gradient(circle at 40% 32%, rgba(220,240,255,.95), rgba(96,176,255,.95) 55%, rgba(56,122,246,.95));
+      box-shadow: 0 0 14px rgba(120, 190, 255, .70), 0 4px 12px rgba(30, 64, 175, .45), inset 0 1px 0 rgba(255,255,255,.40);
     }
     .remoteVolumeSlider::-moz-range-track{
       height: 8px;
@@ -699,12 +833,12 @@
       background: linear-gradient(180deg, var(--remote-vol-fill-start), var(--remote-vol-fill-end));
     }
     .remoteVolumeSlider::-moz-range-thumb{
-      width: 18px;
-      height: 18px;
+      width: 21px;
+      height: 21px;
       border-radius: 999px;
-      border: 1px solid rgba(125, 211, 252, .72);
-      background: linear-gradient(180deg, rgba(56, 189, 248, .98), rgba(37, 99, 235, .95));
-      box-shadow: 0 4px 12px rgba(30, 64, 175, .40), inset 0 1px 0 rgba(255,255,255,.28);
+      border: 1px solid rgba(170, 220, 255, .85);
+      background: radial-gradient(circle at 40% 32%, rgba(220,240,255,.95), rgba(96,176,255,.95) 55%, rgba(56,122,246,.95));
+      box-shadow: 0 0 14px rgba(120, 190, 255, .70), 0 4px 12px rgba(30, 64, 175, .45), inset 0 1px 0 rgba(255,255,255,.40);
     }
 
     @media (prefers-color-scheme: light){
@@ -724,35 +858,6 @@
         box-shadow: 0 10px 22px rgba(2,6,23,.10);
         color: #0c1324;
       }
-      .remoteVolumeRow{
-        background: linear-gradient(180deg, rgba(255,255,255,.94), rgba(236, 246, 255, .88));
-        border-color: rgba(37, 99, 235, .18);
-      }
-      .remoteVolumeValue{
-        color: #0c1324;
-      }
-      .remoteVolumeSlider{
-        --remote-vol-fill-start: rgba(8, 47, 120, .98);
-        --remote-vol-fill-end: rgba(29, 78, 216, .94);
-        --remote-vol-track-start: rgba(191, 219, 254, .78);
-        --remote-vol-track-end: rgba(147, 197, 253, .66);
-        --remote-vol-track-border: rgba(59, 130, 246, .20);
-      }
-      .remoteVolumeSlider::-webkit-slider-runnable-track{
-        border-color: var(--remote-vol-track-border);
-      }
-      .remoteVolumeSlider::-moz-range-track{
-        border-color: var(--remote-vol-track-border);
-      }
-      .remoteVolumeSlider::-webkit-slider-thumb{
-        border-color: rgba(125, 211, 252, .84);
-        background: linear-gradient(180deg, rgba(56, 189, 248, 1), rgba(37, 99, 235, .97));
-      }
-      .remoteVolumeSlider::-moz-range-thumb{
-        border-color: rgba(125, 211, 252, .84);
-        background: linear-gradient(180deg, rgba(56, 189, 248, 1), rgba(37, 99, 235, .97));
-      }
-    }
       .sectionTitle::before{
         box-shadow: 0 0 0 6px rgba(120,180,255,.16);
       }
@@ -926,22 +1031,6 @@
       font-weight: 800;
     }
 
-    .controls{
-      display:grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 10px;
-    }
-    .controls2{
-      display:grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
-      gap: 10px;
-      margin-top: 10px;
-    }
-    @media (max-width: 520px){
-      .controls{ grid-template-columns: repeat(2, minmax(0, 1fr)); }
-      .controls2{ grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    }
-
     button{
       appearance:none;
       border: 1px solid var(--stroke);
@@ -976,23 +1065,7 @@
     button:hover{ background: var(--btnH); box-shadow: 0 14px 30px rgba(0,0,0,.48); transform: translateY(-1px); }
     button:active{ background: var(--btnA); transform: translateY(1px); }
 
-    .bIcon{
-      width: 28px;
-      height: 28px;
-      border-radius: 12px;
-      display:grid;
-      place-items:center;
-      background: rgba(0,0,0,.18);
-      border: 1px solid rgba(255,255,255,.10);
-      font-size: 16px;
-      line-height: 1;
-    }
-    @media (prefers-color-scheme: light){
-      .bIcon{ background: rgba(0,0,0,.06); border-color: rgba(0,0,0,.10); }
-    }
-
     .danger{ border-color: rgba(255,120,140,.35); }
-    .danger .bIcon{ background: rgba(255,120,140,.12); border-color: rgba(255,120,140,.25); }
 
     
     /* Queue tiles */

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -1069,6 +1069,73 @@
 
     
     /* Queue tiles */
+    /* ===== Queue: glass panel matching the remote (always dark) ===== */
+    .queueCard{
+      background-image: none !important;
+      background: linear-gradient(165deg, rgba(13,22,44,.94), rgba(5,9,20,.97)) !important;
+      border: 1px solid rgba(120,180,255,.30);
+      border-radius: 26px;
+      padding: 16px;
+      box-shadow:
+        0 0 28px rgba(56,130,246,.12),
+        0 18px 48px rgba(0,0,0,.50),
+        inset 0 1px 0 rgba(190,220,255,.14);
+    }
+    .qHead{
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 2px 2px 12px;
+      margin-bottom: 12px;
+      border-bottom: 1px solid rgba(140,190,255,.16);
+    }
+    .qHeadTitle{
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      color: #dceaff;
+      text-shadow: 0 1px 6px rgba(4,12,38,.60);
+    }
+    .qCount{
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      padding: 0 7px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 700;
+      color: #eaf3ff;
+      border: 1px solid rgba(96,170,255,.50);
+      background: linear-gradient(180deg, rgba(43,108,231,.85), rgba(22,56,142,.90));
+      box-shadow: 0 0 10px rgba(56,130,246,.25), inset 0 1px 0 rgba(200,228,255,.28);
+    }
+    .qClearBtn{
+      margin-left: auto;
+      min-height: 0;
+      padding: 5px 12px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      color: rgba(210,228,255,.80);
+      border: 1px solid rgba(140,190,255,.28);
+      background: rgba(20,32,62,.45);
+      box-shadow: none;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+    .qClearBtn:hover{
+      color: #eaf3ff;
+      border-color: rgba(150,210,255,.55);
+      background: rgba(34,60,120,.60);
+      box-shadow: 0 0 12px rgba(72,150,255,.22);
+      transform: none;
+    }
+    .qClearBtn:active{ background: rgba(24,44,92,.70); transform: translateY(1px); }
     .queueList{
       margin: 0;
       padding: 0;
@@ -1076,6 +1143,20 @@
       display: grid;
       gap: 10px;
     }
+    .queueList:empty::after{
+      content: "Queue is empty";
+      display: block;
+      padding: 18px 6px;
+      text-align: center;
+      font-size: 13px;
+      letter-spacing: .04em;
+      color: rgba(210,225,250,.45);
+    }
+    .queueCard .footerRow{ color: rgba(210,225,250,.55); }
+    /* Panel is always dark: pin text colors against light-mode var flips */
+    .queueCard .qTitle{ color: #eaf3ff; }
+    .queueCard .qChan,
+    .queueCard .qUrl{ color: rgba(210,225,250,.62); }
 
     .qTile{
       position: relative;
@@ -1084,9 +1165,14 @@
       gap: 10px;
       padding: 12px;
       border-radius: 18px;
-      background: var(--card2);
-      border: 1px solid var(--stroke);
+      background: linear-gradient(180deg, rgba(24,38,72,.55), rgba(12,20,42,.60));
+      border: 1px solid rgba(120,180,255,.22);
+      box-shadow: inset 0 1px 0 rgba(190,220,255,.10);
       user-select: none;
+    }
+    .qTile:hover{
+      border-color: rgba(140,200,255,.36);
+      background: linear-gradient(180deg, rgba(30,48,90,.60), rgba(15,26,52,.65));
     }
     .qTile.isUnavailable{
       opacity: .72;
@@ -1125,10 +1211,10 @@
       justify-content:center;
       align-self: center;
       border-radius: 12px;
-      background: rgba(0, 153, 255, .16);
-      border: 1px solid rgba(95, 205, 255, .34);
-      color: rgba(125, 220, 255, .94);
-      box-shadow: inset 0 1px 0 rgba(255,255,255,.08);
+      background: linear-gradient(180deg, rgba(43,108,231,.40), rgba(22,56,142,.45));
+      border: 1px solid rgba(96, 170, 255, .42);
+      color: rgba(190, 222, 255, .94);
+      box-shadow: inset 0 1px 0 rgba(200,228,255,.16);
       cursor: grab;
       position: relative;
       z-index: 2;
@@ -1136,8 +1222,9 @@
       user-select: none;
     }
     .qHandle:hover{
-      background: rgba(0, 153, 255, .22);
-      border-color: rgba(125, 220, 255, .46);
+      background: linear-gradient(180deg, rgba(56,124,246,.50), rgba(26,64,158,.55));
+      border-color: rgba(150, 210, 255, .58);
+      box-shadow: 0 0 10px rgba(72,150,255,.25), inset 0 1px 0 rgba(200,228,255,.20);
     }
     .qHandle:active{ cursor: grabbing; }
 
@@ -1164,20 +1251,28 @@
       width: 28px;
       height: 28px;
       border-radius: 999px;
-      font-size: 14px;
+      font-size: 13px;
       font-weight: 800;
       line-height: 1;
-      border: 1px solid rgba(248, 113, 113, .72);
-      background: rgba(220, 38, 38, .88);
-      color: #fff;
+      border: 1px solid rgba(255, 130, 150, .42);
+      background: rgba(20, 26, 40, .60);
+      color: rgba(255, 165, 180, .90);
       display: inline-flex;
       align-items: center;
       justify-content: center;
       position: relative;
       z-index: 2;
-      box-shadow: 0 8px 16px rgba(127, 29, 29, .45);
+      box-shadow: none;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
     }
-    .qDelBtn:hover{ background: rgba(239, 68, 68, .92); transform: none; }
+    .qDelBtn:hover{
+      background: rgba(220, 38, 38, .88);
+      border-color: rgba(255, 150, 165, .70);
+      color: #fff;
+      box-shadow: 0 0 12px rgba(255, 120, 140, .30);
+      transform: none;
+    }
     .qDelBtn:active{ transform: none; }
 
     .qBody{

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -330,9 +330,10 @@
     .helperTxt.err{ color: #ff9aa8; }
     .helperTxt.ok{ color: #9df6b7; }
 
-    /* Send-to-TV modal: opaque glass slab with one contained panel per tool.
-       .modal.addModal outranks the generic .modal shell that follows later. */
-    .modal.addModal{
+    /* Send-to-TV + History modals: opaque glass slabs. The compound selector
+       outranks the generic .modal shell that follows later in the file. */
+    .modal.addModal,
+    .modal.histModal{
       width: min(720px, 100%);
       background: linear-gradient(165deg, rgba(13,22,44,.97), rgba(5,9,20,.985));
       border: 1px solid rgba(148,180,255,.28);
@@ -345,7 +346,8 @@
       display: grid;
       gap: 14px;
     }
-    .addModal .modalTitle{
+    .addModal .modalTitle,
+    .histModal .modalTitle{
       font-size: 13px;
       font-weight: 700;
       letter-spacing: .14em;
@@ -381,17 +383,40 @@
     .addModal .fieldRow{ margin-top: 0; }
     .addModal .helperTxt{ margin-top: 0; }
     .amActions{ justify-content: flex-end; }
-    .addModal .iconBtn{
+    .addModal .iconBtn,
+    .histModal .iconBtn{
       background: linear-gradient(180deg, rgba(148,178,255,.14), rgba(96,130,255,.06));
       border: 1px solid rgba(148,180,255,.30);
       color: #dceaff;
       box-shadow: inset 0 1px 0 rgba(255,255,255,.10);
     }
-    .addModal .iconBtn:hover{
+    .addModal .iconBtn:hover,
+    .histModal .iconBtn:hover{
       transform: none;
       border-color: rgba(148,180,255,.55);
       background: linear-gradient(180deg, rgba(148,178,255,.20), rgba(96,130,255,.10));
       box-shadow: inset 0 1px 0 rgba(255,255,255,.12), 0 0 0 2px rgba(120,180,255,.14);
+    }
+    .histModal #histClearBtn{
+      min-height: 0;
+      width: auto;
+      padding: 8px 14px;
+      border-radius: 10px;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      color: rgba(255, 172, 184, .90);
+      background: rgba(90, 20, 30, .28);
+      border: 1px solid rgba(255,120,140,.38);
+      box-shadow: none;
+    }
+    .histModal #histClearBtn:hover{
+      transform: none;
+      color: #ffe2e6;
+      background: rgba(140, 30, 45, .45);
+      border-color: rgba(255,140,160,.60);
+      box-shadow: 0 0 12px rgba(255,90,110,.20);
     }
     .addModal .urlInput,
     .addModal .notifyInput{
@@ -445,12 +470,26 @@
     #notifySendBtn:active,
     #addQueueBtn:active{ transform: translateY(1px); }
     @media (prefers-color-scheme: light){
-      .modal.addModal{
+      .modal.addModal,
+      .modal.histModal{
         background: linear-gradient(165deg, rgba(255,255,255,.97), rgba(233, 241, 255, .98));
         border-color: rgba(37, 99, 235, .20);
         box-shadow: 0 24px 54px rgba(37, 99, 235, .18), inset 0 1px 0 rgba(255,255,255,.9);
       }
-      .addModal .modalTitle{ color: #0c1324; }
+      .addModal .modalTitle,
+      .histModal .modalTitle{ color: #0c1324; }
+      .histModal #histClearBtn{
+        color: rgba(185, 28, 48, .95);
+        background: rgba(255, 235, 238, .90);
+        border-color: rgba(220, 60, 80, .40);
+      }
+      .histModal #histClearBtn:hover{
+        color: #8f1626;
+        background: rgb(255, 224, 228);
+        border-color: rgba(220, 60, 80, .60);
+        box-shadow: none;
+      }
+      .histList .muted{ color: rgba(12, 19, 36, .55); }
       .amSection{
         border-color: rgba(37, 99, 235, .14);
         background: linear-gradient(180deg, rgba(255,255,255,.65), rgba(223, 238, 255, .45));
@@ -472,6 +511,7 @@
         box-shadow: 0 0 0 2px rgba(56, 140, 248, .16);
       }
       .addModal .iconBtn,
+      .histModal .iconBtn,
       #addQueueBtn{
         background: linear-gradient(180deg, rgba(255,255,255,.92), rgba(223, 238, 255, .88));
         border-color: rgba(37, 99, 235, .22);
@@ -479,6 +519,7 @@
         box-shadow: inset 0 1px 0 rgba(255,255,255,.85);
       }
       .addModal .iconBtn:hover,
+      .histModal .iconBtn:hover,
       #addQueueBtn:hover{
         background: linear-gradient(180deg, rgba(255,255,255,.98), rgba(210, 232, 255, .95));
         border-color: rgba(37, 99, 235, .40);
@@ -591,70 +632,94 @@
     .modalTop{ display:flex; align-items:center; justify-content:space-between; gap: 10px; }
     .modalTitle{ font-weight: 700; letter-spacing: .2px; }
     .modalBtns{ display:flex; gap: 10px; }
-    .histList{ display:grid; gap: 10px; margin-top: 12px; }
+    .histList{ display:grid; gap: 10px; }
+    .histList > *{ min-width: 0; }
+    .histList .muted{
+      padding: 22px 6px;
+      text-align: center;
+      font-size: 13px;
+      letter-spacing: .04em;
+      color: rgba(210,225,250,.45);
+    }
+    /* History tiles mirror the queue's contained-thumb design and stay dark
+       glass in both themes so the artwork pops. */
     .histItem{
       position: relative;
-      display:flex;
-      gap: 10px;
-      align-items: stretch;
-      padding: 12px;
-      border-radius: 18px;
-      background: var(--card2);
-      border: 1px solid var(--stroke);
-      overflow: hidden;
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      padding: 10px;
+      border-radius: 16px;
+      background: linear-gradient(180deg, rgb(31,45,82), rgb(17,26,50));
+      border: 1px solid rgba(120,180,255,.24);
+      box-shadow: inset 0 1px 0 rgba(190,220,255,.10);
     }
     .histItem.isUnavailable{
       opacity: .72;
       filter: saturate(.78);
     }
-    .histProvBg{
-      position:absolute;
-      inset: 0;
-      pointer-events:none;
-      opacity: .12;
-      display:flex;
-      align-items:center;
-      justify-content:flex-start;
-      padding-left: 10px;
+    .histThumb{
+      position: relative;
+      flex: 0 0 auto;
+      width: 118px;
+      aspect-ratio: 16 / 9;
+      border-radius: 10px;
+      overflow: hidden;
+      border: 1px solid rgba(120,180,255,.18);
+      background:
+        radial-gradient(80% 80% at 30% 20%, rgba(43,108,231,.30), transparent 60%),
+        linear-gradient(150deg, rgba(20,34,66,.85), rgba(8,14,30,.90));
     }
-    .histProvBg img{
-      width: 84px;
-      height: 84px;
-      border-radius: 22px;
-      border: 1px solid rgba(255,255,255,.10);
+    .histThumbImg{
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    .histThumbFav{
+      position: absolute;
+      right: 5px;
+      bottom: 5px;
+      width: 18px;
+      height: 18px;
+      border-radius: 6px;
+      border: 1px solid rgba(8,14,30,.65);
+      background: rgba(8,14,30,.80);
+      padding: 2px;
+      z-index: 2;
     }
     .histProgress{
       position: absolute;
       left: 0;
       right: 0;
       bottom: 0;
-      height: 5px;
-      z-index: 3;
+      height: 4px;
+      z-index: 2;
       overflow: hidden;
-      background: rgba(15,23,42,.68);
+      background: rgba(8, 14, 30, .70);
       pointer-events: none;
     }
     .histProgress > span{
       display: block;
       height: 100%;
       background: #38bdf8;
-      box-shadow: 0 0 10px rgba(56,189,248,.80);
+      box-shadow: 0 0 8px rgba(56,189,248,.80);
     }
     .histMeta{
-      min-width:0;
+      min-width: 0;
       flex: 1 1 auto;
-      position: relative;
-      z-index: 2;
-      display:flex;
+      display: flex;
       flex-direction: column;
-      gap: 2px;
+      gap: 3px;
     }
     .histTitle{
       font-weight: 650;
-      line-height: 1.2;
+      font-size: 14px;
+      line-height: 1.25;
       min-width: 0;
-      display:flex;
-      align-items:flex-start;
+      color: #eaf3ff;
+      display: flex;
+      align-items: flex-start;
       gap: 8px;
     }
     .histTitleText{
@@ -665,9 +730,85 @@
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
     }
-    .histSub{ font-size: 12px; color: var(--muted2); margin-top: 4px; word-break: break-word; }
-    .histBtns{ margin-top: 8px; display:flex; gap: 8px; flex-wrap: wrap; }
-    .histBtns button{ min-height: 0; padding: 8px 12px; font-size: 13px; border-radius: 12px; }
+    .histSub{
+      font-size: 12px;
+      color: rgba(210,225,250,.62);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .histTags{
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+      margin-top: 2px;
+    }
+    .histTag{
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      padding: 2px 8px;
+      border-radius: 6px;
+    }
+    .histTag.resume{
+      color: rgba(150, 205, 255, .92);
+      border: 1px solid rgba(96, 170, 255, .40);
+      background: rgba(24, 60, 130, .35);
+    }
+    .histTag.done{
+      color: rgba(150, 240, 190, .92);
+      border: 1px solid rgba(110, 230, 170, .35);
+      background: rgba(20, 90, 55, .30);
+    }
+    .histTag.gone{
+      color: rgba(255, 205, 130, .92);
+      border: 1px solid rgba(255, 190, 110, .40);
+      background: rgba(90, 60, 18, .35);
+    }
+    .histBtns{ margin-top: 6px; display:flex; gap: 8px; flex-wrap: wrap; }
+    .histPlayBtn,
+    .histQueueBtn{
+      min-height: 0;
+      width: auto;
+      padding: 7px 16px;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: .04em;
+      border-radius: 10px;
+      box-shadow: none;
+    }
+    .histPlayBtn{
+      border: 1px solid rgba(125,211,252,.62);
+      background: linear-gradient(180deg, rgba(56,189,248,.82), rgba(37,99,235,.74));
+      color: #f0f9ff;
+      text-shadow: 0 1px 2px rgba(2,6,23,.35);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.25);
+    }
+    .histPlayBtn:hover:not(:disabled){
+      transform: none;
+      background: linear-gradient(180deg, rgba(94,207,255,.9), rgba(59,120,246,.82));
+      border-color: rgba(165,225,255,.75);
+    }
+    .histQueueBtn{
+      background: linear-gradient(180deg, rgba(148,178,255,.14), rgba(96,130,255,.06));
+      border: 1px solid rgba(148,180,255,.30);
+      color: #dceaff;
+    }
+    .histQueueBtn:hover:not(:disabled){
+      transform: none;
+      border-color: rgba(148,180,255,.55);
+      background: linear-gradient(180deg, rgba(148,178,255,.20), rgba(96,130,255,.10));
+    }
+    .histPlayBtn:disabled,
+    .histQueueBtn:disabled{
+      opacity: .45;
+      cursor: not-allowed;
+    }
+    @media (max-width: 480px){
+      .histThumb{ width: 96px; }
+    }
     .mediaBadge{
       display:inline-flex;
       align-items:center;

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -227,13 +227,61 @@
       background: rgba(120,180,255,.14);
     }
     .hdrMenuItem:active{ transform: none; }
+    .hdrMenuTheme{
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 10px 12px 8px;
+      margin-top: 2px;
+      border-top: 1px solid rgba(148,180,255,.10);
+    }
+    .mtLabel{
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      color: rgba(148, 180, 255, .55);
+    }
+    .mtSeg{
+      display: inline-flex;
+      gap: 2px;
+      padding: 3px;
+      border-radius: 10px;
+      background: rgba(8, 14, 30, .65);
+      border: 1px solid rgba(148,180,255,.18);
+    }
+    .mtBtn{
+      min-height: 0 !important;
+      width: auto !important;
+      padding: 4px 9px !important;
+      border: 0;
+      border-radius: 8px !important;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: .02em;
+      background: transparent;
+      color: rgba(200, 216, 255, .60);
+      box-shadow: none !important;
+      text-shadow: none;
+    }
+    .mtBtn:hover{
+      transform: none;
+      color: #eaf3ff;
+      background: rgba(120,180,255,.12);
+    }
+    .mtBtn:active{ transform: none; }
+    .mtBtn.on{
+      background: linear-gradient(180deg, rgba(56,189,248,.75), rgba(37,99,235,.68));
+      color: #f0f9ff;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.25) !important;
+    }
     .hdrMenuFoot{
       display: flex;
       align-items: center;
       justify-content: space-between;
       gap: 12px;
       padding: 9px 12px 7px;
-      margin-top: 2px;
       border-top: 1px solid rgba(148,180,255,.12);
       font-size: 10px;
       font-weight: 700;
@@ -1834,6 +1882,25 @@
   .hdrMenuFoot{
     border-top-color: rgba(37, 99, 235, .14);
     color: rgba(37, 99, 235, .58);
+  }
+  .hdrMenuTheme{ border-top-color: rgba(37, 99, 235, .12); }
+  .mtLabel{ color: rgba(37, 99, 235, .58); }
+  .mtSeg{
+    background: rgba(255,255,255,.72);
+    border-color: rgba(37, 99, 235, .18);
+  }
+  .mtBtn{ color: rgba(12, 19, 36, .55); }
+  .mtBtn:hover{
+    color: #0c1324;
+    background: rgba(56, 140, 248, .10);
+  }
+  .mtBtn.on{
+    background: linear-gradient(180deg, rgb(56, 152, 248), rgb(29, 78, 216));
+    color: #f0f9ff;
+  }
+  .mtBtn.on:hover{
+    background: linear-gradient(180deg, rgb(76, 165, 250), rgb(37, 90, 230));
+    color: #f0f9ff;
   }
   .settingsGroup{
     background: linear-gradient(180deg, rgba(191, 228, 255, .62), rgba(227, 241, 255, .54));

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -2679,3 +2679,49 @@
         background: linear-gradient(180deg, rgb(37,54,96), rgb(21,32,60));
       }
     }
+
+/* --- Compact mobile experiment: heading + now playing + remote share one
+   phone screen; only the queue scrolls below the fold. The now-playing
+   header collapses into chips floating over the hero art. --- */
+@media (max-width: 520px){
+  .wrap{ gap: 12px; }
+  .topgrid{ gap: 12px; }
+
+  .nowCard{ position: relative; padding: 12px; }
+  .nowCard .nHead{
+    position: absolute;
+    top: 22px;
+    left: 22px;
+    right: 22px;
+    z-index: 6;
+    justify-content: flex-end;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    border-bottom: 0;
+    pointer-events: none;
+  }
+  .nowCard .nHead > *{ pointer-events: auto; }
+  .nowCard .nHeadTitle{ display: none; }
+  .nowCard .nSkipBtn{ margin-left: 0; }
+  /* Floating over the art needs its own contrast in both themes */
+  .nowCard .nStateTag,
+  .nowCard .nSkipBtn{
+    background: rgba(5, 10, 22, .60);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+  .nowCard .nSkipBtn{ color: rgba(222, 236, 255, .92); }
+  /* Idle hides the hero, so the row gets its inline spot back */
+  .nowCard.isIdle .nHead{ position: static; margin: 0; }
+
+  .nHero{ aspect-ratio: 2 / 1; }
+  .nowCard .progress{ margin-top: 10px; }
+
+  .remoteCard{ padding: 12px; }
+  .rGrid{ gap: 10px; }
+  .rBig{ aspect-ratio: auto; min-height: 104px; gap: 8px; padding: 12px 10px; }
+  .rTile{ min-height: 56px; padding: 12px 14px; }
+  .rSeek{ min-height: 58px; }
+  .remoteVolumeRow{ margin-top: 10px; }
+}

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -2535,3 +2535,67 @@
     padding-bottom: calc(10px + env(safe-area-inset-bottom) / 2);
   }
 }
+
+    /* ===== Light mode: lighter section backgrounds =====
+       The three glass sections lighten; inner tiles (blue remote tiles,
+       dark-glass queue tiles, charcoal Close) keep their identity. Only
+       text sitting directly on the section surface flips dark. */
+    @media (prefers-color-scheme: light){
+      .remoteCard,
+      .queueCard,
+      .nowCard{
+        background: linear-gradient(165deg, rgba(255,255,255,.94), rgba(233,241,255,.97)) !important;
+        border-color: rgba(37,99,235,.22);
+        box-shadow:
+          0 0 24px rgba(56,130,246,.10),
+          0 14px 36px rgba(15,23,42,.14),
+          inset 0 1px 0 rgba(255,255,255,.90);
+      }
+      .qHead, .nHead{ border-bottom-color: rgba(37,99,235,.16); }
+      .qHeadTitle, .nHeadTitle{ color: #14295e; text-shadow: none; }
+      .qClearBtn, .nSkipBtn, .nGhostBtn{
+        color: rgba(23,52,120,.85);
+        border-color: rgba(37,99,235,.30);
+        background: rgba(219,232,255,.55);
+      }
+      .qClearBtn:hover, .nSkipBtn:hover, .nGhostBtn:hover{
+        color: #0c1f4d;
+        border-color: rgba(37,99,235,.50);
+        background: rgba(199,220,255,.80);
+        box-shadow: 0 0 12px rgba(72,150,255,.25);
+      }
+      .queueList:empty::after{ color: rgba(30,50,100,.48); }
+      .queueCard .footerRow{ color: rgba(30,50,100,.58); }
+      .nIdleMsg{ color: rgba(30,50,100,.52); }
+      .nTimeRow{ color: #1d4ed8; }
+      .remoteVolumeValue{ color: #1d4ed8; }
+      .rVolIcon{ color: #1e3a8a; }
+      .remoteVolumeSlider{
+        --remote-vol-track-start: rgba(37,99,235,.20);
+        --remote-vol-track-end: rgba(37,99,235,.13);
+        --remote-vol-track-border: rgba(37,99,235,.22);
+      }
+      .nowCard .progress{
+        background: linear-gradient(180deg, rgba(37,99,235,.16), rgba(37,99,235,.11));
+        border-color: rgba(37,99,235,.20);
+      }
+      .nStateDot{ background: rgba(30,64,175,.28); }
+      .nHero{ border-color: rgba(37,99,235,.16); }
+      .nHeroFade{
+        background: linear-gradient(180deg, rgba(240,246,255,0) 30%, rgba(240,246,255,.55) 62%, rgba(242,247,255,.96) 100%);
+      }
+      .nTitle{ color: #0c1324; text-shadow: 0 1px 10px rgba(255,255,255,.80); }
+      .nChan{ color: rgba(30,50,100,.75); text-shadow: 0 1px 8px rgba(255,255,255,.70); }
+      .nHeroBody .providerIcon{ background: rgba(255,255,255,.85); border-color: rgba(15,23,42,.12); }
+      /* Queue tiles keep their dark identity on the light section, but must
+         be opaque: the translucent dark gradient blends muddy over white. */
+      .qTile{
+        background: linear-gradient(180deg, rgb(31,45,82), rgb(17,26,50));
+        border-color: rgba(37,99,235,.30);
+        box-shadow: 0 6px 16px rgba(15,23,42,.18), inset 0 1px 0 rgba(190,220,255,.14);
+      }
+      .qTile:hover{
+        border-color: rgba(96,165,250,.48);
+        background: linear-gradient(180deg, rgb(37,54,96), rgb(21,32,60));
+      }
+    }

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -67,15 +67,29 @@ function _fetchWithTimeout(url, opts, timeoutMs){
 }
 
 async function post(path, body) {
+  const opts = {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: body ? JSON.stringify(body) : '{}'
+  };
+  // Generous timeout: Android wifi power-save adds seconds of first-packet
+  // latency right when the user picks the phone up.
+  let ok = false;
   try {
-    await _fetchWithTimeout(path, {
-      method: 'POST',
-      headers: {'Content-Type':'application/json'},
-      body: body ? JSON.stringify(body) : '{}'
-    }, 1800);
-  } catch(_e) {
-    // Keep controls responsive even if a transient request stalls.
+    await _fetchWithTimeout(path, opts, 5000);
+    ok = true;
+  } catch(e) {
+    // Retry only when the request never left (connection refused / network
+    // error). An abort may have landed server-side, and most commands are
+    // toggles or relative seeks where a blind resend would double-apply.
+    if (!e || e.name !== 'AbortError') {
+      try {
+        await _fetchWithTimeout(path, opts, 5000);
+        ok = true;
+      } catch(_e2) {}
+    }
   }
+  if (!ok) _connSignal(false, {sticky: true, message: 'Command failed — check connection'});
   refresh().catch(() => null);
 }
 
@@ -326,13 +340,13 @@ function _shouldRefreshFullStatus(st, fast){
 }
 
 async function _fetchFastPlaybackState(){
-  const r = await _fetchWithTimeout('/playback/state', {cache:'no-store'}, 900);
+  const r = await _fetchWithTimeout('/playback/state', {cache:'no-store'}, 2500);
   if (!r.ok) throw new Error(`playback_state ${r.status}`);
   return await r.json();
 }
 
 async function _fetchFullStatus(){
-  const r = await _fetchWithTimeout('/status', {cache:'no-store'}, 1600);
+  const r = await _fetchWithTimeout('/status', {cache:'no-store'}, 4000);
   if (!r.ok) throw new Error(`status ${r.status}`);
   const st = await r.json();
   __lastStatusFullFetchTs = Date.now();
@@ -341,10 +355,54 @@ async function _fetchFullStatus(){
 
 function _uiEventMarkAlive(){
   __uiEventSourceLastTs = Date.now();
+  _connSignal(true);
 }
 
 function _uiEventHealthy(){
-  return !!(__uiEventSource && ((Date.now() - __uiEventSourceLastTs) < 10000));
+  // Server pings every 5s when idle; allow two missed pings before we call
+  // the stream dead.
+  return !!(__uiEventSource && ((Date.now() - __uiEventSourceLastTs) < 12000));
+}
+
+function _closeUiEventStream(){
+  const es = __uiEventSource;
+  __uiEventSource = null;
+  if (es) { try { es.close(); } catch (_e) {} }
+}
+
+// Reconnect on staleness, not just on a null handle: connections killed by
+// Android screen-off/Doze or an AP roam often die without ever firing onerror,
+// leaving a zombie EventSource that would otherwise block reconnects forever.
+function _ensureUiEventStream(){
+  if (__uiEventSource && _uiEventHealthy()) return;
+  _closeUiEventStream();
+  connectUiEventStream();
+}
+
+// --- Connection indicator ---------------------------------------------------
+let __connFailStreak = 0;
+let __connBadgeStickyUntil = 0;
+
+function _connSignal(ok, opts){
+  const badge = document.getElementById('connBadge');
+  if (ok){
+    __connFailStreak = 0;
+    if (badge && Date.now() >= __connBadgeStickyUntil){
+      badge.classList.add('hidden');
+      document.body.classList.remove('connLost');
+    }
+    return;
+  }
+  const o = (opts && typeof opts === 'object') ? opts : {};
+  __connFailStreak += 1;
+  if (o.sticky) __connBadgeStickyUntil = Date.now() + 2500;
+  if (__connFailStreak >= 2 || o.sticky){
+    if (badge){
+      badge.textContent = o.message || 'Reconnecting…';
+      badge.classList.remove('hidden');
+    }
+    document.body.classList.add('connLost');
+  }
 }
 
 function _scheduleUiEventReconnect(){
@@ -3160,20 +3218,22 @@ function renderStatus(st) {
 async function refresh() {
   let st = __lastStatus || null;
   let fast = null;
+  let reachedServer = false;
   try {
     fast = await _fetchFastPlaybackState();
+    reachedServer = true;
     st = _mergePlaybackStateIntoStatus(st, fast);
   } catch(_e) {}
 
   try {
     if (_shouldRefreshFullStatus(st, fast)) {
       const full = await _fetchFullStatus();
+      reachedServer = true;
       st = fast ? _mergePlaybackStateIntoStatus(full, fast) : full;
     }
-  } catch(_e) {
-    if (!st) return;
-  }
+  } catch(_e) {}
 
+  _connSignal(reachedServer);
   if (!st) return;
   __lastStatus = st;
   renderStatus(st);
@@ -3253,7 +3313,10 @@ function connectUiEventStream(){
     return;
   }
   __uiEventSource = es;
-  _uiEventMarkAlive();
+  // Stamp the health clock without signalling connectivity: the stream hasn't
+  // proven itself until a real event (hello/ping) arrives, and a false "ok"
+  // here would flicker the reconnect badge on every failed attempt.
+  __uiEventSourceLastTs = Date.now();
 
   es.addEventListener('hello', (ev) => {
     _uiEventMarkAlive();
@@ -4618,11 +4681,15 @@ window.addEventListener('DOMContentLoaded', () => {
     if (__uiNavDepth > 0) __uiNavDepth = Math.max(0, __uiNavDepth - 1);
     _uiCloseTopLayerFromNav();
   });
-  document.addEventListener('visibilitychange', () => {
+  const wakeReconnect = () => {
     if (document.visibilityState !== 'visible') return;
-    if (!__uiEventSource) connectUiEventStream();
-    if (!_uiEventHealthy()) refresh().catch(() => {});
-  });
+    const wasHealthy = _uiEventHealthy();
+    _ensureUiEventStream();
+    if (!wasHealthy) refresh().catch(() => {});
+  };
+  document.addEventListener('visibilitychange', wakeReconnect);
+  window.addEventListener('online', wakeReconnect);
+  window.addEventListener('pageshow', wakeReconnect);
   connectUiEventStream();
   refresh();
   setInterval(() => {
@@ -4630,8 +4697,7 @@ window.addEventListener('DOMContentLoaded', () => {
     refresh().catch(() => {});
   }, __UI_FALLBACK_REFRESH_MS);
   setInterval(() => {
-    if (__uiEventSource) return;
-    connectUiEventStream();
+    _ensureUiEventStream();
   }, __UI_EVENT_RECONNECT_MS);
   setInterval(() => {
     if (document.visibilityState !== 'visible') return;

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -3149,15 +3149,28 @@ function renderStatus(st) {
     if (item && item.available === false) li.classList.add('isUnavailable');
     li.dataset.index = String(idx);
 
-    setBg(li, thumbUrl(item));
-
-    // Big, faint provider logo behind handle
-    const bg = document.createElement('div');
-    bg.className = 'qProvBg';
-    const bgFav = faviconUrl(item);
-    if (bgFav){
-      bg.innerHTML = `<img src="${bgFav}" alt="" />`;
-      li.appendChild(bg);
+    // Contained 16:9 artwork (not a background: text stays on clean glass)
+    const thumb = document.createElement('div');
+    thumb.className = 'qThumb';
+    const turl = thumbUrl(item);
+    if (turl){
+      const art = document.createElement('img');
+      art.className = 'qThumbImg';
+      art.alt = '';
+      art.loading = 'lazy';
+      art.src = turl;
+      art.onerror = () => { try { art.remove(); } catch(_e) {} };
+      thumb.appendChild(art);
+    }
+    const thumbFav = faviconUrl(item);
+    if (thumbFav){
+      const favBadge = document.createElement('img');
+      favBadge.className = 'qThumbFav';
+      favBadge.alt = '';
+      favBadge.loading = 'lazy';
+      favBadge.src = thumbFav;
+      favBadge.onerror = () => { try { favBadge.remove(); } catch(_e) {} };
+      thumb.appendChild(favBadge);
     }
 
     // Drag handle (hamburger)
@@ -3175,17 +3188,10 @@ function renderStatus(st) {
     const title = document.createElement('div');
     title.className = 'qTitle';
 
-    const favImg = document.createElement('img');
-    favImg.className = 'fav';
-    favImg.alt = '';
-    favImg.loading = 'lazy';
-    favImg.src = faviconUrl(item) || '';
-
     const tspan = document.createElement('span');
     tspan.className = 'qTitleText';
     tspan.textContent = item.title || item.url || '';
 
-    if (favImg.src) title.appendChild(favImg);
     title.appendChild(tspan);
     const titleBadge = _uploadBadge(item);
     if (titleBadge) title.insertAdjacentHTML('beforeend', titleBadge);
@@ -3193,6 +3199,12 @@ function renderStatus(st) {
     const chan = document.createElement('div');
     chan.className = 'qChan';
     chan.textContent = displaySub(item) || '';
+    if (item && item.available === false){
+      const tag = document.createElement('span');
+      tag.className = 'qUnavailTag';
+      tag.textContent = 'unavailable';
+      chan.appendChild(tag);
+    }
 
     body.appendChild(title);
     body.appendChild(chan);
@@ -3203,8 +3215,9 @@ function renderStatus(st) {
     del.title = 'Remove from queue';
     del.onclick = () => qRemove(idx);
 
-    li.appendChild(handle);
+    li.appendChild(thumb);
     li.appendChild(body);
+    li.appendChild(handle);
     li.appendChild(del);
     ol.appendChild(li);
   });

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -3100,8 +3100,20 @@ function renderStatus(st) {
     };
   }
 
-  // background thumbnail (YouTube supported; others fall back to none)
-  setBg(document.getElementById('nowTopCard'), thumbUrl(np));
+  // hero artwork (YouTube supported; others fall back to glass gradient)
+  setBg(document.getElementById('nHeroArt'), hasNow ? thumbUrl(np) : '');
+
+  const nowCardEl = document.getElementById('nowTopCard');
+  const paused = !!st.paused && hasNow;
+  const activelyPlaying = !!st.playing && !st.paused && hasNow;
+  if (nowCardEl){
+    nowCardEl.classList.toggle('isIdle', !hasNow);
+    nowCardEl.classList.toggle('isPaused', paused);
+  }
+  const stateTag = document.getElementById('nowStateTag');
+  if (stateTag) stateTag.classList.toggle('hidden', !paused);
+  const stateDot = document.getElementById('nowStateDot');
+  if (stateDot) stateDot.classList.toggle('playing', activelyPlaying);
 
   const posTxt = fmtTime(st.position);
   const durTxt = fmtTime(st.duration);
@@ -3120,7 +3132,6 @@ function renderStatus(st) {
   }
   const ppb = document.getElementById('playPauseBtn');
   if (ppb) ppb.classList.toggle('isPlaying', !!st.playing && !st.paused);
-  document.getElementById('qlen').textContent = st.queue_length || 0;
   const qCount = document.getElementById('queueCount');
   if (qCount) qCount.textContent = String(st.queue_length || 0);
   const qClear = document.getElementById('queueClearBtn');

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -3094,6 +3094,8 @@ function renderStatus(st) {
   const brand = document.getElementById('appBrandName');
   const sess = st.state || (st.playing ? (st.paused ? 'paused' : 'playing') : 'idle');
   if (brand) brand.textContent = st.device_name || 'RelayTV';
+  const menuDev = document.getElementById('menuDeviceName');
+  if (menuDev) menuDev.textContent = st.device_name || 'RelayTV';
   if (dot) {
     dot.className = 'dot' + (sess === 'playing' ? ' playing' : (sess === 'paused' ? ' paused' : (sess === 'closed' ? ' closed' : '')));
   }
@@ -3429,6 +3431,22 @@ function closeHeaderMenu(){
   if (btn) btn.setAttribute('aria-expanded', 'false');
 }
 
+let __menuFootVersionLoaded = false;
+async function _loadMenuFootVersion(){
+  if (__menuFootVersionLoaded) return;
+  __menuFootVersionLoaded = true;
+  try {
+    const r = await fetch('/app/info', {cache:'no-store'});
+    if (!r.ok) throw new Error('status ' + r.status);
+    const info = await r.json();
+    const v = String(info.version || info.release_version || '').trim();
+    const el = document.getElementById('menuAppVersion');
+    if (el && v) el.textContent = /^\d/.test(v) ? `v${v}` : v;
+  } catch (_e) {
+    __menuFootVersionLoaded = false;
+  }
+}
+
 function bindHeaderMenu(){
   const wrap = document.getElementById('hdrMenuWrap');
   const btn = document.getElementById('hdrMenuBtn');
@@ -3440,6 +3458,7 @@ function bindHeaderMenu(){
     const isHidden = panel.classList.contains('hidden');
     panel.classList.toggle('hidden', !isHidden);
     btn.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
+    if (isHidden) _loadMenuFootVersion().catch(() => {});
   };
   panel.addEventListener('pointerdown', (e) => {
     try { e.stopPropagation(); } catch(_){}

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -66,7 +66,7 @@ function _fetchWithTimeout(url, opts, timeoutMs){
   return fetch(url, finalOpts).finally(() => clearTimeout(timer));
 }
 
-async function post(path, body) {
+async function post(path, body, postOpts) {
   const opts = {
     method: 'POST',
     headers: {'Content-Type':'application/json'},
@@ -78,11 +78,13 @@ async function post(path, body) {
   try {
     await _fetchWithTimeout(path, opts, 5000);
     ok = true;
-  } catch(e) {
-    // Retry only when the request never left (connection refused / network
-    // error). An abort may have landed server-side, and most commands are
-    // toggles or relative seeks where a blind resend would double-apply.
-    if (!e || e.name !== 'AbortError') {
+  } catch(_e) {
+    // A network error doesn't prove the request never reached the server (the
+    // connection can drop after the command lands), and most commands are
+    // toggles or relative seeks where a resend would double-apply. Only
+    // retry commands the caller marked idempotent (absolute sets); everything
+    // else surfaces the failure so the user can retap.
+    if (postOpts && postOpts.idempotent) {
       try {
         await _fetchWithTimeout(path, opts, 5000);
         ok = true;
@@ -293,6 +295,7 @@ let __lastStatus = null;
 let __lastStatusFullFetchTs = 0;
 let __uiEventSource = null;
 let __uiEventSourceLastTs = 0;
+let __uiEventSourceBornTs = 0;
 let __uiEventReconnectTimer = 0;
 let __remoteVolumeKnownValue = null;
 
@@ -360,8 +363,11 @@ function _uiEventMarkAlive(){
 
 function _uiEventHealthy(){
   // Server pings every 5s when idle; allow two missed pings before we call
-  // the stream dead.
-  return !!(__uiEventSource && ((Date.now() - __uiEventSourceLastTs) < 12000));
+  // the stream dead. Only real events stamp the clock, so a stream that never
+  // delivers anything can never read as healthy — the fallback poll and the
+  // reconnect badge stay armed while reconnect attempts are unproven.
+  return !!(__uiEventSource && __uiEventSourceLastTs
+    && ((Date.now() - __uiEventSourceLastTs) < 12000));
 }
 
 function _closeUiEventStream(){
@@ -374,7 +380,13 @@ function _closeUiEventStream(){
 // Android screen-off/Doze or an AP roam often die without ever firing onerror,
 // leaving a zombie EventSource that would otherwise block reconnects forever.
 function _ensureUiEventStream(){
-  if (__uiEventSource && _uiEventHealthy()) return;
+  if (__uiEventSource){
+    if (_uiEventHealthy()) return;
+    // A fresh stream gets time to connect and deliver its first event before
+    // we recycle it — but it stays "unhealthy" until that event arrives, so
+    // this grace never suppresses the fallback poll.
+    if ((Date.now() - __uiEventSourceBornTs) < 12000) return;
+  }
   _closeUiEventStream();
   connectUiEventStream();
 }
@@ -839,7 +851,7 @@ function initRemoteVolumeSlider(){
     const val = Math.max(0, Math.min(200, Number(slider.value || 0)));
     slider.__draggingVolume = false;
     _renderRemoteVolume(val, {source:'user'});
-    await post('/volume', {set: val});
+    await post('/volume', {set: val}, {idempotent: true});
   };
 
   slider.addEventListener('pointerdown', () => { slider.__draggingVolume = true; });
@@ -888,7 +900,7 @@ async function _commitSeekFromPct(pct){
   const dur = __lastStatus.duration;
   if (dur == null || isNaN(dur) || dur <= 0) return;
   const sec = pct * dur;
-  await post('/seek_abs', {sec: sec});
+  await post('/seek_abs', {sec: sec}, {idempotent: true});
 }
 
 function initScrubber(){
@@ -3369,10 +3381,10 @@ function connectUiEventStream(){
     return;
   }
   __uiEventSource = es;
-  // Stamp the health clock without signalling connectivity: the stream hasn't
-  // proven itself until a real event (hello/ping) arrives, and a false "ok"
-  // here would flicker the reconnect badge on every failed attempt.
-  __uiEventSourceLastTs = Date.now();
+  // Record birth only — never the health clock. The stream hasn't proven
+  // itself until a real event (hello/ping) arrives; stamping health here
+  // would let a silent reconnect loop read as healthy forever.
+  __uiEventSourceBornTs = Date.now();
 
   es.addEventListener('hello', (ev) => {
     _uiEventMarkAlive();

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -3431,6 +3431,83 @@ function closeHeaderMenu(){
   if (btn) btn.setAttribute('aria-expanded', 'false');
 }
 
+// --- Theme override (Auto / Dark / Light) -----------------------------------
+// All light styling lives in `prefers-color-scheme: light` media blocks; the
+// manual override rewrites those rules' media conditions at runtime instead of
+// duplicating every block under a data-attribute selector.
+const __THEME_KEY = 'relaytv_theme';
+const __THEME_RE = /\(prefers-color-scheme:\s*(light|dark)\)/;
+
+function _themeStoredMode(){
+  try {
+    const v = localStorage.getItem(__THEME_KEY);
+    return (v === 'dark' || v === 'light') ? v : 'auto';
+  } catch (_e) { return 'auto'; }
+}
+
+function _themeApplyToSheets(mode){
+  for (const sheet of Array.from(document.styleSheets)){
+    let rules = null;
+    try { rules = sheet.cssRules; } catch (_e) { continue; }
+    if (!rules) continue;
+    for (const rule of Array.from(rules)){
+      if (!rule.media || !rule.media.mediaText) continue;
+      const orig = rule.__relaytvOrigMedia || rule.media.mediaText;
+      const m = orig.match(__THEME_RE);
+      if (!m) continue;
+      rule.__relaytvOrigMedia = orig;
+      if (mode === 'auto'){
+        rule.media.mediaText = orig;
+      } else {
+        // Always/never tokens that stay valid inside `and (...)` chains.
+        const on = (m[1] === mode);
+        rule.media.mediaText = orig.replace(__THEME_RE, on ? '(min-width: 0px)' : '(min-width: 99999px)');
+      }
+    }
+  }
+}
+
+function _themeEffective(mode){
+  if (mode !== 'auto') return mode;
+  try {
+    return (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) ? 'light' : 'dark';
+  } catch (_e) { return 'dark'; }
+}
+
+function applyTheme(mode){
+  _themeApplyToSheets(mode);
+  try { document.documentElement.style.colorScheme = (mode === 'auto') ? '' : mode; } catch (_e) {}
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) meta.setAttribute('content', _themeEffective(mode) === 'light' ? '#edf2ff' : '#05070d');
+  document.querySelectorAll('.mtBtn').forEach((b) => {
+    const on = (b.dataset.themeMode || 'auto') === mode;
+    b.classList.toggle('on', on);
+    b.setAttribute('aria-checked', on ? 'true' : 'false');
+  });
+}
+
+function bindThemeUi(){
+  document.querySelectorAll('.mtBtn').forEach((b) => {
+    b.onclick = () => {
+      const mode = b.dataset.themeMode || 'auto';
+      try { localStorage.setItem(__THEME_KEY, mode); } catch (_e) {}
+      applyTheme(mode);
+    };
+  });
+  try {
+    const mq = window.matchMedia('(prefers-color-scheme: light)');
+    const onChange = () => applyTheme(_themeStoredMode());
+    if (mq.addEventListener) mq.addEventListener('change', onChange);
+    else if (mq.addListener) mq.addListener(onChange);
+  } catch (_e) {}
+}
+
+// Apply immediately (deferred script: DOM and stylesheets are already in) so a
+// stored override never flashes the system theme; re-applied on `load` in case
+// a stylesheet finished late.
+try { applyTheme(_themeStoredMode()); } catch (_e) {}
+window.addEventListener('load', () => { try { applyTheme(_themeStoredMode()); } catch (_e) {} });
+
 let __menuFootVersionLoaded = false;
 async function _loadMenuFootVersion(){
   if (__menuFootVersionLoaded) return;
@@ -4754,6 +4831,7 @@ window.addEventListener('DOMContentLoaded', () => {
   initRemoteVolumeSlider();
   primeRemoteVolumeSlider().catch(() => {});
   bindHeaderMenu();
+  bindThemeUi();
   bindHistoryUi();
   bindAboutUi();
   bindNowLanguageUi();

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -686,7 +686,11 @@ function _uploadSummary(item){
 
 function _hasNowPlayingItem(st, np){
   if (st && (st.playing || st.paused)) return true;
-  return !!(np && (np.title || np.url || np.stream));
+  const hasItem = !!(np && (np.title || np.url || np.stream));
+  // Both /status and /playback/state now carry the authoritative flag; trust
+  // it when present so the fast and full views cannot disagree at idle.
+  if (st && typeof st.has_now_playing === 'boolean') return st.has_now_playing && hasItem;
+  return hasItem;
 }
 
 function _isNowPlayingJellyfin(np){
@@ -1015,6 +1019,10 @@ let __jfViewportBound = false;
 const __JF_CATALOG_LIMIT = 5000;
 const __JF_REQ_TIMEOUT_MS = 12000;
 const __UI_FALLBACK_REFRESH_MS = 8000;
+const __NOW_IDLE_DEBOUNCE_MS = 4000;
+let __nowIdleSinceTs = 0;
+let __nowIdleSettleTimer = 0;
+let __nowLastShownNp = null;
 const __UI_EVENT_RECONNECT_MS = 5000;
 const __JF_DASHBOARD_REFRESH_MS = 45000;
 
@@ -3080,9 +3088,33 @@ function renderStatus(st) {
   if (state) state.textContent = sess;
 
   // now playing
-  const np = st.now_playing || {};
+  let np = st.now_playing || {};
   const picon = document.getElementById('picon');
-  const hasNow = _hasNowPlayingItem(st, np);
+  // Debounce the idle flip: a transient idle signal (transition gap, fast/full
+  // disagreement) must not blank the card. Content applies instantly; idle
+  // only lands after the signal has been stable for a few seconds, and the
+  // last-shown item stays frozen on screen during that window.
+  let hasNow = _hasNowPlayingItem(st, np);
+  if (!hasNow){
+    if (!__nowIdleSinceTs){
+      __nowIdleSinceTs = Date.now();
+      if (!__nowIdleSettleTimer){
+        __nowIdleSettleTimer = window.setTimeout(() => {
+          __nowIdleSettleTimer = 0;
+          if (__lastStatus) renderStatus(__lastStatus);
+        }, __NOW_IDLE_DEBOUNCE_MS + 300);
+      }
+    }
+    if (((Date.now() - __nowIdleSinceTs) < __NOW_IDLE_DEBOUNCE_MS) && __nowLastShownNp){
+      hasNow = true;
+      np = __nowLastShownNp;
+    }
+  } else {
+    __nowIdleSinceTs = 0;
+    if (__nowIdleSettleTimer){ window.clearTimeout(__nowIdleSettleTimer); __nowIdleSettleTimer = 0; }
+  }
+  if (hasNow) __nowLastShownNp = np;
+  else __nowLastShownNp = null;
   const fav = hasNow ? faviconUrl(np) : '/pwa/brand/logo.svg';
   picon.innerHTML = fav ? `<img src="${fav}" alt="" />` : '🎞️';
   document.getElementById('now').textContent = hasNow ? (np.title || 'Now Playing') : 'Ready';

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -750,9 +750,9 @@ function _renderRemoteVolume(value, opts){
     const liveDragValue = Math.max(0, Math.min(200, Number(slider.value || 100)));
     const base = slider.__draggingVolume ? liveDragValue : (effective != null ? effective : liveDragValue);
     slider.style.setProperty('--remote-vol-pct', `${((base / 200) * 100).toFixed(2)}%`);
-    if (label) label.textContent = `${Math.round(base)}% Volume`;
+    if (label) label.textContent = `${Math.round(base)}%`;
   } else if (label) {
-    label.textContent = effective == null ? '--% Volume' : `${effective}% Volume`;
+    label.textContent = effective == null ? '--%' : `${effective}%`;
   }
   if (effective != null) {
     __remoteVolumeKnownValue = effective;
@@ -3056,10 +3056,12 @@ function renderStatus(st) {
   const mute = !!st.mute;
   const mb = document.getElementById('muteBtn');
   if (mb){
-    // update label/icon subtly
-    mb.querySelector('.bIcon').textContent = mute ? '🔇' : '🔈';
-    mb.querySelector('span:last-child').textContent = mute ? 'Unmute' : 'Mute';
+    mb.classList.toggle('muted', mute);
+    const muteLbl = mb.querySelector('.rLabel');
+    if (muteLbl) muteLbl.textContent = mute ? 'Unmute' : 'Mute';
   }
+  const ppb = document.getElementById('playPauseBtn');
+  if (ppb) ppb.classList.toggle('isPlaying', !!st.playing && !st.paused);
   document.getElementById('qlen').textContent = st.queue_length || 0;
 
   // progress bar fill

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -3609,14 +3609,28 @@ async function renderHistory(){
     const row = document.createElement('div');
     row.className = 'histItem';
     if (!available) row.classList.add('isUnavailable');
-    setBg(row, thumbUrl(it));
 
-    const bgFav = faviconUrl(it);
-    if (bgFav){
-      const bg = document.createElement('div');
-      bg.className = 'histProvBg';
-      bg.innerHTML = `<img src="${bgFav}" alt="" />`;
-      row.appendChild(bg);
+    const thumb = document.createElement('div');
+    thumb.className = 'histThumb';
+    const turl = thumbUrl(it);
+    if (turl){
+      const img = document.createElement('img');
+      img.className = 'histThumbImg';
+      img.alt = '';
+      img.loading = 'lazy';
+      img.src = turl;
+      img.onerror = () => { try { img.remove(); } catch(_e){} };
+      thumb.appendChild(img);
+    }
+    const fav = faviconUrl(it);
+    if (fav){
+      const badge = document.createElement('img');
+      badge.className = 'histThumbFav';
+      badge.alt = '';
+      badge.loading = 'lazy';
+      badge.src = fav;
+      badge.onerror = () => { try { badge.remove(); } catch(_e){} };
+      thumb.appendChild(badge);
     }
 
     const resumePos = Number(it.resume_pos);
@@ -3628,7 +3642,7 @@ async function renderHistory(){
       const fill = document.createElement('span');
       fill.style.width = `${Math.max(0, Math.min(100, progressRatio * 100))}%`;
       bar.appendChild(fill);
-      row.appendChild(bar);
+      thumb.appendChild(bar);
     }
 
     const meta = document.createElement('div');
@@ -3636,17 +3650,6 @@ async function renderHistory(){
 
     const title = document.createElement('div');
     title.className = 'histTitle';
-
-    const fav = faviconUrl(it);
-    if (fav){
-      const favImg = document.createElement('img');
-      favImg.className = 'fav';
-      favImg.alt = '';
-      favImg.loading = 'lazy';
-      favImg.src = fav;
-      title.appendChild(favImg);
-    }
-
     const tspan = document.createElement('span');
     tspan.className = 'histTitleText';
     tspan.textContent = it.title || it.url || '(unknown)';
@@ -3658,29 +3661,35 @@ async function renderHistory(){
     channel.className = 'histSub';
     channel.textContent = displaySub(it) || '';
 
-    const sub = document.createElement('div');
-    sub.className = 'histSub';
-    sub.textContent = `${_fmtTs(it.ts)}  •  ${it.mode || ''}`.trim();
+    const when = document.createElement('div');
+    when.className = 'histSub';
+    when.textContent = `${_fmtTs(it.ts)} · ${String(it.mode || '').replace(/_/g, ' ')}`.replace(/ · $/, '');
 
-    const progress = document.createElement('div');
-    progress.className = 'histSub';
-    if (it.completed === true) {
-      progress.textContent = 'Completed · 00:00';
-    } else {
-      const resumePos = Number(it.resume_pos);
-      progress.textContent = Number.isFinite(resumePos) && resumePos > 0
-        ? `Resume · ${fmtTime(resumePos)}`
-        : 'Resume · 00:00';
+    const tags = document.createElement('div');
+    tags.className = 'histTags';
+    if (it.completed === true){
+      const t = document.createElement('span');
+      t.className = 'histTag done';
+      t.textContent = 'Completed';
+      tags.appendChild(t);
+    } else if (Number.isFinite(resumePos) && resumePos > 0){
+      const t = document.createElement('span');
+      t.className = 'histTag resume';
+      t.textContent = `Resume ${fmtTime(resumePos)}`;
+      tags.appendChild(t);
     }
-
-    const url = document.createElement('div');
-    url.className = 'histSub';
-    url.textContent = available ? (it.url || '') : 'Playback unavailable: stored upload was removed';
+    if (!available){
+      const t = document.createElement('span');
+      t.className = 'histTag gone';
+      t.textContent = 'Upload removed';
+      tags.appendChild(t);
+    }
 
     const btns = document.createElement('div');
     btns.className = 'histBtns';
 
     const play = document.createElement('button');
+    play.className = 'histPlayBtn';
     play.textContent = 'Play';
     play.disabled = !available;
     play.onclick = async () => {
@@ -3691,6 +3700,7 @@ async function renderHistory(){
     };
 
     const queue = document.createElement('button');
+    queue.className = 'histQueueBtn';
     queue.textContent = 'Queue';
     queue.disabled = !available;
     queue.onclick = async () => {
@@ -3705,11 +3715,11 @@ async function renderHistory(){
 
     meta.appendChild(title);
     meta.appendChild(channel);
-    meta.appendChild(sub);
-    meta.appendChild(progress);
-    meta.appendChild(url);
+    meta.appendChild(when);
+    if (tags.childElementCount > 0) meta.appendChild(tags);
     meta.appendChild(btns);
 
+    row.appendChild(thumb);
     row.appendChild(meta);
     list.appendChild(row);
   });

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -3063,6 +3063,10 @@ function renderStatus(st) {
   const ppb = document.getElementById('playPauseBtn');
   if (ppb) ppb.classList.toggle('isPlaying', !!st.playing && !st.paused);
   document.getElementById('qlen').textContent = st.queue_length || 0;
+  const qCount = document.getElementById('queueCount');
+  if (qCount) qCount.textContent = String(st.queue_length || 0);
+  const qClear = document.getElementById('queueClearBtn');
+  if (qClear) qClear.classList.toggle('hidden', !(Number(st.queue_length) > 0));
 
   // progress bar fill
   if (!__scrubbing && st.position != null && st.duration != null && st.duration > 0) {

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 import json
 import os
+import re
 import shutil
 import subprocess
 import tomllib
@@ -50,8 +51,9 @@ def test_ui_smoke() -> None:
 
     assert response.status_code == 200
     assert 'text/html' in response.headers['content-type']
-    assert '<link rel="stylesheet" href="/static/ui/app.css" />' in response.text
-    assert '<script src="/static/ui/app.js" defer></script>' in response.text
+    assert re.search(r'<link rel="stylesheet" href="/static/ui/app\.css\?v=\d+" />', response.text)
+    assert re.search(r'<script src="/static/ui/app\.js\?v=\d+" defer></script>', response.text)
+    assert response.headers.get('cache-control') == 'no-cache'
     assert 'window.RELAYTV_IDLE_PANEL_CATALOG = ' in response.text
     assert '<style>' not in response.text
     assert css_response.status_code == 200

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -145,7 +145,7 @@ def test_ui_smoke() -> None:
     assert 'function _formatUploadSize(bytes)' in js
     assert 'mediaBadge' in js
     assert 'isUnavailable' in js
-    assert 'Playback unavailable: stored upload was removed' in js
+    assert 'Upload removed' in js
     assert 'onclick="post(\'/close\')"' in response.text
     assert "await post('/now_playing/clear');" in js
     assert 'id="jfSearchBtn"' not in response.text

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -109,7 +109,9 @@ def test_ui_smoke() -> None:
     assert "const imageUrl = file ? await readNotifyImageDataUrl(file) : String(imageUrlEl?.value || '').trim();" in js
     assert "await _fetchWithTimeout('/overlay'" in js
     assert 'bindAboutUi();' in js
-    assert 'class="nowSubRow"' in response.text
+    assert 'class="nMetaRow"' in response.text
+    assert 'id="nHeroArt"' in response.text
+    assert 'id="nowStateDot"' in response.text
     assert 'id="langBackdrop"' in response.text
     assert 'id="subLangBackdrop"' in response.text
     assert 'role="tablist"' in response.text


### PR DESCRIPTION
## Summary

Full redesign of the phone remote around the neon-glass concept, applied consistently across all three sections, plus the connectivity and caching fixes that fell out of using it in anger.

**Remote panel** — dark floating glass slab with a luminous rim: large square Play/Pause and Next tiles with ring-outlined inline-SVG glyphs (emoji icons removed everywhere), a full-width Mute bar whose bright sweep-lit treatment doubles as the muted-active state, a neutral charcoal Close with a red hint only on hover, ringed-number seek tiles, and a bare volume row with a glowing thumb. Play/Pause and Mute now reflect live state from the status poll.

**Queue panel** — same glass language: flat header with a live count badge and a ghost Clear pill (shown only when items exist) replacing the pill section title and footer link; queue items rebuilt around a contained 16:9 thumbnail (locally-proxied art, provider favicon corner badge, gradient fallback) with text on clean glass, an amber unavailable tag, and grip + delete in a right rail.

**Now-playing card** — hero treatment: flat header with a pulsing state dot and amber PAUSED tag, ghost Skip pill, 16:9 artwork fading bottom-up into the panel with title and channel anchored over it, Audio/Subs as labeled ghost pills, a slim glowing progress track with plain position/duration text, and a proper dimmed idle state.

**Light mode** — the three sections take a light-glass treatment; inner tiles keep their identity (queue tiles go opaque so the dark gradient doesn't blend muddy over white); hero art fades into the light surface with dark text.

**Connectivity hardening** (Android PWA felt "sketchy"): SSE reconnect now keys on stream staleness rather than a null handle, so zombie EventSources killed silently by screen-off/Doze recover; the server pings idle streams every 5s inside a 12s client health window; command POSTs get radio-wake-friendly 5s timeouts (retrying only when the request never left); failures surface via an amber "Reconnecting…" badge with panel dimming. Verified live by stopping/restarting the server under an open session.

**Fixes discovered en route**: /static/ui assets are served max-age=3600, so asset-only deploys never reached installed clients — the shell is now no-cache and links assets with a `?v=<mtime>` stamp. The now-playing card could flap between content and idle every 5s when the fast and full status views disagreed — the full payload now carries the authoritative `has_now_playing` flag and the idle flip is debounced 4s with the last-shown item frozen during the window.

## Verification

Every stage screenshot-verified against the running appliance with headless Chromium at 1440/390/320 widths in both color schemes, including injected muted/playing/paused/idle/unavailable states; connectivity behavior proven with a live browser watching a real container stop/start (badge at 12s, SSE reattach 2s after recovery); the idle-flash fix validated by injecting the exact flapping pattern. 401 tests + ruff green throughout; smoke test updated for the new markup and cache-busted asset URLs.

BEGIN_COMMIT_OVERRIDE
feat: redesign the remote, queue, and now-playing UI as a neon-glass control system with light mode
fix: harden the remote UI against silent connection loss on mobile
fix: cache-bust UI assets so deploys reach already-installed clients
fix: stop the now-playing card flashing to idle every few seconds
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)