### PR TITLE
fix: harden public playback data for Home Assistant

### DIFF
--- a/app/relaytv_app/public_media.py
+++ b/app/relaytv_app/public_media.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Safe serialization helpers for media objects exposed by public APIs."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+_PRIVATE_ITEM_KEYS = {
+    "access_token",
+    "api_key",
+    "audio",
+    "cookie",
+    "cookies",
+    "headers",
+    "http_headers",
+    "resolved_audio",
+    "resolved_source_url",
+    "resolved_stream",
+    "stream",
+    "token",
+}
+
+_SENSITIVE_QUERY_KEYS = {
+    "access_token",
+    "apikey",
+    "api_key",
+    "authorization",
+    "auth_token",
+    "cookie",
+    "expires",
+    "hdnea",
+    "hdnts",
+    "key-pair-id",
+    "policy",
+    "sig",
+    "signature",
+    "token",
+}
+
+_URL_FIELDS = {"art", "image", "input", "poster", "thumbnail", "thumbnail_local", "url"}
+
+
+def _is_sensitive_query_key(key: str) -> bool:
+    normalized = str(key or "").strip().lower()
+    return normalized in _SENSITIVE_QUERY_KEYS or normalized.startswith("x-amz-")
+
+
+def sanitize_public_url(value: object) -> str:
+    """Remove credentials and transient signing parameters from a public URL."""
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    try:
+        parsed = urlsplit(raw)
+    except Exception:
+        return ""
+    if not parsed.scheme or not parsed.netloc:
+        return raw
+
+    hostname = parsed.hostname or ""
+    if not hostname:
+        return ""
+    netloc = hostname
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+
+    query = [
+        (key, val)
+        for key, val in parse_qsl(parsed.query, keep_blank_values=True)
+        if not _is_sensitive_query_key(key)
+    ]
+    return urlunsplit((parsed.scheme, netloc, parsed.path, urlencode(query, doseq=True), ""))
+
+
+def public_media_item(item: object) -> object:
+    """Return a display-safe copy of a queue/history/now-playing item."""
+    if not isinstance(item, dict):
+        return item
+
+    source_url = item.get("_resolved_source_url") or item.get("resolved_source_url")
+    result: dict[str, object] = {}
+    for key, value in item.items():
+        normalized = str(key or "").strip().lower()
+        if key.startswith("_") or normalized in _PRIVATE_ITEM_KEYS:
+            continue
+        if normalized in _URL_FIELDS and isinstance(value, str):
+            safe_url = sanitize_public_url(value)
+            if safe_url:
+                result[key] = safe_url
+            continue
+        result[key] = value
+
+    if source_url:
+        safe_source = sanitize_public_url(source_url)
+        if safe_source:
+            result["url"] = safe_source
+    return result
+
+
+def public_media_items(items: list[object] | None) -> list[object]:
+    """Return display-safe copies of media items."""
+    return [public_media_item(item) for item in list(items or [])]

--- a/app/relaytv_app/public_media.py
+++ b/app/relaytv_app/public_media.py
@@ -61,7 +61,7 @@ def sanitize_public_url(value: object) -> str:
     hostname = parsed.hostname or ""
     if not hostname:
         return ""
-    netloc = hostname
+    netloc = f"[{hostname}]" if ":" in hostname else hostname
     if parsed.port is not None:
         netloc = f"{netloc}:{parsed.port}"
 

--- a/app/relaytv_app/public_media.py
+++ b/app/relaytv_app/public_media.py
@@ -25,17 +25,22 @@ _SENSITIVE_QUERY_KEYS = {
     "access_token",
     "apikey",
     "api_key",
+    "auth",
     "authorization",
     "auth_token",
     "cookie",
+    "exp",
     "expires",
     "hdnea",
     "hdnts",
+    "jwt",
     "key-pair-id",
     "policy",
     "sig",
     "signature",
     "token",
+    "x-emby-token",
+    "x-jellyfin-token",
 }
 
 _URL_FIELDS = {"art", "image", "input", "poster", "thumbnail", "thumbnail_local", "url"}

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -20,7 +20,7 @@ import socket
 import urllib.request
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
-from .. import config, state, resolver, player, playback_service, discovery_mdns, video_profile, upload_store, x11_overlay
+from .. import config, discovery_mdns, playback_service, player, public_media, resolver, state, upload_store, video_profile, x11_overlay
 from ..debug import debug_log, get_logger
 from ..config import env_choice, runtime_config
 from ..integrations import jellyfin_receiver, jellyfin_service
@@ -976,7 +976,7 @@ def _ui_event_push_queue(action: str, queue: list[object] | None = None, queue_l
 
 
 def _annotate_upload_item(item: object) -> object:
-    return upload_store.annotate_item(item)
+    return public_media.public_media_item(upload_store.annotate_item(item))
 
 
 def _annotate_upload_items(items: list[object] | None) -> list[object]:

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -2651,7 +2651,7 @@ def _resume_paused_current_session_in_place(*, action: str = "resume") -> dict[s
         "ok": True,
         "action": action,
         "paused": False,
-        "now_playing": state.NOW_PLAYING,
+        "now_playing": _annotate_upload_item(state.NOW_PLAYING),
         **_control_ack_payload(result),
     }
 

--- a/app/relaytv_app/routes/assets.py
+++ b/app/relaytv_app/routes/assets.py
@@ -12,6 +12,11 @@ from ..thumb_cache import THUMB_DIR, ensure_cached_sync
 router = APIRouter()
 
 _RELAYTV_THEME = "#0b0f19"
+_THUMBNAIL_HEADERS = {
+    "Cache-Control": "public, max-age=86400",
+    "Access-Control-Allow-Origin": "*",
+    "Cross-Origin-Resource-Policy": "cross-origin",
+}
 _STATIC_ROOT = os.getenv("RELAYTV_STATIC_DIR") or os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static"))
 _PWA_STATIC_ROOT = os.path.join(_STATIC_ROOT, "pwa")
 
@@ -243,12 +248,12 @@ async def thumbs(filename: str):
         return Response(status_code=400)
     path = os.path.join(THUMB_DIR, filename)
     if os.path.exists(path):
-        return FileResponse(path, media_type="image/jpeg", headers={"Cache-Control": "public, max-age=86400"})
+        return FileResponse(path, media_type="image/jpeg", headers=_THUMBNAIL_HEADERS)
     # Try to materialize on-demand from the stored mapping (best effort).
     thumb_id = filename[:-4] if filename.lower().endswith(".jpg") else filename
     ok = await asyncio.to_thread(ensure_cached_sync, thumb_id)
     if ok and os.path.exists(path):
-        return FileResponse(path, media_type="image/jpeg", headers={"Cache-Control": "public, max-age=86400"})
+        return FileResponse(path, media_type="image/jpeg", headers=_THUMBNAIL_HEADERS)
     return Response(status_code=404)
 
 

--- a/app/relaytv_app/routes/health.py
+++ b/app/relaytv_app/routes/health.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-only
 from fastapi import APIRouter
 
+from .. import api_auth
+
 
 router = APIRouter()
 
@@ -10,3 +12,9 @@ def health() -> dict[str, bool]:
     # Keep the health payload intentionally minimal so basic liveness checks and
     # smoke tests can rely on a stable response contract.
     return {"ok": True}
+
+
+@router.post("/auth/check")
+def auth_check() -> dict[str, bool]:
+    """Validate write authorization without changing server state."""
+    return {"ok": True, "token_required": bool(api_auth.configured_api_token())}

--- a/app/relaytv_app/routes/playback.py
+++ b/app/relaytv_app/routes/playback.py
@@ -77,6 +77,12 @@ def _control_result_or_raise(result: dict | None, *, action: str) -> dict[str, o
     return control_result_or_raise(result, action=action)
 
 
+def _annotate_upload_item(item: object) -> object:
+    from . import _annotate_upload_item as annotate_upload_item
+
+    return annotate_upload_item(item)
+
+
 def _seek_transition_hold_sec() -> float:
     from . import _seek_transition_hold_sec as seek_transition_hold_sec
 
@@ -269,7 +275,7 @@ def play(req: PlayReq):
         mode="play",
         start_pos=(float(start_pos) if start_pos is not None else None),
     )
-    return {"status": "playing", "now_playing": now}
+    return {"status": "playing", "now_playing": _annotate_upload_item(now)}
 
 
 @router.post("/next")
@@ -280,6 +286,8 @@ def next_track():
         raise HTTPException(status_code=400, detail="Queue is empty")
     if result.get("method") == "dequeue_play_item":
         result.pop("method", None)
+    if "now_playing" in result:
+        result["now_playing"] = _annotate_upload_item(result.get("now_playing"))
     return result
 
 
@@ -347,8 +355,8 @@ def play_now(req: PlayNowReq):
             return {
                 "ok": True,
                 "action": "skipped_post_live_processing",
-                "now_playing": now,
-                "preserved": preserved,
+                "now_playing": _annotate_upload_item(now),
+                "preserved": _annotate_upload_item(preserved),
                 "queue_length": qlen,
             }
         _rollback_play_now_preserve(preserved)
@@ -381,7 +389,13 @@ def play_now(req: PlayNowReq):
         queue_snapshot = list(state.QUEUE)
     if preserved is not None or qlen:
         _ui_event_push_queue("play_now", queue=queue_snapshot, queue_length=qlen, source="play_now")
-    return {"ok": True, "action": "played", "now_playing": now, "preserved": preserved, "queue_length": qlen}
+    return {
+        "ok": True,
+        "action": "played",
+        "now_playing": _annotate_upload_item(now),
+        "preserved": _annotate_upload_item(preserved),
+        "queue_length": qlen,
+    }
 
 
 @router.post("/play_temporary")
@@ -420,7 +434,7 @@ def play_temporary(req: PlayTemporaryReq):
         pass
     timeout = float(req.timeout_sec) if req.timeout_sec is not None and req.timeout_sec > 0 else None
     _threading_module().Thread(target=_temporary_watchdog, args=(frame_id, timeout), daemon=True).start()
-    return {"ok": True, "temporary_id": frame_id, "now_playing": now, "stack_depth": len(stack)}
+    return {"ok": True, "temporary_id": frame_id, "now_playing": _annotate_upload_item(now), "stack_depth": len(stack)}
 
 
 @router.post("/play_temporary/cancel")
@@ -507,7 +521,7 @@ def share(url: str | None = None, link: str | None = None, cec: bool = True):
         mode="share",
         start_pos=(float(start_pos) if start_pos is not None else None),
     )
-    return {"status": "playing", "now_playing": now, "source": "share_target"}
+    return {"status": "playing", "now_playing": _annotate_upload_item(now), "source": "share_target"}
 
 
 @router.post("/smart")
@@ -520,7 +534,12 @@ def smart(req: PlayReq):
             _push_queue_added_toast_async(item, req.url or "item")
         except Exception:
             pass
-        return {"status": "queued", "item": item, "queue_length": qlen, "now_playing": state.NOW_PLAYING}
+        return {
+            "status": "queued",
+            "item": _annotate_upload_item(item),
+            "queue_length": qlen,
+            "now_playing": _annotate_upload_item(state.NOW_PLAYING),
+        }
 
     item = _smart_item_from_url(req.url or "")
     start_pos = item.get("resume_pos") if isinstance(item, dict) else None
@@ -532,7 +551,7 @@ def smart(req: PlayReq):
         mode="smart_play",
         start_pos=(float(start_pos) if start_pos is not None else None),
     )
-    return {"status": "playing", "now_playing": now}
+    return {"status": "playing", "now_playing": _annotate_upload_item(now)}
 
 
 @router.post("/now_playing/clear")
@@ -592,7 +611,7 @@ def resume_session():
         raise HTTPException(status_code=400, detail="No item to resume")
 
     _resumed, resume_result = playback_service.resume_session()
-    return {"status": "resumed", "now_playing": state.NOW_PLAYING, **_control_ack_payload(resume_result)}
+    return {"status": "resumed", "now_playing": _annotate_upload_item(state.NOW_PLAYING), **_control_ack_payload(resume_result)}
 
 
 @router.post("/stop")
@@ -654,7 +673,7 @@ def playback_play():
             "ok": True,
             "action": ("pause" if target else "resume"),
             "paused": target,
-            "now_playing": state.NOW_PLAYING,
+            "now_playing": _annotate_upload_item(state.NOW_PLAYING),
             **_control_ack_payload(result),
         }
 
@@ -696,7 +715,12 @@ def playback_play():
             resumed["mode"] = "resume"
             resumed["closed"] = False
             playback_service.mark_resumed_now_playing(resumed)
-            return {"ok": True, "action": "resume_session", "now_playing": state.NOW_PLAYING, **_control_ack_payload(resume_result)}
+            return {
+                "ok": True,
+                "action": "resume_session",
+                "now_playing": _annotate_upload_item(state.NOW_PLAYING),
+                **_control_ack_payload(resume_result),
+            }
 
         # Fallback: re-resolve/play via play_item
         resumed = playback_service.play_now(
@@ -709,14 +733,14 @@ def playback_play():
         )
         resumed["closed"] = False
         playback_service.mark_resumed_now_playing(resumed)
-        return {"ok": True, "action": "resume_session", "now_playing": state.NOW_PLAYING}
+        return {"ok": True, "action": "resume_session", "now_playing": _annotate_upload_item(state.NOW_PLAYING)}
 
     # Else: play next queue item.
     try:
         handoff = playback_service.advance_queue(mode="play_next", prefer_playlist_next=False)
     except playback_service.QueueAdvanceEmptyError:
         raise HTTPException(status_code=400, detail="Queue is empty")
-    return {"ok": True, "action": "play_next", "now_playing": handoff.get("now_playing")}
+    return {"ok": True, "action": "play_next", "now_playing": _annotate_upload_item(handoff.get("now_playing"))}
 
 
 @router.post("/playback/toggle")

--- a/app/relaytv_app/routes/queue.py
+++ b/app/relaytv_app/routes/queue.py
@@ -136,6 +136,43 @@ def history_clear():
     return {"status": "cleared"}
 
 
+@router.post("/history/requeue")
+def history_requeue(req: HistoryPlayReq):
+    """Queue an item from history by index using the server-stored URL.
+
+    Public history payloads carry display-safe URLs with credentials
+    stripped, so clients requeue by index and the server rebuilds the
+    item from its unredacted copy.
+    """
+    idx = int(req.index)
+    with state.HISTORY_LOCK:
+        if idx < 0 or idx >= len(state.HISTORY):
+            raise HTTPException(status_code=400, detail="index out of range")
+        it = dict(state.HISTORY[idx])
+    url = it.get("url")
+    if not isinstance(url, str) or not url.strip():
+        raise HTTPException(status_code=400, detail="history item missing url")
+
+    item = _smart_item_from_url(url.strip(), lightweight=True)
+    if isinstance(item, dict):
+        for key in ("title", "thumbnail", "thumbnail_local", "history_id"):
+            val = it.get(key)
+            if val and not item.get(key):
+                item[key] = val
+    qlen, queue_snapshot = playback_service.queue_item(item)
+    try:
+        _push_queue_added_toast_async(item, str(it.get("title") or url or "item"))
+    except Exception:
+        pass
+    _ui_event_push_queue("add", queue=queue_snapshot, queue_length=qlen, source="history_requeue")
+    return {
+        "status": "queued",
+        "item": _annotate_upload_item(item),
+        "queue_length": qlen,
+        "now_playing": _annotate_upload_item(state.NOW_PLAYING),
+    }
+
+
 @router.post("/history/play")
 def history_play(req: HistoryPlayReq):
     """Play an item from history by index while preserving current playback."""

--- a/app/relaytv_app/routes/queue.py
+++ b/app/relaytv_app/routes/queue.py
@@ -4,7 +4,7 @@ import time
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from .. import player, playback_service, state, upload_store
+from .. import player, playback_service, public_media, state, upload_store
 from ..debug import get_logger
 
 
@@ -59,7 +59,7 @@ def _play_now_from_history(payload: dict[str, object]) -> dict:
 
 
 def _annotate_upload_item(item: object) -> object:
-    return upload_store.annotate_item(item)
+    return public_media.public_media_item(upload_store.annotate_item(item))
 
 
 def _annotate_upload_items(items: list[object] | None) -> list[object]:

--- a/app/relaytv_app/routes/queue.py
+++ b/app/relaytv_app/routes/queue.py
@@ -84,7 +84,12 @@ def enqueue(req: EnqueueReq):
     except Exception:
         pass
     _ui_event_push_queue("add", queue=queue_snapshot, queue_length=qlen, source="enqueue")
-    return {"status": "queued", "item": item, "queue_length": qlen, "now_playing": state.NOW_PLAYING}
+    return {
+        "status": "queued",
+        "item": _annotate_upload_item(item),
+        "queue_length": qlen,
+        "now_playing": _annotate_upload_item(state.NOW_PLAYING),
+    }
 
 
 @router.post("/clear")
@@ -189,7 +194,12 @@ def queue_remove(req: QueueRemoveReq):
         pass
     _ui_event_push_queue("remove", queue=snapshot["queue"], queue_length=len(snapshot["queue"]), source="queue_remove")
 
-    return {"status": "removed", "removed": removed, "queue": snapshot["queue"], "queue_length": len(snapshot["queue"])}
+    return {
+        "status": "removed",
+        "removed": _annotate_upload_item(removed),
+        "queue": _annotate_upload_items(snapshot["queue"]),
+        "queue_length": len(snapshot["queue"]),
+    }
 
 
 def _queue_item_dedupe_key(item: object) -> tuple[str, str]:
@@ -245,7 +255,7 @@ def queue_dedupe():
         "changed": changed,
         "removed_count": removed,
         "queue_length": len(state.QUEUE),
-        "queue": list(state.QUEUE),
+        "queue": _annotate_upload_items(state.QUEUE),
     }
 
 
@@ -273,4 +283,4 @@ def queue_move(req: QueueMoveReq):
         pass
     _ui_event_push_queue("move", queue=snapshot["queue"], queue_length=len(snapshot["queue"]), source="queue_move")
 
-    return {"status": "moved", "queue": snapshot["queue"], "queue_length": len(snapshot["queue"])}
+    return {"status": "moved", "queue": _annotate_upload_items(snapshot["queue"]), "queue_length": len(snapshot["queue"])}

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -1627,8 +1627,9 @@ async function renderHistory(){
     queue.disabled = !available;
     queue.onclick = async () => {
       if (!available) return;
-      if (!it.url) return;
-      await fetch('/enqueue', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({url: it.url})});
+      // Requeue by index so the server uses its stored (unredacted) URL —
+      // the url in this payload is display-safe and may lack credentials.
+      await fetch('/history/requeue', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({index: idx})});
       await refresh();
     };
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -342,6 +342,11 @@ History endpoints:
 - `GET /history`
 - `POST /history/play`
   - body: `{"index": int}`
+- `POST /history/requeue`
+  - body: `{"index": int}`
+  - queues the item using the server-stored URL; use this instead of
+    `POST /enqueue` with a history payload URL, since public history
+    URLs are display-safe copies with credentials stripped
 - `POST /history/clear`
 
 ## Notifications and overlay delivery

--- a/docs/API.md
+++ b/docs/API.md
@@ -51,6 +51,11 @@ With the token enabled:
 
 Unset or blank `RELAYTV_API_TOKEN` restores the fully open behavior.
 
+Clients can validate write credentials without changing server state by
+calling `POST /auth/check`. A successful response is
+`{"ok": true, "token_required": true|false}`; an incorrect or missing token on
+a protected server receives the same `401` response as other writes.
+
 The token protects control actions; it is not transport security. For
 exposure beyond the trusted LAN, terminate TLS and (optionally) an extra
 auth layer at a reverse proxy. Example with Caddy:

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -113,6 +113,27 @@ def test_write_with_correct_token_accepted(monkeypatch) -> None:
     assert response.json() == {"status": "cleared"}
 
 
+def test_auth_check_validates_without_mutating_state(monkeypatch) -> None:
+    _enable_token(monkeypatch)
+    client = _client()
+
+    assert client.post("/auth/check").status_code == 401
+    accepted = client.post("/auth/check", headers={"Authorization": f"Bearer {TOKEN}"})
+
+    assert accepted.status_code == 200
+    assert accepted.json() == {"ok": True, "token_required": True}
+
+
+def test_auth_check_reports_unprotected_server(monkeypatch) -> None:
+    monkeypatch.delenv("RELAYTV_API_TOKEN", raising=False)
+    runtime_config.refresh_from_env()
+
+    response = _client().post("/auth/check")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "token_required": False}
+
+
 # --- token on: reads stay open -------------------------------------------------
 
 

--- a/tests/test_public_media.py
+++ b/tests/test_public_media.py
@@ -23,6 +23,17 @@ def test_sanitize_public_url_removes_credentials_and_signature() -> None:
     assert "signed" not in result
 
 
+def test_sanitize_public_url_strips_emby_jellyfin_and_jwt_auth_keys() -> None:
+    url = (
+        "https://media.example/Videos/abc/stream"
+        "?static=true&X-Emby-Token=secret&X-Jellyfin-Token=secret&jwt=secret&auth=secret&exp=123"
+    )
+
+    result = sanitize_public_url(url)
+
+    assert result == "https://media.example/Videos/abc/stream?static=true"
+
+
 def test_sanitize_public_url_preserves_ipv6_hosts() -> None:
     url = "http://[fd00::a1]:8096/Videos/abc/stream?api_key=secret&static=true"
 
@@ -127,6 +138,38 @@ def test_queue_remove_response_redacts_items_without_mutating_state(monkeypatch)
     assert body["queue"] == [_SAFE_ITEM]
     assert "secret" not in json.dumps(body)
     assert routes.state.QUEUE[0]["_resolved_stream"].endswith("token=secret")
+
+
+def test_history_requeue_uses_server_stored_url(monkeypatch) -> None:
+    monkeypatch.setattr(routes.state, "QUEUE", [], raising=False)
+    monkeypatch.setattr(routes.state, "HISTORY", [_secret_item()], raising=False)
+    monkeypatch.setattr(routes.state, "NOW_PLAYING", None, raising=False)
+    monkeypatch.setattr(routes.state, "persist_queue", lambda: None)
+    monkeypatch.setattr(routes.state, "persist_queue_payload", lambda payload: None)
+    rebuilt_from: dict[str, str] = {}
+
+    def _fake_smart_item(url, **kwargs):
+        rebuilt_from["url"] = str(url)
+        return {"url": str(url)}
+
+    monkeypatch.setattr(routes, "_smart_item_from_url", _fake_smart_item)
+    monkeypatch.setattr(routes.player, "prefetch_queue_item_stream", lambda item: None)
+    monkeypatch.setattr(routes.player, "prime_mpv_up_next_from_queue", lambda force=True: None)
+    monkeypatch.setattr(routes, "_push_queue_added_toast_async", lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, "_ui_event_push_queue", lambda action, **payload: None)
+    client = TestClient(create_app(testing=True))
+
+    response = client.post("/history/requeue", json={"index": 0})
+
+    assert response.status_code == 200
+    assert rebuilt_from["url"] == _secret_item()["url"]
+    assert routes.state.QUEUE[0]["url"] == _secret_item()["url"]
+    body = response.json()
+    assert body["status"] == "queued"
+    assert body["item"] == {"title": "Movie", "url": _SAFE_ITEM["url"]}
+    assert "secret" not in json.dumps(body)
+
+    assert client.post("/history/requeue", json={"index": 5}).status_code == 400
 
 
 def test_play_response_redacts_now_playing(monkeypatch) -> None:

--- a/tests/test_public_media.py
+++ b/tests/test_public_media.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-only
+import json
+
+from fastapi.testclient import TestClient
+
 from relaytv_app.public_media import public_media_item, sanitize_public_url
 from relaytv_app import routes
+from relaytv_app.main import create_app
 
 
 def test_sanitize_public_url_removes_credentials_and_signature() -> None:
@@ -16,6 +21,14 @@ def test_sanitize_public_url_removes_credentials_and_signature() -> None:
     assert "secret" not in result
     assert "password" not in result
     assert "signed" not in result
+
+
+def test_sanitize_public_url_preserves_ipv6_hosts() -> None:
+    url = "http://[fd00::a1]:8096/Videos/abc/stream?api_key=secret&static=true"
+
+    result = sanitize_public_url(url)
+
+    assert result == "http://[fd00::a1]:8096/Videos/abc/stream?static=true"
 
 
 def test_public_media_item_prefers_safe_source_and_drops_private_runtime_fields() -> None:
@@ -62,3 +75,67 @@ def test_status_payload_redacts_runtime_media_without_mutating_state(monkeypatch
     assert payload["queue"] == [payload["now_playing"]]
     assert item["url"].endswith("api_key=secret&static=true")
     assert item["_resolved_stream"].endswith("token=secret")
+
+
+def _secret_item() -> dict:
+    return {
+        "title": "Movie",
+        "url": "https://media.example/Videos/123/stream?api_key=secret&static=true",
+        "_resolved_stream": "https://cdn.example/video?token=secret",
+    }
+
+
+_SAFE_ITEM = {
+    "title": "Movie",
+    "url": "https://media.example/Videos/123/stream?static=true",
+}
+
+
+def test_enqueue_response_redacts_item_and_now_playing(monkeypatch) -> None:
+    monkeypatch.setattr(routes.state, "QUEUE", [], raising=False)
+    monkeypatch.setattr(routes.state, "NOW_PLAYING", _secret_item(), raising=False)
+    monkeypatch.setattr(routes.state, "persist_queue", lambda: None)
+    monkeypatch.setattr(routes.state, "persist_queue_payload", lambda payload: None)
+    monkeypatch.setattr(routes, "_smart_item_from_url", lambda url, **kwargs: _secret_item())
+    monkeypatch.setattr(routes.player, "prefetch_queue_item_stream", lambda item: None)
+    monkeypatch.setattr(routes.player, "prime_mpv_up_next_from_queue", lambda force=True: None)
+    monkeypatch.setattr(routes, "_push_queue_added_toast_async", lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, "_ui_event_push_queue", lambda action, **payload: None)
+    client = TestClient(create_app(testing=True))
+
+    response = client.post("/enqueue", json={"url": "https://media.example/watch"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["item"] == _SAFE_ITEM
+    assert body["now_playing"] == _SAFE_ITEM
+    assert "secret" not in json.dumps(body)
+
+
+def test_queue_remove_response_redacts_items_without_mutating_state(monkeypatch) -> None:
+    monkeypatch.setattr(routes.state, "QUEUE", [_secret_item(), _secret_item()], raising=False)
+    monkeypatch.setattr(routes.state, "persist_queue_payload", lambda payload: None)
+    monkeypatch.setattr(routes.player, "prime_mpv_up_next_from_queue", lambda force=True: None)
+    monkeypatch.setattr(routes, "_ui_event_push_queue", lambda action, **payload: None)
+    client = TestClient(create_app(testing=True))
+
+    response = client.post("/queue/remove", json={"index": 0})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["removed"] == _SAFE_ITEM
+    assert body["queue"] == [_SAFE_ITEM]
+    assert "secret" not in json.dumps(body)
+    assert routes.state.QUEUE[0]["_resolved_stream"].endswith("token=secret")
+
+
+def test_play_response_redacts_now_playing(monkeypatch) -> None:
+    monkeypatch.setattr(routes, "_smart_item_from_url", lambda url, **kwargs: {"url": str(url)})
+    monkeypatch.setattr(routes.playback_service, "suppress_auto_next", lambda sec: None)
+    monkeypatch.setattr(routes.playback_service, "play_now", lambda *args, **kwargs: _secret_item())
+    client = TestClient(create_app(testing=True))
+
+    response = client.post("/play", json={"url": "https://media.example/watch"})
+
+    assert response.status_code == 200
+    assert response.json()["now_playing"] == _SAFE_ITEM

--- a/tests/test_public_media.py
+++ b/tests/test_public_media.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: GPL-3.0-only
+from relaytv_app.public_media import public_media_item, sanitize_public_url
+from relaytv_app import routes
+
+
+def test_sanitize_public_url_removes_credentials_and_signature() -> None:
+    url = (
+        "http://user:password@media.example/Videos/abc/stream"
+        "?static=true&mediaSourceId=abc&api_key=secret&X-Amz-Signature=signed"
+        "#private-fragment"
+    )
+
+    result = sanitize_public_url(url)
+
+    assert result == "http://media.example/Videos/abc/stream?static=true&mediaSourceId=abc"
+    assert "secret" not in result
+    assert "password" not in result
+    assert "signed" not in result
+
+
+def test_public_media_item_prefers_safe_source_and_drops_private_runtime_fields() -> None:
+    item = {
+        "title": "Movie",
+        "url": "https://media.example/direct.m3u8?token=secret",
+        "_resolved_source_url": "https://media.example/watch/123?api_key=secret&lang=en",
+        "_resolved_stream": "https://cdn.example/video?Policy=secret",
+        "stream": "https://cdn.example/video?token=secret",
+        "audio": "https://cdn.example/audio?token=secret",
+        "headers": {"Authorization": "Bearer secret"},
+        "thumbnail": "https://media.example/image/123?api_key=secret&width=400",
+        "resume_pos": 42.5,
+    }
+
+    result = public_media_item(item)
+
+    assert result == {
+        "title": "Movie",
+        "url": "https://media.example/watch/123?lang=en",
+        "thumbnail": "https://media.example/image/123?width=400",
+        "resume_pos": 42.5,
+    }
+    assert item["_resolved_stream"] == "https://cdn.example/video?Policy=secret"
+
+
+def test_status_payload_redacts_runtime_media_without_mutating_state(monkeypatch) -> None:
+    item = {
+        "title": "Movie",
+        "url": "https://media.example/Videos/123/stream?api_key=secret&static=true",
+        "_resolved_stream": "https://cdn.example/video?token=secret",
+    }
+    monkeypatch.setattr(routes.state, "NOW_PLAYING", item, raising=False)
+    monkeypatch.setattr(routes.state, "QUEUE", [dict(item)], raising=False)
+    monkeypatch.setattr(routes.state, "SESSION_STATE", "closed", raising=False)
+    monkeypatch.setattr(routes.player, "is_playing", lambda: False)
+
+    payload = routes._status_payload()
+
+    assert payload["now_playing"] == {
+        "title": "Movie",
+        "url": "https://media.example/Videos/123/stream?static=true",
+    }
+    assert payload["queue"] == [payload["now_playing"]]
+    assert item["url"].endswith("api_key=secret&static=true")
+    assert item["_resolved_stream"].endswith("token=secret")

--- a/tests/test_route_inventory.py
+++ b/tests/test_route_inventory.py
@@ -11,6 +11,7 @@ EXPECTED_ROUTES = {
     ("GET", "/assets/banner.png", "relaytv_banner_png_asset"),
     ("GET", "/assets/banner.svg", "relaytv_banner_svg_asset"),
     ("GET", "/assets/logo.svg", "relaytv_logo_svg_asset"),
+    ("POST", "/auth/check", "auth_check"),
     ("POST", "/clear", "clear"),
     ("POST", "/close", "close"),
     ("GET", "/devices", "get_devices"),

--- a/tests/test_route_inventory.py
+++ b/tests/test_route_inventory.py
@@ -22,6 +22,7 @@ EXPECTED_ROUTES = {
     ("GET", "/history", "history"),
     ("POST", "/history/clear", "history_clear"),
     ("POST", "/history/play", "history_play"),
+    ("POST", "/history/requeue", "history_requeue"),
     ("GET", "/idle", "idle_page"),
     ("GET", "/idle/weather", "get_idle_weather"),
     ("POST", "/ingest/media", "ingest_media"),

--- a/tests/test_thumbnail_cors.py
+++ b/tests/test_thumbnail_cors.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Tests for thumbnails embedded by cross-origin Home Assistant pages."""
+
+from fastapi.testclient import TestClient
+
+from relaytv_app.main import create_app
+from relaytv_app.routes import assets
+
+
+def test_thumbnail_allows_cross_origin_image_processing(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(assets, "THUMB_DIR", str(tmp_path))
+    (tmp_path / "sample.jpg").write_bytes(b"jpeg-test")
+    client = TestClient(create_app(testing=True))
+
+    response = client.get("/thumbs/sample.jpg", headers={"Origin": "http://homeassistant.local:8123"})
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "*"
+    assert response.headers["cross-origin-resource-policy"] == "cross-origin"
+    assert response.headers["cache-control"] == "public, max-age=86400"


### PR DESCRIPTION
## What changed

- Redact private playback URLs, headers, and runtime-only media fields from public status, SSE, queue, and history payloads.
- Redact media items in write-endpoint responses too (`/enqueue`, `/queue/remove`, `/queue/move`, `/queue/dedupe`, `/play`, `/play_now`, `/next`, `/smart`, and the pause/resume family), which previously returned raw state items.
- Strip all recognized auth query parameters, including `auth`, `exp`, `jwt`, `X-Emby-Token`, and `X-Jellyfin-Token` (matching the volatile-key set in `player.py`).
- Preserve IPv6 literal hosts when sanitizing URLs (brackets were dropped, corrupting the netloc).
- Add `POST /history/requeue` and switch the web UI's history Queue button to it, so requeues use the server-stored URL instead of round-tripping the display-safe public URL.
- Add `POST /auth/check` so clients can validate optional bearer credentials without changing playback state.
- Allow cross-origin use of cached thumbnails by Home Assistant.
- Add regression coverage for public serialization, write-response redaction, history requeue, authentication validation, route inventory, and thumbnail headers.

## Why

RelayTV could expose resolved media stream URLs containing upstream credentials through public API payloads. The Home Assistant integration also needed a safe way to verify write credentials, and HA thumbnail color processing was blocked by browser CORS enforcement.

## Impact

Public API consumers receive credential-free media metadata while internal playback state remains unchanged. Protected and unprotected clients can validate configuration safely, and Home Assistant can render and process RelayTV thumbnails.

## Validation

- `PYTHONPATH=app pytest -q` — 421 passed
- `ruff check app tests`
- `node --check app/relaytv_app/static/ui/app.js`
- Branch rebased on RelayTV `main` / v0.7.0
