### PR TITLE
feat: appear as a Jellyfin cast target

### DIFF
--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import contextlib
+from dataclasses import dataclass
 import os
 import threading
 from ..config import env_bool as _env_bool
@@ -34,6 +35,35 @@ _TRANSACTION = threading.RLock()
 # outgoing server takes seconds, and landing late would pin the new server's
 # address to the old server's identity.
 _CONFIG_GENERATION = 0
+
+
+@dataclass(frozen=True, repr=False)
+class _RequestContext:
+    """One secret-bearing, point-in-time view used by a network operation.
+
+    ``repr`` is deliberately disabled: authentication material must not leak if
+    a caller logs an exception or a local while debugging a failed request.
+    """
+
+    generation: int
+    enabled: bool
+    running: bool
+    server_url: str
+    device_id: str
+    device_name: str
+    client_name: str
+    client_version: str
+    username: str
+    password: str
+    token: str
+    catalog_user_id: str
+    authenticated: bool
+    connected: bool
+    last_register_ok: bool | None
+    register_retry_failures: int
+    next_register_retry_ts: float
+    last_detect_ok: bool | None
+    last_detect_ts: float | None
 
 _STATUS: dict[str, object] = {
     "enabled": False,
@@ -350,6 +380,11 @@ def _effective_catalog_user(st: dict[str, object]) -> tuple[str, str]:
 
 
 def start() -> None:
+    with _control_socket_suspended():
+        _start_locked()
+
+
+def _start_locked() -> None:
     """Initialize Jellyfin receiver runtime state (network wiring added later)."""
     global _API_KEY, _AUTH_USERNAME, _AUTH_PASSWORD, _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
     cfg = _read_config()
@@ -600,21 +635,25 @@ def _persist_server_type(server_type: str, product_name: str = "", *, generation
             _STATUS["server_product_name"] = ""
 
     gen = config_generation() if generation is None else int(generation)
-    if not _publish(gen, _apply):
-        return
-    if not changed:
-        return
-    try:
-        runtime_config.set_value("RELAYTV_JELLYFIN_SERVER_TYPE", st)
-    except Exception:
-        pass
-    try:
-        from .. import state as _state
+    # Status and durable settings are one short commit. A configuration
+    # transaction must not land between them and let a retired detection result
+    # persist after its in-memory write was accepted.
+    with _TRANSACTION:
+        if not _publish(gen, _apply):
+            return
+        if not changed:
+            return
+        try:
+            runtime_config.set_value("RELAYTV_JELLYFIN_SERVER_TYPE", st)
+        except Exception:
+            pass
+        try:
+            from .. import state as _state
 
-        if hasattr(_state, "update_settings"):
-            _state.update_settings({"jellyfin_server_type": st})
-    except Exception:
-        pass
+            if hasattr(_state, "update_settings"):
+                _state.update_settings({"jellyfin_server_type": st})
+        except Exception:
+            pass
 
 
 def set_server_type(server_type: str) -> dict[str, object]:
@@ -622,7 +661,8 @@ def set_server_type(server_type: str) -> dict[str, object]:
     st = str(server_type or "").strip().lower()
     if st not in ("jellyfin", "emby"):
         raise ValueError("server_type must be jellyfin or emby")
-    _persist_server_type(st)
+    with _configuration_transaction(suspend_socket=False):
+        _persist_server_type(st, generation=config_generation())
     return status()
 
 
@@ -643,26 +683,32 @@ def _config_generation_current(generation: int) -> bool:
         return int(_CONFIG_GENERATION) == int(generation)
 
 
-def config_snapshot() -> dict[str, object]:
-    """Everything network work needs, plus the generation, captured together.
-
-    Reading the URL and then capturing the generation separately is a race in
-    itself: settings can change in between, leaving work that dialled the old
-    server holding a generation that says it is current.
-    """
+def _request_context() -> _RequestContext:
+    """Capture every input for one network operation under one lock."""
     with _LOCK:
-        return {
-            "generation": int(_CONFIG_GENERATION),
-            "enabled": bool(_STATUS.get("enabled")),
-            "running": bool(_STATUS.get("running")),
-            "server_url": str(_STATUS.get("server_url") or "").strip().rstrip("/"),
-            "device_id": str(_STATUS.get("device_id") or "").strip(),
-            "device_name": str(_STATUS.get("device_name") or "RelayTV"),
-            "client_name": str(_STATUS.get("client_name") or "RelayTV"),
-            "client_version": str(_STATUS.get("client_version") or "1.0"),
-            "username": str(_AUTH_USERNAME or ""),
-            "password": str(_AUTH_PASSWORD or ""),
-        }
+        detect_ts = _STATUS.get("last_detect_ts")
+        catalog_user_id, _catalog_user_source = _effective_catalog_user(_STATUS)
+        return _RequestContext(
+            generation=int(_CONFIG_GENERATION),
+            enabled=bool(_STATUS.get("enabled")),
+            running=bool(_STATUS.get("running")),
+            server_url=str(_STATUS.get("server_url") or "").strip().rstrip("/"),
+            device_id=str(_STATUS.get("device_id") or "").strip(),
+            device_name=str(_STATUS.get("device_name") or "RelayTV"),
+            client_name=str(_STATUS.get("client_name") or "RelayTV"),
+            client_version=str(_STATUS.get("client_version") or "1.0"),
+            username=str(_AUTH_USERNAME or ""),
+            password=str(_AUTH_PASSWORD or ""),
+            token=str(_ACCESS_TOKEN or _API_KEY or ""),
+            catalog_user_id=catalog_user_id,
+            authenticated=bool(_STATUS.get("authenticated")),
+            connected=bool(_STATUS.get("connected")),
+            last_register_ok=_STATUS.get("last_register_ok") if isinstance(_STATUS.get("last_register_ok"), bool) else None,
+            register_retry_failures=int(_REGISTER_RETRY_FAILURES or 0),
+            next_register_retry_ts=float(_NEXT_REGISTER_RETRY_TS or 0.0),
+            last_detect_ok=_STATUS.get("last_detect_ok") if isinstance(_STATUS.get("last_detect_ok"), bool) else None,
+            last_detect_ts=float(detect_ts) if isinstance(detect_ts, (int, float)) else None,
+        )
 
 
 def _publish(generation: int, apply) -> bool:
@@ -696,15 +742,16 @@ def _run_detection(server_url: str, *, generation: int | None = None) -> dict[st
         _STATUS["last_detect_ok"] = bool(result.get("ok"))
         _STATUS["last_detect_error"] = result.get("error")
 
-    if not _publish(gen, _apply):
-        logger.info("jellyfin_detect_discarded reason=config_changed")
-        return {"ok": False, "reason": "config_changed"}
-    if result.get("ok"):
-        _persist_server_type(
-            str(result.get("server_type") or ""),
-            str(result.get("product_name") or ""),
-            generation=gen,
-        )
+    with _TRANSACTION:
+        if not _publish(gen, _apply):
+            logger.info("jellyfin_detect_discarded reason=config_changed")
+            return {"ok": False, "reason": "config_changed"}
+        if result.get("ok"):
+            _persist_server_type(
+                str(result.get("server_type") or ""),
+                str(result.get("product_name") or ""),
+                generation=gen,
+            )
     return result
 
 
@@ -715,21 +762,18 @@ def _maybe_retry_detection() -> None:
     and at most every 300s, so an endpoint hidden by a proxy doesn't get
     hammered on every heartbeat.
     """
-    st = status()
-    if st.get("last_detect_ok") is True:
+    context = _request_context()
+    if not context.enabled or not context.running:
         return
-    if not (bool(st.get("authenticated")) or bool(st.get("last_register_ok"))):
+    if context.last_detect_ok is True:
         return
-    last_ts = st.get("last_detect_ts")
-    if last_ts and (time.time() - float(last_ts)) < 300.0:
+    if not (context.authenticated or context.last_register_ok is True):
         return
-    # URL and generation come from the same snapshot, so the probe can never
-    # hold a generation that belongs to a different server.
-    snapshot = config_snapshot()
-    base = str(snapshot.get("server_url") or "").strip()
-    if not base:
+    if context.last_detect_ts and (time.time() - context.last_detect_ts) < 300.0:
         return
-    _run_detection(base, generation=int(snapshot["generation"]))
+    if not context.server_url:
+        return
+    _run_detection(context.server_url, generation=context.generation)
 
 
 def connect(*, server_url: str, api_key: str | None = None, device_name: str | None = None, heartbeat_sec: int | None = None) -> dict[str, object]:
@@ -978,12 +1022,12 @@ def _build_emby_headers(*, token: str = "") -> dict[str, str]:
 
 def get_item_metadata(item_id: str, *, token_override: str = "", server_url_override: str = "") -> dict[str, object]:
     iid = str(item_id or "").strip()
-    st = status()
-    base = str(server_url_override or st.get("server_url") or "").strip().rstrip("/")
+    context = _request_context()
+    base = str(server_url_override or context.server_url or "").strip().rstrip("/")
     if not iid or not base:
         return {}
-    token = str(token_override or _active_token() or "").strip()
-    user_id = str(st.get("catalog_user_id") or st.get("auth_user_id") or "").strip()
+    token = str(token_override or context.token or "").strip()
+    user_id = context.catalog_user_id
     token_key = hashlib.sha1(token.encode("utf-8", "ignore")).hexdigest()[:12] if token else "-"
     cache_key = f"meta:{base}:{user_id}:{iid}:{token_key}"
     cached = _catalog_cache_get(cache_key)
@@ -991,10 +1035,10 @@ def get_item_metadata(item_id: str, *, token_override: str = "", server_url_over
         _mark_catalog_ok()
         return _attach_thumb(dict(cached))
 
-    client_name = str(st.get("client_name") or "RelayTV")
-    device_name = str(st.get("device_name") or "RelayTV")
-    device_id = str(st.get("device_id") or "relaytv")
-    client_version = str(st.get("client_version") or "1.0")
+    client_name = context.client_name
+    device_name = context.device_name
+    device_id = context.device_id or "relaytv"
+    client_version = context.client_version
 
     def _headers() -> dict[str, str]:
         out: dict[str, str] = {}
@@ -1397,11 +1441,8 @@ def _extract_total_count(payload: object, default_count: int = 0) -> int:
 
 
 def _catalog_base_token_user() -> tuple[str, str, str]:
-    st = status()
-    base = str(st.get("server_url") or "").strip().rstrip("/")
-    token = _active_token()
-    user_id = str(st.get("catalog_user_id") or st.get("auth_user_id") or "").strip()
-    return base, token, user_id
+    context = _request_context()
+    return context.server_url, context.token, context.catalog_user_id
 
 
 def get_item_detail(item_id: str, *, refresh: bool = False) -> dict[str, object]:
@@ -2553,61 +2594,83 @@ def command_sink_registered() -> bool:
     return _COMMAND_SINK is not None
 
 
-def _build_url(path: str) -> str:
-    st = status()
-    base = str(st.get("server_url") or "").strip().rstrip("/")
-    p = (path or "").strip()
-    if not p:
-        return base
+def _context_url(context: _RequestContext, path: str) -> str:
+    """Build a URL without consulting mutable receiver state."""
+    p = str(path or "").strip()
     if p.startswith("http://") or p.startswith("https://"):
         return p
-    if not base:
+    if not p:
+        return context.server_url
+    if not context.server_url:
         return p
     if not p.startswith("/"):
         p = f"/{p}"
-    return f"{base}{p}"
+    return f"{context.server_url}{p}"
 
 
-def _post_json(url: str, payload: dict, *, timeout: float = 3.0) -> None:
+def _context_headers(context: _RequestContext) -> dict[str, str]:
+    """Authentication headers derived entirely from one request context."""
+    token = context.token.strip()
+    out: dict[str, str] = {}
+    if token:
+        out["X-Emby-Token"] = token
+        out["Authorization"] = f'MediaBrowser Token="{token}"'
+    auth = (
+        f'MediaBrowser Client="{context.client_name}", '
+        f'Device="{context.device_name}", '
+        f'DeviceId="{context.device_id or "relaytv"}", '
+        f'Version="{context.client_version}"'
+    )
+    if token:
+        auth = f'{auth}, Token="{token}"'
+    out["X-Emby-Authorization"] = auth
+    return out
+
+
+def _post_json_for(
+    context: _RequestContext,
+    path: str,
+    payload: dict,
+    *,
+    timeout: float = 3.0,
+) -> str:
+    """POST JSON using only values captured with ``context.generation``."""
+    url = _context_url(context, path)
     body = json.dumps(payload).encode("utf-8")
     req = _urlrequest.Request(url, data=body, method="POST")
     req.add_header("Content-Type", "application/json")
-    st = status()
-    token = _active_token()
-    if token:
-        req.add_header("X-Emby-Token", token)
-        req.add_header("Authorization", f'MediaBrowser Token="{token}"')
-    auth = (
-        f'MediaBrowser Client="{st.get("client_name")}", '
-        f'Device="{st.get("device_name")}", '
-        f'DeviceId="{st.get("device_id")}", '
-        f'Version="{st.get("client_version")}"'
-    )
-    if token:
-        auth = f'{auth}, Token="{token}"'
-    req.add_header("X-Emby-Authorization", auth)
+    for key, value in _context_headers(context).items():
+        req.add_header(key, value)
     with _urlrequest.urlopen(req, timeout=timeout):
-        return
+        pass
+    return url
 
 
-def _post_no_body(url: str, *, timeout: float = 3.0) -> None:
+def _post_no_body_for(context: _RequestContext, path: str, *, timeout: float = 3.0) -> str:
+    """POST an empty body using only values from one request context."""
+    url = _context_url(context, path)
     req = _urlrequest.Request(url, data=b"", method="POST")
-    st = status()
-    token = _active_token()
-    if token:
-        req.add_header("X-Emby-Token", token)
-        req.add_header("Authorization", f'MediaBrowser Token="{token}"')
-    auth = (
-        f'MediaBrowser Client="{st.get("client_name")}", '
-        f'Device="{st.get("device_name")}", '
-        f'DeviceId="{st.get("device_id")}", '
-        f'Version="{st.get("client_version")}"'
-    )
-    if token:
-        auth = f'{auth}, Token="{token}"'
-    req.add_header("X-Emby-Authorization", auth)
+    for key, value in _context_headers(context).items():
+        req.add_header(key, value)
     with _urlrequest.urlopen(req, timeout=timeout):
-        return
+        pass
+    return url
+
+
+def _get_json_for(context: _RequestContext, path: str, *, timeout: float = 5.0) -> object:
+    """GET JSON using only values from one request context."""
+    url = _context_url(context, path)
+    req = _urlrequest.Request(url, method="GET")
+    for key, value in _context_headers(context).items():
+        req.add_header(key, value)
+    with _urlrequest.urlopen(req, timeout=timeout) as resp:
+        raw = (resp.read() or b"{}").decode("utf-8", "ignore")
+    if not raw.strip():
+        return {}
+    try:
+        return json.loads(raw)
+    except Exception:
+        return {}
 
 
 def _sanitize_error_text(msg: object) -> str:
@@ -2639,24 +2702,20 @@ def _format_http_error(exc: Exception) -> str:
     return _sanitize_error_text(str(exc))
 
 
-def authenticate_once() -> dict[str, object]:
-    st = status()
-    if not bool(st.get("enabled")) or not bool(st.get("running")):
+def authenticate_once(*, _context: _RequestContext | None = None) -> dict[str, object]:
+    context = _context or _request_context()
+    if not context.enabled or not context.running:
         return {"ok": False, "reason": "disabled"}
-    # Inputs and generation in one capture: reading the URL first and stamping
-    # the generation afterwards lets settings change in between, leaving this
-    # request dialling the old server while claiming to be current.
-    snapshot = config_snapshot()
-    generation = int(snapshot["generation"])
-    base = str(snapshot["server_url"])
+    generation = context.generation
+    base = context.server_url
     if not base:
         return {"ok": False, "reason": "no_server_url"}
-    username = str(snapshot["username"])
-    password = str(snapshot["password"])
-    device_name = str(snapshot["device_name"])
-    device_id = str(snapshot["device_id"]) or "relaytv"
-    client_name = str(snapshot["client_name"])
-    client_version = str(snapshot["client_version"])
+    username = context.username
+    password = context.password
+    device_name = context.device_name
+    device_id = context.device_id or "relaytv"
+    client_name = context.client_name
+    client_version = context.client_version
     if not username or not password:
         return {"ok": False, "reason": "no_credentials"}
 
@@ -2780,13 +2839,31 @@ def read_session_capabilities(device_id: str = "", *, timeout: float = 3.0) -> d
     whether or not the body bound to anything. Only the session readback tells
     us media control is really advertised, so registration asserts on this.
     """
-    did = str(device_id or status().get("device_id") or "").strip()
+    context = _request_context()
+    return _read_session_capabilities_for(
+        context,
+        device_id=str(device_id or context.device_id or "").strip(),
+        timeout=timeout,
+    )
+
+
+def _read_session_capabilities_for(
+    context: _RequestContext,
+    *,
+    device_id: str,
+    timeout: float,
+) -> dict[str, object]:
+    """Read back capabilities from the same server/session just registered."""
+    did = str(device_id or "").strip()
     if not did:
         return {}
-    url = _build_url(f"/Sessions?deviceId={_urlparse.quote(did)}")
-    if not url:
+    if not context.server_url:
         return {}
-    rows = _get_json(url, timeout=timeout, token=_active_token())
+    rows = _get_json_for(
+        context,
+        f"/Sessions?deviceId={_urlparse.quote(did)}",
+        timeout=timeout,
+    )
     if not isinstance(rows, list):
         return {}
     for row in rows:
@@ -2795,34 +2872,33 @@ def read_session_capabilities(device_id: str = "", *, timeout: float = 3.0) -> d
     return {}
 
 
-def register_receiver_once() -> dict[str, object]:
-    st = status()
-    if not bool(st.get("enabled")) or not bool(st.get("running")):
+def register_receiver_once(*, _context: _RequestContext | None = None) -> dict[str, object]:
+    context = _context or _request_context()
+    if not context.enabled or not context.running:
         return {"ok": False, "reason": "disabled"}
-    base = str(st.get("server_url") or "").strip().rstrip("/")
-    if not base:
+    if not context.server_url:
         return {"ok": False, "reason": "no_server_url"}
-    snapshot = config_snapshot()
-    did = str(snapshot["device_id"])
+    did = context.device_id
     payload = capabilities_payload()
     # The query-string form is what older Emby builds accept; it stays as a
     # fallback so an Emby server that rejects the DTO body still registers.
     candidates: list[tuple[str, str, dict | None]] = [
-        ("full", f"{base}/Sessions/Capabilities/Full", payload),
-        ("caps_query", f"{base}/Sessions/Capabilities?{_capabilities_query(did)}", None),
+        ("full", "/Sessions/Capabilities/Full", payload),
+        ("caps_query", f"/Sessions/Capabilities?{_capabilities_query(did)}", None),
     ]
     timeout = float(os.getenv("RELAYTV_JELLYFIN_REGISTER_TIMEOUT_SEC", "3"))
-    generation = int(snapshot["generation"])
+    generation = context.generation
     last_err = "register_failed"
     last_name = ""
     last_url = ""
     try:
-        for name, url, body in candidates:
+        for name, path, body in candidates:
+            url = _context_url(context, path)
             try:
                 if body is None:
-                    _post_no_body(url, timeout=timeout)
+                    _post_no_body_for(context, path, timeout=timeout)
                 else:
-                    _post_json(url, body, timeout=timeout)
+                    _post_json_for(context, path, body, timeout=timeout)
             except Exception as e:
                 last_err = _format_http_error(e)
                 last_name = name
@@ -2831,7 +2907,7 @@ def register_receiver_once() -> dict[str, object]:
 
             # The readback is another network round trip, so it goes before
             # the ownership check rather than between it and the publish.
-            verified = _verify_registration(did, timeout=timeout)
+            verified = _verify_registration(context, timeout=timeout)
             if verified is False:
                 last_err = "server did not record media control for this session"
                 last_name = name
@@ -2863,16 +2939,20 @@ def register_receiver_once() -> dict[str, object]:
         return {"ok": False, "reason": "register_failed", "error": f"{last_name}: {last_err}", "url": last_url}
     except Exception as e:
         msg = _format_http_error(e)
-        with _LOCK:
+
+        def _apply_exception() -> None:
             _STATUS["connected"] = False
             _STATUS["last_register_ts"] = int(time.time())
             _STATUS["last_register_ok"] = False
             _STATUS["last_register_error"] = msg
             _STATUS["last_error"] = msg
+
+        if not _publish(generation, _apply_exception):
+            return {"ok": False, "reason": "config_changed"}
         return {"ok": False, "reason": "register_failed", "error": msg}
 
 
-def _verify_registration(device_id: str, *, timeout: float) -> bool | None:
+def _verify_registration(context: _RequestContext, *, timeout: float) -> bool | None:
     """True if the server advertises media control, False if it does not.
 
     ``None`` means the readback itself failed — a server that hides ``/Sessions``
@@ -2880,7 +2960,11 @@ def _verify_registration(device_id: str, *, timeout: float) -> bool | None:
     a registration failure, so the caller accepts the POST on its own terms.
     """
     try:
-        session = read_session_capabilities(device_id, timeout=timeout)
+        session = _read_session_capabilities_for(
+            context,
+            device_id=context.device_id,
+            timeout=timeout,
+        )
     except Exception:
         return None
     if not session:
@@ -2920,51 +3004,74 @@ def _register_backoff_sec(failures: int) -> float:
     return min(cap, base * (2 ** (f - 1)))
 
 
-def _schedule_register_retry(now_ts: float, failures: int, delay_sec: float) -> None:
-    global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS
-    _REGISTER_RETRY_FAILURES = max(0, int(failures))
-    _NEXT_REGISTER_RETRY_TS = max(0.0, float(now_ts) + max(0.0, float(delay_sec)))
-    with _LOCK:
+def _schedule_register_retry(
+    now_ts: float,
+    failures: int,
+    delay_sec: float,
+    *,
+    generation: int | None = None,
+) -> bool:
+    def _apply() -> None:
+        global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS
+        _REGISTER_RETRY_FAILURES = max(0, int(failures))
+        _NEXT_REGISTER_RETRY_TS = max(0.0, float(now_ts) + max(0.0, float(delay_sec)))
         _STATUS["register_retry_failures"] = _REGISTER_RETRY_FAILURES
         _STATUS["next_register_retry_ts"] = int(_NEXT_REGISTER_RETRY_TS)
         _STATUS["last_register_backoff_sec"] = float(delay_sec)
-
-
-def _clear_register_retry_state() -> None:
-    global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS
-    _REGISTER_RETRY_FAILURES = 0
-    _NEXT_REGISTER_RETRY_TS = 0.0
+    if generation is not None:
+        return _publish(generation, _apply)
     with _LOCK:
+        _apply()
+    return True
+
+
+def _clear_register_retry_state(*, generation: int | None = None) -> bool:
+    def _apply() -> None:
+        global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS
+        _REGISTER_RETRY_FAILURES = 0
+        _NEXT_REGISTER_RETRY_TS = 0.0
         _STATUS["register_retry_failures"] = 0
         _STATUS["next_register_retry_ts"] = None
         _STATUS["last_register_backoff_sec"] = 0.0
+    if generation is not None:
+        return _publish(generation, _apply)
+    with _LOCK:
+        _apply()
+    return True
 
 
 def _ensure_registration(now_ts: float | None = None) -> None:
     if not _register_retry_enabled():
         return
-    st = status()
-    if not bool(st.get("enabled")) or not bool(st.get("running")):
+    context = _request_context()
+    if not context.enabled or not context.running:
         return
-    if not str(st.get("server_url") or "").strip():
+    if not context.server_url:
         return
-    if not bool(st.get("api_key_configured")) and not bool(st.get("authenticated")):
+    if not context.token:
         return
 
     now_val = float(now_ts if now_ts is not None else time.time())
-    if _NEXT_REGISTER_RETRY_TS and now_val < float(_NEXT_REGISTER_RETRY_TS):
+    if context.next_register_retry_ts and now_val < context.next_register_retry_ts:
         return
-    if bool(st.get("connected")) and bool(st.get("last_register_ok")):
+    if context.connected and context.last_register_ok is True:
         return
 
-    out = register_receiver_once()
+    out = register_receiver_once(_context=context)
     if bool(out.get("ok")):
-        _clear_register_retry_state()
+        _clear_register_retry_state(generation=context.generation)
+        return
+    if out.get("reason") == "config_changed":
         return
 
-    failures = _REGISTER_RETRY_FAILURES + 1
+    failures = context.register_retry_failures + 1
     delay = _register_backoff_sec(failures)
-    _schedule_register_retry(now_val, failures, delay)
+    _schedule_register_retry(
+        now_val,
+        failures,
+        delay,
+        generation=context.generation,
+    )
 
 
 def _ensure_control_socket() -> None:
@@ -2991,6 +3098,33 @@ def _stop_control_socket() -> None:
 
 
 @contextlib.contextmanager
+def _configuration_transaction(*, suspend_socket: bool):
+    """Serialize a configuration mutation and invalidate work at both ends.
+
+    Socket suspension is optional because a display-only change such as an
+    operator-selected server type must invalidate detection work but does not
+    require tearing down an otherwise healthy control channel.
+    """
+    with _TRANSACTION:
+        _advance_config_generation()
+        try:
+            if not suspend_socket:
+                yield
+                return
+            try:
+                from . import jellyfin_ws
+            except Exception:
+                yield
+                return
+            with jellyfin_ws.suspended():
+                yield
+        finally:
+            # This also covers an unavailable socket module and exceptions from
+            # either the socket context or the configuration body.
+            _advance_config_generation()
+
+
+@contextlib.contextmanager
 def _control_socket_suspended():
     """Run one configuration change to completion, with the socket held down.
 
@@ -3008,23 +3142,8 @@ def _control_socket_suspended():
     should sail through and find the suspension flag, not block on a lock for
     the length of a network probe.
     """
-    with _TRANSACTION:
-        # Advance on the way in *and* on the way out. Entering invalidates work
-        # that started under the previous configuration; leaving invalidates
-        # work that started mid-transaction, which would otherwise have
-        # captured a generation that was current while the settings it read
-        # were half-installed.
-        _advance_config_generation()
-        try:
-            from . import jellyfin_ws
-        except Exception:
-            yield
-            return
-        try:
-            with jellyfin_ws.suspended():
-                yield
-        finally:
-            _advance_config_generation()
+    with _configuration_transaction(suspend_socket=True):
+        yield
 
 
 def _control_socket_status() -> dict[str, object]:
@@ -3039,14 +3158,14 @@ def _control_socket_status() -> dict[str, object]:
 def _ensure_authentication() -> None:
     if not runtime_config.snapshot().flag("RELAYTV_JELLYFIN_AUTH_ENABLED", True):
         return
-    st = status()
-    if not bool(st.get("enabled")) or not bool(st.get("running")):
+    context = _request_context()
+    if not context.enabled or not context.running:
         return
-    if bool(st.get("authenticated")):
+    if context.authenticated:
         return
-    if not bool(st.get("auth_user_configured")):
+    if not context.username or not context.password:
         return
-    authenticate_once()
+    authenticate_once(_context=context)
 
 
 def send_playback_start_once(payload: dict | None = None) -> dict[str, object]:
@@ -3057,18 +3176,24 @@ def send_playback_start_once(payload: dict | None = None) -> dict[str, object]:
     the item as playing straight away instead of an empty remote for a few
     seconds.
     """
-    st = status()
-    if not bool(st.get("enabled")) or not bool(st.get("running")):
+    context = _request_context()
+    if not context.enabled or not context.running:
         return {"ok": False, "reason": "disabled"}
     body = payload if isinstance(payload, dict) else {}
     if not body:
         return {"ok": False, "reason": "no_payload"}
-    generation = config_generation()
-    url = _build_url(os.getenv("RELAYTV_JELLYFIN_PLAYING_PATH", "/Sessions/Playing"))
+    generation = context.generation
+    path = os.getenv("RELAYTV_JELLYFIN_PLAYING_PATH", "/Sessions/Playing")
+    url = _context_url(context, path)
     if not url:
         return {"ok": False, "reason": "no_server_url"}
     try:
-        _post_json(url, body, timeout=float(os.getenv("RELAYTV_JELLYFIN_PROGRESS_TIMEOUT_SEC", "3")))
+        _post_json_for(
+            context,
+            path,
+            body,
+            timeout=float(os.getenv("RELAYTV_JELLYFIN_PROGRESS_TIMEOUT_SEC", "3")),
+        )
     except Exception as e:
         msg = _format_http_error(e)
 
@@ -3091,22 +3216,32 @@ def send_playback_start_once(payload: dict | None = None) -> dict[str, object]:
     return {"ok": True}
 
 
-def send_progress_payload_once(payload: dict | None = None) -> dict[str, object]:
-    st = status()
-    if not bool(st.get("enabled")) or not bool(st.get("running")):
+def send_progress_payload_once(
+    payload: dict | None = None,
+    *,
+    _context: _RequestContext | None = None,
+) -> dict[str, object]:
+    context = _context or _request_context()
+    if not context.enabled or not context.running:
         return {"ok": False, "reason": "disabled"}
     body = payload if isinstance(payload, dict) else {}
     if not body:
         return {"ok": False, "reason": "no_payload"}
     # A post takes up to three seconds. Landing after a disconnect used to set
     # connected=True while running was already false.
-    generation = config_generation()
-    url = _build_url(os.getenv("RELAYTV_JELLYFIN_PROGRESS_PATH", "/Sessions/Playing/Progress"))
+    generation = context.generation
+    path = os.getenv("RELAYTV_JELLYFIN_PROGRESS_PATH", "/Sessions/Playing/Progress")
+    url = _context_url(context, path)
     if not url:
         return {"ok": False, "reason": "no_server_url"}
     t0 = time.monotonic()
     try:
-        _post_json(url, body, timeout=float(os.getenv("RELAYTV_JELLYFIN_PROGRESS_TIMEOUT_SEC", "3")))
+        _post_json_for(
+            context,
+            path,
+            body,
+            timeout=float(os.getenv("RELAYTV_JELLYFIN_PROGRESS_TIMEOUT_SEC", "3")),
+        )
         latency_ms = max(0, int((time.monotonic() - t0) * 1000))
 
         def _apply() -> None:
@@ -3140,18 +3275,21 @@ def send_progress_payload_once(payload: dict | None = None) -> dict[str, object]
 
 
 def send_progress_once() -> dict[str, object]:
-    st = status()
-    if not bool(st.get("enabled")) or not bool(st.get("running")):
+    context = _request_context()
+    if not context.enabled or not context.running:
         return {"ok": False, "reason": "disabled"}
     if _PROGRESS_PROVIDER is None:
         return {"ok": False, "reason": "no_provider"}
     payload = _PROGRESS_PROVIDER()
-    return send_progress_payload_once(payload if isinstance(payload, dict) else None)
+    return send_progress_payload_once(
+        payload if isinstance(payload, dict) else None,
+        _context=context,
+    )
 
 
 def send_playback_stopped_once(payload: dict | None = None) -> dict[str, object]:
-    st = status()
-    if not bool(st.get("enabled")) or not bool(st.get("running")):
+    context = _request_context()
+    if not context.enabled or not context.running:
         return {"ok": False, "reason": "disabled"}
     body = payload if isinstance(payload, dict) else {}
     if not body:
@@ -3164,13 +3302,19 @@ def send_playback_stopped_once(payload: dict | None = None) -> dict[str, object]
             "suppressed_duplicate_stopped": True,
             "window_sec": _stopped_dedupe_sec(),
         }
-    generation = config_generation()
-    url = _build_url(os.getenv("RELAYTV_JELLYFIN_STOPPED_PATH", "/Sessions/Playing/Stopped"))
+    generation = context.generation
+    path = os.getenv("RELAYTV_JELLYFIN_STOPPED_PATH", "/Sessions/Playing/Stopped")
+    url = _context_url(context, path)
     if not url:
         return {"ok": False, "reason": "no_server_url"}
     t0 = time.monotonic()
     try:
-        _post_json(url, body, timeout=float(os.getenv("RELAYTV_JELLYFIN_STOPPED_TIMEOUT_SEC", "3")))
+        _post_json_for(
+            context,
+            path,
+            body,
+            timeout=float(os.getenv("RELAYTV_JELLYFIN_STOPPED_TIMEOUT_SEC", "3")),
+        )
         latency_ms = max(0, int((time.monotonic() - t0) * 1000))
 
         def _apply() -> None:

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -15,7 +15,10 @@ from urllib import error as _urlerror
 from urllib import parse as _urlparse
 import platform
 from .. import device_identity
+from ..debug import get_logger
 from ..thumb_cache import attach_local_thumbnail
+
+logger = get_logger("jellyfin_receiver")
 
 _LOCK = threading.Lock()
 _THREAD_LOCK = threading.Lock()
@@ -25,6 +28,12 @@ _THREAD_LOCK = threading.Lock()
 # is not enough: a transaction spans several of them plus a network probe, and
 # two overlapping ones interleave into a state neither caller asked for.
 _TRANSACTION = threading.RLock()
+
+# Bumped by every configuration transaction. Network work started under one
+# generation must not publish its result under a later one: a probe of the
+# outgoing server takes seconds, and landing late would pin the new server's
+# address to the old server's identity.
+_CONFIG_GENERATION = 0
 
 _STATUS: dict[str, object] = {
     "enabled": False,
@@ -95,7 +104,10 @@ _AUTH_PASSWORD: str = ""
 _ACCESS_TOKEN: str = ""
 _AUTH_USER_ID: str = ""
 _AUTH_SESSION_ID: str = ""
+# The current heartbeat generation's stop flag. Replaced, never reused: see
+# _start_worker. Starts set so a stop before any start is a no-op.
 _STOP_EVENT = threading.Event()
+_STOP_EVENT.set()
 _THREAD: threading.Thread | None = None
 _PROGRESS_PROVIDER = None
 _COMMAND_SINK = None
@@ -607,8 +619,26 @@ def set_server_type(server_type: str) -> dict[str, object]:
     return status()
 
 
+def config_generation() -> int:
+    with _LOCK:
+        return int(_CONFIG_GENERATION)
+
+
+def _config_generation_current(generation: int) -> bool:
+    """Whether the configuration this work started under is still installed."""
+    with _LOCK:
+        return int(_CONFIG_GENERATION) == int(generation)
+
+
 def _run_detection(server_url: str) -> dict[str, object]:
+    generation = config_generation()
     result = detect_server_type(server_url)
+    # The probe takes seconds. If settings changed while it was in flight it is
+    # describing a server this device no longer points at, and publishing it
+    # would leave the new URL labelled with the old server's identity.
+    if not _config_generation_current(generation):
+        logger.info("jellyfin_detect_discarded reason=config_changed")
+        return {"ok": False, "reason": "config_changed"}
     with _LOCK:
         _STATUS["last_detect_ts"] = int(time.time())
         _STATUS["last_detect_ok"] = bool(result.get("ok"))
@@ -2563,6 +2593,7 @@ def authenticate_once() -> dict[str, object]:
     if not username or not password:
         return {"ok": False, "reason": "no_credentials"}
 
+    generation = config_generation()
     url = f"{base}/Users/AuthenticateByName"
     payload = {"Username": username, "Pw": password}
     req = _urlrequest.Request(url, data=json.dumps(payload).encode("utf-8"), method="POST")
@@ -2588,6 +2619,11 @@ def authenticate_once() -> dict[str, object]:
         sess_id = str(session.get("Id") or "").strip()
         if not access_token:
             raise RuntimeError("authenticate response missing AccessToken")
+        # A token minted against the previous server or identity must not be
+        # installed over the current one.
+        if not _config_generation_current(generation):
+            logger.info("jellyfin_auth_discarded reason=config_changed")
+            return {"ok": False, "reason": "config_changed"}
         global _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
         with _LOCK:
             _ACCESS_TOKEN = access_token
@@ -2604,6 +2640,8 @@ def authenticate_once() -> dict[str, object]:
         return {"ok": True, "user_id": user_id, "session_id": sess_id}
     except Exception as e:
         msg = _format_http_error(e)
+        if not _config_generation_current(generation):
+            return {"ok": False, "reason": "config_changed"}
         with _LOCK:
             _STATUS["authenticated"] = False
             _STATUS["auth_user_id"] = ""
@@ -2701,6 +2739,7 @@ def register_receiver_once() -> dict[str, object]:
         ("caps_query", f"{base}/Sessions/Capabilities?{_capabilities_query(did)}", None),
     ]
     timeout = float(os.getenv("RELAYTV_JELLYFIN_REGISTER_TIMEOUT_SEC", "3"))
+    generation = config_generation()
     last_err = "register_failed"
     last_name = ""
     last_url = ""
@@ -2717,6 +2756,9 @@ def register_receiver_once() -> dict[str, object]:
                 last_url = url
                 continue
 
+            if not _config_generation_current(generation):
+                logger.info("jellyfin_register_discarded reason=config_changed")
+                return {"ok": False, "reason": "config_changed"}
             verified = _verify_registration(did, timeout=timeout)
             if verified is False:
                 last_err = "server did not record media control for this session"
@@ -2732,6 +2774,8 @@ def register_receiver_once() -> dict[str, object]:
                 _STATUS["last_error"] = None
                 _STATUS["media_control_verified"] = verified
             return {"ok": True, "url": url, "method": name, "verified": verified}
+        if not _config_generation_current(generation):
+            return {"ok": False, "reason": "config_changed"}
         with _LOCK:
             _STATUS["connected"] = False
             _STATUS["last_register_ts"] = int(time.time())
@@ -2887,7 +2931,10 @@ def _control_socket_suspended():
     should sail through and find the suspension flag, not block on a lock for
     the length of a network probe.
     """
+    global _CONFIG_GENERATION
     with _TRANSACTION:
+        with _LOCK:
+            _CONFIG_GENERATION += 1
         try:
             from . import jellyfin_ws
         except Exception:
@@ -3044,8 +3091,8 @@ def send_playback_stopped_once(payload: dict | None = None) -> dict[str, object]
         return {"ok": False, "reason": "post_failed", "error": err, "latency_ms": latency_ms}
 
 
-def _heartbeat_worker() -> None:
-    while not _STOP_EVENT.is_set():
+def _heartbeat_worker(stop: threading.Event) -> None:
+    while not stop.is_set():
         try:
             _ensure_authentication()
             send_progress_once()
@@ -3055,18 +3102,30 @@ def _heartbeat_worker() -> None:
         except Exception:
             pass
         hb = max(2, int(float(status().get("heartbeat_sec") or 5)))
-        _STOP_EVENT.wait(hb)
+        stop.wait(hb)
 
 
 def _start_worker() -> None:
-    global _THREAD
+    """Start a heartbeat generation with a stop flag only it can see.
+
+    A module-level event cannot work here: _stop_worker gives the worker one
+    second to notice, a worker inside a network call outlives that, and the
+    next start would clear the shared flag out from under it. Two generations
+    then authenticate, register, post progress, and probe identity in
+    parallel — with an event owned by the generation, a retired one stays
+    retired.
+    """
+    global _THREAD, _STOP_EVENT
     with _THREAD_LOCK:
         if _THREAD is not None and _THREAD.is_alive():
             return
         if not bool(status().get("enabled")):
             return
-        _STOP_EVENT.clear()
-        _THREAD = threading.Thread(target=_heartbeat_worker, daemon=True, name="relaytv-jellyfin-heartbeat")
+        stop = threading.Event()
+        _STOP_EVENT = stop
+        _THREAD = threading.Thread(
+            target=_heartbeat_worker, args=(stop,), daemon=True, name="relaytv-jellyfin-heartbeat"
+        )
         _THREAD.start()
 
 

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -584,17 +584,24 @@ def detect_server_type(server_url: str, *, timeout_sec: float = 3.0) -> dict[str
         return {"ok": False, "server_type": "", "product_name": "", "version": "", "error": _format_http_error(e)}
 
 
-def _persist_server_type(server_type: str, product_name: str = "") -> None:
+def _persist_server_type(server_type: str, product_name: str = "", *, generation: int | None = None) -> None:
     st = str(server_type or "").strip().lower()
     if st not in ("jellyfin", "emby"):
         return
-    with _LOCK:
+    changed = False
+
+    def _apply() -> None:
+        nonlocal changed
         changed = _STATUS.get("server_type") != st
         _STATUS["server_type"] = st
         if product_name:
             _STATUS["server_product_name"] = str(product_name)
         elif changed:
             _STATUS["server_product_name"] = ""
+
+    gen = config_generation() if generation is None else int(generation)
+    if not _publish(gen, _apply):
+        return
     if not changed:
         return
     try:
@@ -619,6 +626,12 @@ def set_server_type(server_type: str) -> dict[str, object]:
     return status()
 
 
+def _advance_config_generation() -> None:
+    global _CONFIG_GENERATION
+    with _LOCK:
+        _CONFIG_GENERATION += 1
+
+
 def config_generation() -> int:
     with _LOCK:
         return int(_CONFIG_GENERATION)
@@ -630,21 +643,68 @@ def _config_generation_current(generation: int) -> bool:
         return int(_CONFIG_GENERATION) == int(generation)
 
 
-def _run_detection(server_url: str) -> dict[str, object]:
-    generation = config_generation()
-    result = detect_server_type(server_url)
-    # The probe takes seconds. If settings changed while it was in flight it is
-    # describing a server this device no longer points at, and publishing it
-    # would leave the new URL labelled with the old server's identity.
-    if not _config_generation_current(generation):
-        logger.info("jellyfin_detect_discarded reason=config_changed")
-        return {"ok": False, "reason": "config_changed"}
+def config_snapshot() -> dict[str, object]:
+    """Everything network work needs, plus the generation, captured together.
+
+    Reading the URL and then capturing the generation separately is a race in
+    itself: settings can change in between, leaving work that dialled the old
+    server holding a generation that says it is current.
+    """
     with _LOCK:
+        return {
+            "generation": int(_CONFIG_GENERATION),
+            "enabled": bool(_STATUS.get("enabled")),
+            "running": bool(_STATUS.get("running")),
+            "server_url": str(_STATUS.get("server_url") or "").strip().rstrip("/"),
+            "device_id": str(_STATUS.get("device_id") or "").strip(),
+            "device_name": str(_STATUS.get("device_name") or "RelayTV"),
+            "client_name": str(_STATUS.get("client_name") or "RelayTV"),
+            "client_version": str(_STATUS.get("client_version") or "1.0"),
+            "username": str(_AUTH_USERNAME or ""),
+            "password": str(_AUTH_PASSWORD or ""),
+        }
+
+
+def _publish(generation: int, apply) -> bool:
+    """Apply a status mutation only if the configuration has not moved on.
+
+    The check and the write share one acquisition of ``_LOCK`` so a transaction
+    cannot slip between them. ``apply`` runs with the lock held and must not
+    re-acquire it.
+    """
+    with _LOCK:
+        if int(_CONFIG_GENERATION) != int(generation):
+            return False
+        apply()
+        return True
+
+
+def _run_detection(server_url: str, *, generation: int | None = None) -> dict[str, object]:
+    """Probe a server's identity and publish the result, if it is still ours.
+
+    The probe takes seconds. If settings changed while it was in flight it is
+    describing a server this device no longer points at, and publishing would
+    leave the new URL labelled with the old server's identity. The generation
+    is captured by the caller where the URL came from, so the two cannot
+    disagree.
+    """
+    gen = int(generation) if generation is not None else config_generation()
+    result = detect_server_type(server_url)
+
+    def _apply() -> None:
         _STATUS["last_detect_ts"] = int(time.time())
         _STATUS["last_detect_ok"] = bool(result.get("ok"))
         _STATUS["last_detect_error"] = result.get("error")
+
+    if not _publish(gen, _apply):
+        logger.info("jellyfin_detect_discarded reason=config_changed")
+        return {"ok": False, "reason": "config_changed"}
     if result.get("ok"):
-        _persist_server_type(str(result.get("server_type") or ""), str(result.get("product_name") or ""))
+        _persist_server_type(
+            str(result.get("server_type") or ""),
+            str(result.get("product_name") or ""),
+            generation=gen,
+        )
     return result
 
 
@@ -658,15 +718,18 @@ def _maybe_retry_detection() -> None:
     st = status()
     if st.get("last_detect_ok") is True:
         return
-    base = str(st.get("server_url") or "").strip()
-    if not base:
-        return
     if not (bool(st.get("authenticated")) or bool(st.get("last_register_ok"))):
         return
     last_ts = st.get("last_detect_ts")
     if last_ts and (time.time() - float(last_ts)) < 300.0:
         return
-    _run_detection(base)
+    # URL and generation come from the same snapshot, so the probe can never
+    # hold a generation that belongs to a different server.
+    snapshot = config_snapshot()
+    base = str(snapshot.get("server_url") or "").strip()
+    if not base:
+        return
+    _run_detection(base, generation=int(snapshot["generation"]))
 
 
 def connect(*, server_url: str, api_key: str | None = None, device_name: str | None = None, heartbeat_sec: int | None = None) -> dict[str, object]:
@@ -2580,20 +2643,23 @@ def authenticate_once() -> dict[str, object]:
     st = status()
     if not bool(st.get("enabled")) or not bool(st.get("running")):
         return {"ok": False, "reason": "disabled"}
-    base = str(st.get("server_url") or "").strip().rstrip("/")
+    # Inputs and generation in one capture: reading the URL first and stamping
+    # the generation afterwards lets settings change in between, leaving this
+    # request dialling the old server while claiming to be current.
+    snapshot = config_snapshot()
+    generation = int(snapshot["generation"])
+    base = str(snapshot["server_url"])
     if not base:
         return {"ok": False, "reason": "no_server_url"}
-    with _LOCK:
-        username = str(_AUTH_USERNAME or "")
-        password = str(_AUTH_PASSWORD or "")
-        device_name = str(_STATUS.get("device_name") or "RelayTV")
-        device_id = str(_STATUS.get("device_id") or "relaytv")
-        client_name = str(_STATUS.get("client_name") or "RelayTV")
-        client_version = str(_STATUS.get("client_version") or "1.0")
+    username = str(snapshot["username"])
+    password = str(snapshot["password"])
+    device_name = str(snapshot["device_name"])
+    device_id = str(snapshot["device_id"]) or "relaytv"
+    client_name = str(snapshot["client_name"])
+    client_version = str(snapshot["client_version"])
     if not username or not password:
         return {"ok": False, "reason": "no_credentials"}
 
-    generation = config_generation()
     url = f"{base}/Users/AuthenticateByName"
     payload = {"Username": username, "Pw": password}
     req = _urlrequest.Request(url, data=json.dumps(payload).encode("utf-8"), method="POST")
@@ -2619,13 +2685,13 @@ def authenticate_once() -> dict[str, object]:
         sess_id = str(session.get("Id") or "").strip()
         if not access_token:
             raise RuntimeError("authenticate response missing AccessToken")
-        # A token minted against the previous server or identity must not be
-        # installed over the current one.
-        if not _config_generation_current(generation):
-            logger.info("jellyfin_auth_discarded reason=config_changed")
-            return {"ok": False, "reason": "config_changed"}
         global _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
-        with _LOCK:
+
+        def _apply() -> None:
+            # A token minted against the previous server or identity must never
+            # be installed over the current one, so the check and the install
+            # share one acquisition of the lock.
+            global _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
             _ACCESS_TOKEN = access_token
             _AUTH_USER_ID = user_id
             _AUTH_SESSION_ID = sess_id
@@ -2636,13 +2702,16 @@ def authenticate_once() -> dict[str, object]:
             _STATUS["last_auth_ok"] = True
             _STATUS["last_auth_error"] = None
             _STATUS["last_error"] = None
+
+        if not _publish(generation, _apply):
+            logger.info("jellyfin_auth_discarded reason=config_changed")
+            return {"ok": False, "reason": "config_changed"}
         _catalog_cache_clear()
         return {"ok": True, "user_id": user_id, "session_id": sess_id}
     except Exception as e:
         msg = _format_http_error(e)
-        if not _config_generation_current(generation):
-            return {"ok": False, "reason": "config_changed"}
-        with _LOCK:
+
+        def _apply_failure() -> None:
             _STATUS["authenticated"] = False
             _STATUS["auth_user_id"] = ""
             _STATUS["auth_session_id"] = ""
@@ -2650,6 +2719,9 @@ def authenticate_once() -> dict[str, object]:
             _STATUS["last_auth_ok"] = False
             _STATUS["last_auth_error"] = msg
             _STATUS["last_error"] = msg
+
+        if not _publish(generation, _apply_failure):
+            return {"ok": False, "reason": "config_changed"}
         return {"ok": False, "reason": "auth_failed", "error": msg}
 
 
@@ -2730,7 +2802,8 @@ def register_receiver_once() -> dict[str, object]:
     base = str(st.get("server_url") or "").strip().rstrip("/")
     if not base:
         return {"ok": False, "reason": "no_server_url"}
-    did = str(st.get("device_id") or "").strip()
+    snapshot = config_snapshot()
+    did = str(snapshot["device_id"])
     payload = capabilities_payload()
     # The query-string form is what older Emby builds accept; it stays as a
     # fallback so an Emby server that rejects the DTO body still registers.
@@ -2739,7 +2812,7 @@ def register_receiver_once() -> dict[str, object]:
         ("caps_query", f"{base}/Sessions/Capabilities?{_capabilities_query(did)}", None),
     ]
     timeout = float(os.getenv("RELAYTV_JELLYFIN_REGISTER_TIMEOUT_SEC", "3"))
-    generation = config_generation()
+    generation = int(snapshot["generation"])
     last_err = "register_failed"
     last_name = ""
     last_url = ""
@@ -2756,9 +2829,8 @@ def register_receiver_once() -> dict[str, object]:
                 last_url = url
                 continue
 
-            if not _config_generation_current(generation):
-                logger.info("jellyfin_register_discarded reason=config_changed")
-                return {"ok": False, "reason": "config_changed"}
+            # The readback is another network round trip, so it goes before
+            # the ownership check rather than between it and the publish.
             verified = _verify_registration(did, timeout=timeout)
             if verified is False:
                 last_err = "server did not record media control for this session"
@@ -2766,23 +2838,28 @@ def register_receiver_once() -> dict[str, object]:
                 last_url = url
                 continue
 
-            with _LOCK:
+            def _apply(_verified=verified, _now=None) -> None:
                 _STATUS["connected"] = True
                 _STATUS["last_register_ts"] = int(time.time())
                 _STATUS["last_register_ok"] = True
                 _STATUS["last_register_error"] = None
                 _STATUS["last_error"] = None
-                _STATUS["media_control_verified"] = verified
+                _STATUS["media_control_verified"] = _verified
+
+            if not _publish(generation, _apply):
+                logger.info("jellyfin_register_discarded reason=config_changed")
+                return {"ok": False, "reason": "config_changed"}
             return {"ok": True, "url": url, "method": name, "verified": verified}
-        if not _config_generation_current(generation):
-            return {"ok": False, "reason": "config_changed"}
-        with _LOCK:
+        def _apply_failure() -> None:
             _STATUS["connected"] = False
             _STATUS["last_register_ts"] = int(time.time())
             _STATUS["last_register_ok"] = False
             _STATUS["last_register_error"] = f"{last_name}: {last_err}"
             _STATUS["last_error"] = f"{last_name}: {last_err}"
             _STATUS["media_control_verified"] = False
+
+        if not _publish(generation, _apply_failure):
+            return {"ok": False, "reason": "config_changed"}
         return {"ok": False, "reason": "register_failed", "error": f"{last_name}: {last_err}", "url": last_url}
     except Exception as e:
         msg = _format_http_error(e)
@@ -2931,17 +3008,23 @@ def _control_socket_suspended():
     should sail through and find the suspension flag, not block on a lock for
     the length of a network probe.
     """
-    global _CONFIG_GENERATION
     with _TRANSACTION:
-        with _LOCK:
-            _CONFIG_GENERATION += 1
+        # Advance on the way in *and* on the way out. Entering invalidates work
+        # that started under the previous configuration; leaving invalidates
+        # work that started mid-transaction, which would otherwise have
+        # captured a generation that was current while the settings it read
+        # were half-installed.
+        _advance_config_generation()
         try:
             from . import jellyfin_ws
         except Exception:
             yield
             return
-        with jellyfin_ws.suspended():
-            yield
+        try:
+            with jellyfin_ws.suspended():
+                yield
+        finally:
+            _advance_config_generation()
 
 
 def _control_socket_status() -> dict[str, object]:
@@ -2980,6 +3063,7 @@ def send_playback_start_once(payload: dict | None = None) -> dict[str, object]:
     body = payload if isinstance(payload, dict) else {}
     if not body:
         return {"ok": False, "reason": "no_payload"}
+    generation = config_generation()
     url = _build_url(os.getenv("RELAYTV_JELLYFIN_PLAYING_PATH", "/Sessions/Playing"))
     if not url:
         return {"ok": False, "reason": "no_server_url"}
@@ -2987,15 +3071,23 @@ def send_playback_start_once(payload: dict | None = None) -> dict[str, object]:
         _post_json(url, body, timeout=float(os.getenv("RELAYTV_JELLYFIN_PROGRESS_TIMEOUT_SEC", "3")))
     except Exception as e:
         msg = _format_http_error(e)
-        with _LOCK:
+
+        def _apply_failure() -> None:
             _STATUS["last_playing_ts"] = int(time.time())
             _STATUS["last_playing_ok"] = False
             _STATUS["last_playing_error"] = msg
+
+        if not _publish(generation, _apply_failure):
+            return {"ok": False, "reason": "config_changed"}
         return {"ok": False, "reason": "playing_failed", "error": msg}
-    with _LOCK:
+
+    def _apply() -> None:
         _STATUS["last_playing_ts"] = int(time.time())
         _STATUS["last_playing_ok"] = True
         _STATUS["last_playing_error"] = None
+
+    if not _publish(generation, _apply):
+        return {"ok": False, "reason": "config_changed"}
     return {"ok": True}
 
 
@@ -3006,6 +3098,9 @@ def send_progress_payload_once(payload: dict | None = None) -> dict[str, object]
     body = payload if isinstance(payload, dict) else {}
     if not body:
         return {"ok": False, "reason": "no_payload"}
+    # A post takes up to three seconds. Landing after a disconnect used to set
+    # connected=True while running was already false.
+    generation = config_generation()
     url = _build_url(os.getenv("RELAYTV_JELLYFIN_PROGRESS_PATH", "/Sessions/Playing/Progress"))
     if not url:
         return {"ok": False, "reason": "no_server_url"}
@@ -3013,7 +3108,8 @@ def send_progress_payload_once(payload: dict | None = None) -> dict[str, object]
     try:
         _post_json(url, body, timeout=float(os.getenv("RELAYTV_JELLYFIN_PROGRESS_TIMEOUT_SEC", "3")))
         latency_ms = max(0, int((time.monotonic() - t0) * 1000))
-        with _LOCK:
+
+        def _apply() -> None:
             _STATUS["connected"] = True
             _STATUS["last_progress_ts"] = int(time.time())
             _STATUS["last_progress_ok"] = True
@@ -3021,11 +3117,15 @@ def send_progress_payload_once(payload: dict | None = None) -> dict[str, object]
             _STATUS["progress_success_count"] = int(_STATUS.get("progress_success_count") or 0) + 1
             _STATUS["last_progress_latency_ms"] = latency_ms
             _STATUS["last_error"] = None
+
+        if not _publish(generation, _apply):
+            return {"ok": False, "reason": "config_changed"}
         return {"ok": True, "url": url, "latency_ms": latency_ms}
     except Exception as e:
         err = _format_http_error(e)
         latency_ms = max(0, int((time.monotonic() - t0) * 1000))
-        with _LOCK:
+
+        def _apply_failure() -> None:
             _STATUS["connected"] = False
             _STATUS["last_progress_ts"] = int(time.time())
             _STATUS["last_progress_ok"] = False
@@ -3033,6 +3133,9 @@ def send_progress_payload_once(payload: dict | None = None) -> dict[str, object]
             _STATUS["progress_failure_count"] = int(_STATUS.get("progress_failure_count") or 0) + 1
             _STATUS["last_progress_latency_ms"] = latency_ms
             _STATUS["last_error"] = err
+
+        if not _publish(generation, _apply_failure):
+            return {"ok": False, "reason": "config_changed"}
         return {"ok": False, "reason": "post_failed", "error": err, "latency_ms": latency_ms}
 
 
@@ -3061,6 +3164,7 @@ def send_playback_stopped_once(payload: dict | None = None) -> dict[str, object]
             "suppressed_duplicate_stopped": True,
             "window_sec": _stopped_dedupe_sec(),
         }
+    generation = config_generation()
     url = _build_url(os.getenv("RELAYTV_JELLYFIN_STOPPED_PATH", "/Sessions/Playing/Stopped"))
     if not url:
         return {"ok": False, "reason": "no_server_url"}
@@ -3068,7 +3172,8 @@ def send_playback_stopped_once(payload: dict | None = None) -> dict[str, object]
     try:
         _post_json(url, body, timeout=float(os.getenv("RELAYTV_JELLYFIN_STOPPED_TIMEOUT_SEC", "3")))
         latency_ms = max(0, int((time.monotonic() - t0) * 1000))
-        with _LOCK:
+
+        def _apply() -> None:
             _STATUS["connected"] = True
             _STATUS["last_stopped_ts"] = int(time.time())
             _STATUS["last_stopped_ok"] = True
@@ -3076,11 +3181,15 @@ def send_playback_stopped_once(payload: dict | None = None) -> dict[str, object]
             _STATUS["stopped_success_count"] = int(_STATUS.get("stopped_success_count") or 0) + 1
             _STATUS["last_stopped_latency_ms"] = latency_ms
             _STATUS["last_error"] = None
+
+        if not _publish(generation, _apply):
+            return {"ok": False, "reason": "config_changed"}
         return {"ok": True, "url": url, "latency_ms": latency_ms}
     except Exception as e:
         err = _format_http_error(e)
         latency_ms = max(0, int((time.monotonic() - t0) * 1000))
-        with _LOCK:
+
+        def _apply_failure() -> None:
             _STATUS["connected"] = False
             _STATUS["last_stopped_ts"] = int(time.time())
             _STATUS["last_stopped_ok"] = False
@@ -3088,6 +3197,9 @@ def send_playback_stopped_once(payload: dict | None = None) -> dict[str, object]
             _STATUS["stopped_failure_count"] = int(_STATUS.get("stopped_failure_count") or 0) + 1
             _STATUS["last_stopped_latency_ms"] = latency_ms
             _STATUS["last_error"] = err
+
+        if not _publish(generation, _apply_failure):
+            return {"ok": False, "reason": "config_changed"}
         return {"ok": False, "reason": "post_failed", "error": err, "latency_ms": latency_ms}
 
 

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -20,6 +20,12 @@ from ..thumb_cache import attach_local_thumbnail
 _LOCK = threading.Lock()
 _THREAD_LOCK = threading.Lock()
 
+# Serializes whole configuration transactions (connect / disconnect / rename /
+# stop) against each other. _LOCK only guards individual _STATUS writes, which
+# is not enough: a transaction spans several of them plus a network probe, and
+# two overlapping ones interleave into a state neither caller asked for.
+_TRANSACTION = threading.RLock()
+
 _STATUS: dict[str, object] = {
     "enabled": False,
     "running": False,
@@ -2865,20 +2871,30 @@ def _stop_control_socket() -> None:
 
 @contextlib.contextmanager
 def _control_socket_suspended():
-    """Keep the socket down for a whole configuration change.
+    """Run one configuration change to completion, with the socket held down.
 
-    Stopping it and then rewriting settings is not enough: the heartbeat runs
-    every few seconds, and one that fires in between opens a socket to the
-    server being replaced — which then keeps taking commands until a later
-    heartbeat notices the drift.
+    Two locks, because they answer different questions.
+
+    ``_TRANSACTION`` makes the change atomic against other changes. The connect
+    endpoints are sync defs, so FastAPI runs concurrent requests on real
+    threads: two overlapping server switches would each install their own URL
+    and token and then race their detection probes, and the slower one landing
+    last leaves the new server's address beside the old server's identity.
+
+    The socket suspension makes it atomic against the heartbeat, which would
+    otherwise reopen the socket to the server being replaced. It deliberately
+    does not hold the socket lifecycle lock across the body — the heartbeat
+    should sail through and find the suspension flag, not block on a lock for
+    the length of a network probe.
     """
-    try:
-        from . import jellyfin_ws
-    except Exception:
-        yield
-        return
-    with jellyfin_ws.suspended():
-        yield
+    with _TRANSACTION:
+        try:
+            from . import jellyfin_ws
+        except Exception:
+            yield
+            return
+        with jellyfin_ws.suspended():
+            yield
 
 
 def _control_socket_status() -> dict[str, object]:

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 from __future__ import annotations
 
+import contextlib
 import os
 import threading
 from ..config import env_bool as _env_bool
@@ -631,11 +632,20 @@ def connect(*, server_url: str, api_key: str | None = None, device_name: str | N
     """Configure and enable Jellyfin receiver runtime."""
     global _API_KEY, _AUTH_USERNAME, _AUTH_PASSWORD, _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
     global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS, _LAST_STOPPED_SIGNATURE, _LAST_STOPPED_TS
-    # Before anything else: the live socket belongs to the outgoing server, and
-    # a command arriving on it after the config swap would execute against the
-    # new server's state. Server-type detection alone can take three seconds,
-    # which is more than long enough for that to happen.
-    _stop_control_socket()
+    # The whole swap runs with the socket suspended: it belongs to the outgoing
+    # server, a command arriving on it after the config change would execute
+    # against the new server's state, and server-type detection alone can take
+    # three seconds. Suspending rather than merely stopping also keeps the
+    # heartbeat from reopening it to the old server mid-transaction.
+    with _control_socket_suspended():
+        return _connect_locked(
+            server_url=server_url, api_key=api_key, device_name=device_name, heartbeat_sec=heartbeat_sec
+        )
+
+
+def _connect_locked(*, server_url: str, api_key: str | None, device_name: str | None, heartbeat_sec: int | None) -> dict[str, object]:
+    global _API_KEY, _AUTH_USERNAME, _AUTH_PASSWORD, _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
+    global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS, _LAST_STOPPED_SIGNATURE, _LAST_STOPPED_TS
     with _LOCK:
         _STATUS["enabled"] = True
         _STATUS["running"] = True
@@ -738,6 +748,13 @@ def disconnect() -> dict[str, object]:
 
 def set_device_identity(name: str) -> dict[str, object]:
     """Update runtime device/client display name for Jellyfin presence."""
+    # Same transaction discipline as connect(): the token is dropped here, so
+    # the socket must not be reopened against the old one mid-change.
+    with _control_socket_suspended():
+        return _set_device_identity_locked(name)
+
+
+def _set_device_identity_locked(name: str) -> dict[str, object]:
     clean = str(name or "").strip() or "RelayTV"
     if len(clean) > 80:
         clean = clean[:80].strip() or "RelayTV"
@@ -759,9 +776,6 @@ def set_device_identity(name: str) -> dict[str, object]:
         _STATUS["media_control_verified"] = None
     _catalog_cache_clear()
     _clear_register_retry_state()
-    # The socket was opened under the old device id; it has to be re-dialled
-    # under the new one or the rename never reaches the cast list.
-    _stop_control_socket()
     return status()
 
 
@@ -2833,6 +2847,24 @@ def _stop_control_socket() -> None:
         jellyfin_ws.stop()
     except Exception:
         pass
+
+
+@contextlib.contextmanager
+def _control_socket_suspended():
+    """Keep the socket down for a whole configuration change.
+
+    Stopping it and then rewriting settings is not enough: the heartbeat runs
+    every few seconds, and one that fires in between opens a socket to the
+    server being replaced — which then keeps taking commands until a later
+    heartbeat notices the drift.
+    """
+    try:
+        from . import jellyfin_ws
+    except Exception:
+        yield
+        return
+    with jellyfin_ws.suspended():
+        yield
 
 
 def _control_socket_status() -> dict[str, object]:

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -666,6 +666,10 @@ def connect(*, server_url: str, api_key: str | None = None, device_name: str | N
             pass
     with _LOCK:
         out = dict(_STATUS)
+    # The old socket is bound to the old server and token. Drop it here rather
+    # than waiting for the heartbeat, so the previous server cannot land one
+    # more playback command on this device after the switch.
+    _stop_control_socket()
     _start_worker()
     if _env_bool("RELAYTV_JELLYFIN_AUTO_REGISTER", False):
         try:
@@ -724,8 +728,12 @@ def set_device_identity(name: str) -> dict[str, object]:
         _STATUS["connected"] = False
         _STATUS["last_auth_ok"] = None
         _STATUS["last_register_ok"] = None
+        _STATUS["media_control_verified"] = None
     _catalog_cache_clear()
     _clear_register_retry_state()
+    # The socket was opened under the old device id; it has to be re-dialled
+    # under the new one or the rename never reaches the cast list.
+    _stop_control_socket()
     return status()
 
 

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -406,11 +406,16 @@ def start() -> None:
 
 
 def stop() -> None:
-    _stop_worker()
-    _stop_control_socket()
-    with _LOCK:
-        _STATUS["running"] = False
-        _STATUS["connected"] = False
+    # Shutting down is a configuration transaction like any other. _stop_worker
+    # gives the heartbeat one second to notice; a heartbeat parked in a network
+    # call outlives that, and it only has to reach ensure_running() once while
+    # ``running`` is still true to leave behind a socket that nothing retires.
+    # ``running`` therefore goes false before the suspension lifts.
+    with _control_socket_suspended():
+        _stop_worker()
+        with _LOCK:
+            _STATUS["running"] = False
+            _STATUS["connected"] = False
 
 
 def mark_command(name: str) -> None:
@@ -718,10 +723,19 @@ def _connect_locked(*, server_url: str, api_key: str | None, device_name: str | 
 
 
 def disconnect() -> dict[str, object]:
+    # The whole teardown is one transaction. A heartbeat still inside a network
+    # call survives _stop_worker's one-second join, and if it reaches
+    # ensure_running() before ``running`` goes false it opens a replacement
+    # socket — one that stays connected forever, because the heartbeat that
+    # would have retired it is already stopped.
+    with _control_socket_suspended():
+        return _disconnect_locked()
+
+
+def _disconnect_locked() -> dict[str, object]:
     global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS, _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
     global _LAST_STOPPED_SIGNATURE, _LAST_STOPPED_TS
     _stop_worker()
-    _stop_control_socket()
     with _LOCK:
         _STATUS["running"] = False
         _STATUS["connected"] = False

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -40,6 +40,7 @@ _STATUS: dict[str, object] = {
     "last_register_ts": None,
     "last_register_ok": None,
     "last_register_error": None,
+    "last_register_reason": None,
     "last_progress_ts": None,
     "last_progress_ok": None,
     "last_progress_error": None,
@@ -2694,6 +2695,27 @@ def _verify_registration(device_id: str, *, timeout: float) -> bool | None:
     if not session:
         return None
     return bool(session.get("SupportsMediaControl"))
+
+
+def invalidate_registration(reason: str = "") -> None:
+    """Force the next heartbeat to re-post and re-verify capabilities.
+
+    Capabilities live in the server's in-memory session state, so a Jellyfin
+    restart drops them while this device's view still says registered. The
+    control socket reconnecting is the signal that the session is new: without
+    this, ``_ensure_registration`` short-circuits on the stale success and the
+    device reports itself castable forever while the server offers nothing.
+    """
+    global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS
+    with _LOCK:
+        _STATUS["connected"] = False
+        _STATUS["last_register_ok"] = None
+        _STATUS["media_control_verified"] = None
+        _REGISTER_RETRY_FAILURES = 0
+        _NEXT_REGISTER_RETRY_TS = 0.0
+        _STATUS["register_retry_failures"] = 0
+        _STATUS["next_register_retry_ts"] = None
+        _STATUS["last_register_reason"] = str(reason or "") or None
 
 
 def _register_retry_enabled() -> bool:

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -13,6 +13,7 @@ from urllib import request as _urlrequest
 from urllib import error as _urlerror
 from urllib import parse as _urlparse
 import platform
+from .. import device_identity
 from ..thumb_cache import attach_local_thumbnail
 
 _LOCK = threading.Lock()
@@ -245,20 +246,30 @@ def _mark_catalog_error(msg: str) -> None:
         _STATUS["catalog_last_error"] = text or None
 
 
-def derive_device_id(device_name: str) -> str:
-    """The Jellyfin DeviceId for a given display name.
+def derive_device_id() -> str:
+    """The Jellyfin DeviceId for this install.
 
-    Every path that sets the name must agree on this. Startup used to append
-    the hostname and the rename paths did not, so renaming a device at runtime
-    and then restarting produced two DeviceIds for one TV — and Jellyfin keys
-    sessions, capabilities, and playback history on DeviceId, so the cast list
-    grew a duplicate.
+    Jellyfin keys sessions, capabilities, and playback history on DeviceId, so
+    it has to outlive a rename. ``device_name`` is a display string an operator
+    changes at will, which is exactly why RelayTV already persists a stable id
+    (``device_identity``) — deriving from the name instead minted a fresh
+    Jellyfin session on every rename and left the old one behind as a duplicate
+    cast target.
+
+    ``RELAYTV_JELLYFIN_DEVICE_ID`` still pins it for cloned images and tests.
     """
     override = (os.getenv("RELAYTV_JELLYFIN_DEVICE_ID") or "").strip()
     if override:
         return override
-    slug = str(device_name or "RelayTV").strip().lower().replace(" ", "-") or "relaytv"
-    return f"relaytv-{slug}-{platform.node() or 'host'}".strip()
+    try:
+        stable = device_identity.device_id()
+    except Exception:
+        stable = ""
+    if stable:
+        return f"relaytv-{stable}"
+    # Persistence is best effort in device_identity too; fall back to something
+    # deterministic per host rather than inventing a new id on every call.
+    return f"relaytv-{platform.node() or 'host'}".strip()
 
 
 def _read_config() -> dict[str, object]:
@@ -288,7 +299,7 @@ def _read_config() -> dict[str, object]:
         "enabled": runtime_config.snapshot().flag("RELAYTV_JELLYFIN_ENABLED", False),
         "server_url": (runtime_config.snapshot().raw("RELAYTV_JELLYFIN_SERVER_URL") or "").strip(),
         "device_name": device_name,
-        "device_id": derive_device_id(device_name),
+        "device_id": derive_device_id(),
         "client_name": (runtime_config.snapshot().raw("RELAYTV_JELLYFIN_CLIENT_NAME") or device_name).strip() or device_name,
         "client_version": (os.getenv("RELAYTV_JELLYFIN_CLIENT_VERSION") or "1.0").strip() or "1.0",
         "heartbeat_sec": max(2, int(float(os.getenv("RELAYTV_JELLYFIN_HEARTBEAT_SEC") or "5"))),
@@ -620,6 +631,11 @@ def connect(*, server_url: str, api_key: str | None = None, device_name: str | N
     """Configure and enable Jellyfin receiver runtime."""
     global _API_KEY, _AUTH_USERNAME, _AUTH_PASSWORD, _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
     global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS, _LAST_STOPPED_SIGNATURE, _LAST_STOPPED_TS
+    # Before anything else: the live socket belongs to the outgoing server, and
+    # a command arriving on it after the config swap would execute against the
+    # new server's state. Server-type detection alone can take three seconds,
+    # which is more than long enough for that to happen.
+    _stop_control_socket()
     with _LOCK:
         _STATUS["enabled"] = True
         _STATUS["running"] = True
@@ -627,7 +643,7 @@ def connect(*, server_url: str, api_key: str | None = None, device_name: str | N
         if device_name is not None:
             _STATUS["device_name"] = str(device_name or "").strip() or "RelayTV"
             _STATUS["client_name"] = str(_STATUS["device_name"])
-            _STATUS["device_id"] = derive_device_id(str(_STATUS["device_name"]))
+            _STATUS["device_id"] = derive_device_id()
         if heartbeat_sec is not None:
             _STATUS["heartbeat_sec"] = max(2, int(heartbeat_sec))
         if api_key is not None:
@@ -682,10 +698,6 @@ def connect(*, server_url: str, api_key: str | None = None, device_name: str | N
             pass
     with _LOCK:
         out = dict(_STATUS)
-    # The old socket is bound to the old server and token. Drop it here rather
-    # than waiting for the heartbeat, so the previous server cannot land one
-    # more playback command on this device after the switch.
-    _stop_control_socket()
     _start_worker()
     if _env_bool("RELAYTV_JELLYFIN_AUTO_REGISTER", False):
         try:
@@ -732,7 +744,7 @@ def set_device_identity(name: str) -> dict[str, object]:
     with _LOCK:
         _STATUS["device_name"] = clean
         _STATUS["client_name"] = clean
-        _STATUS["device_id"] = derive_device_id(clean)
+        _STATUS["device_id"] = derive_device_id()
         # Identity changed, drop session token and force fresh auth/register.
         global _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
         _ACCESS_TOKEN = ""

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -46,9 +46,14 @@ _STATUS: dict[str, object] = {
     "last_stopped_ts": None,
     "last_stopped_ok": None,
     "last_stopped_error": None,
+    "last_playing_ts": None,
+    "last_playing_ok": None,
+    "last_playing_error": None,
     "register_retry_failures": 0,
     "next_register_retry_ts": None,
     "last_register_backoff_sec": 0.0,
+    # None until a session readback has been attempted; see _verify_registration.
+    "media_control_verified": None,
     "auth_user_configured": False,
     "authenticated": False,
     "auth_user": "",
@@ -84,6 +89,7 @@ _AUTH_SESSION_ID: str = ""
 _STOP_EVENT = threading.Event()
 _THREAD: threading.Thread | None = None
 _PROGRESS_PROVIDER = None
+_COMMAND_SINK = None
 _REGISTER_RETRY_FAILURES = 0
 _NEXT_REGISTER_RETRY_TS = 0.0
 _CATALOG_CACHE_LOCK = threading.Lock()
@@ -356,6 +362,7 @@ def start() -> None:
         _STATUS["register_retry_failures"] = 0
         _STATUS["next_register_retry_ts"] = None
         _STATUS["last_register_backoff_sec"] = 0.0
+        _STATUS["media_control_verified"] = None
         _REGISTER_RETRY_FAILURES = 0
         _NEXT_REGISTER_RETRY_TS = 0.0
         _LAST_STOPPED_SIGNATURE = ""
@@ -371,6 +378,7 @@ def start() -> None:
 
 def stop() -> None:
     _stop_worker()
+    _stop_control_socket()
     with _LOCK:
         _STATUS["running"] = False
         _STATUS["connected"] = False
@@ -467,7 +475,27 @@ def _status_with_sync_health(raw: dict[str, object]) -> dict[str, object]:
 
 def status() -> dict[str, object]:
     with _LOCK:
-        return _status_with_sync_health(_STATUS)
+        out = _status_with_sync_health(_STATUS)
+    # Merged outside the lock: the socket module reads this status, so holding
+    # ours while calling into it would invite a deadlock later.
+    return _with_control_socket_status(out)
+
+
+def _with_control_socket_status(out: dict[str, object]) -> dict[str, object]:
+    ws = _control_socket_status()
+    out["ws_enabled"] = bool(ws.get("enabled")) if ws else False
+    out["ws_available"] = bool(ws.get("available")) if ws else False
+    out["ws_connected"] = bool(ws.get("connected")) if ws else False
+    out["ws_last_connect_ts"] = ws.get("last_connect_ts") if ws else None
+    out["ws_last_error"] = ws.get("last_error") if ws else None
+    out["ws_reconnects"] = int(ws.get("reconnects") or 0) if ws else 0
+    out["ws_keepalive_sec"] = ws.get("keepalive_sec") if ws else None
+    out["ws_commands_received"] = int(ws.get("commands_received") or 0) if ws else 0
+    out["ws_commands_dropped"] = int(ws.get("commands_dropped") or 0) if ws else 0
+    # The one field that answers "can I cast to this device?": the server only
+    # offers a session that advertises media control *and* holds a live socket.
+    out["cast_target_ready"] = bool(out.get("media_control_verified")) and bool(out.get("ws_connected"))
+    return out
 
 
 def detect_server_type(server_url: str, *, timeout_sec: float = 3.0) -> dict[str, object]:
@@ -621,6 +649,7 @@ def connect(*, server_url: str, api_key: str | None = None, device_name: str | N
         _STATUS["register_retry_failures"] = 0
         _STATUS["next_register_retry_ts"] = None
         _STATUS["last_register_backoff_sec"] = 0.0
+        _STATUS["media_control_verified"] = None
         _STATUS["last_stopped_ts"] = None
         _STATUS["last_stopped_ok"] = None
         _STATUS["last_stopped_error"] = None
@@ -649,6 +678,7 @@ def disconnect() -> dict[str, object]:
     global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS, _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
     global _LAST_STOPPED_SIGNATURE, _LAST_STOPPED_TS
     _stop_worker()
+    _stop_control_socket()
     with _LOCK:
         _STATUS["running"] = False
         _STATUS["connected"] = False
@@ -660,6 +690,7 @@ def disconnect() -> dict[str, object]:
         _STATUS["register_retry_failures"] = 0
         _STATUS["next_register_retry_ts"] = None
         _STATUS["last_register_backoff_sec"] = 0.0
+        _STATUS["media_control_verified"] = None
         _ACCESS_TOKEN = ""
         _AUTH_USER_ID = ""
         _AUTH_SESSION_ID = ""
@@ -2335,6 +2366,29 @@ def register_progress_provider(fn) -> None:
     _PROGRESS_PROVIDER = fn
 
 
+def register_command_sink(fn) -> None:
+    """Register the callable that executes an inbound Jellyfin command.
+
+    Same seam as ``register_progress_provider``: this module stays transport
+    and never reaches into the routes package, so the socket hands normalized
+    commands back out to whoever owns playback control.
+    """
+    global _COMMAND_SINK
+    _COMMAND_SINK = fn
+
+
+def dispatch_command(action: str, payload: dict[str, object]) -> object:
+    """Run a socket-sourced command through the registered ingress."""
+    sink = _COMMAND_SINK
+    if sink is None:
+        raise RuntimeError("no jellyfin command sink registered")
+    return sink(action, payload)
+
+
+def command_sink_registered() -> bool:
+    return _COMMAND_SINK is not None
+
+
 def _build_url(path: str) -> str:
     st = status()
     base = str(st.get("server_url") or "").strip().rstrip("/")
@@ -2490,6 +2544,76 @@ def authenticate_once() -> dict[str, object]:
         return {"ok": False, "reason": "auth_failed", "error": msg}
 
 
+"""Commands advertised to the server, as ``GeneralCommandType`` members.
+
+Jellyfin has two disjoint command enums and rejects a body that mixes them.
+``Stop``/``Pause``/``Unpause``/``Seek``/``NextTrack``/``PreviousTrack`` are
+``PlaystateCommand`` values and arrive over the socket as a single ``Playstate``
+message, which ``PlayState`` here covers; listing them individually is a 400.
+
+Only commands RelayTV actually executes belong here. Advertising one without a
+handler puts a button on every Jellyfin remote in the house that does nothing.
+"""
+CAPABILITY_COMMANDS = (
+    "PlayState",
+    "Play",
+    "PlayNext",
+    "SetVolume",
+    "Mute",
+    "Unmute",
+    "ToggleMute",
+)
+
+CAPABILITY_MEDIA_TYPES = ("Video", "Audio")
+
+
+def capabilities_payload() -> dict[str, object]:
+    """The ``ClientCapabilitiesDto`` body, posted unwrapped.
+
+    Wrapping it as ``{"Capabilities": {...}}`` is accepted with a 204 and then
+    bound as an all-default DTO, which silently *erases* the session's
+    capabilities. Registration looked healthy for as long as that was the first
+    shape tried.
+    """
+    return {
+        "PlayableMediaTypes": list(CAPABILITY_MEDIA_TYPES),
+        "SupportedCommands": list(CAPABILITY_COMMANDS),
+        "SupportsMediaControl": True,
+        "SupportsPersistentIdentifier": True,
+    }
+
+
+def _capabilities_query(device_id: str) -> str:
+    q: list[tuple[str, str]] = [("id", device_id)]
+    q.extend(("playableMediaTypes", value) for value in CAPABILITY_MEDIA_TYPES)
+    q.extend(("supportedCommands", value) for value in CAPABILITY_COMMANDS)
+    q.append(("supportsMediaControl", "true"))
+    q.append(("supportsPersistentIdentifier", "true"))
+    return _urlparse.urlencode(q, doseq=True)
+
+
+def read_session_capabilities(device_id: str = "", *, timeout: float = 3.0) -> dict[str, object]:
+    """Ask the server what it recorded for this device's session.
+
+    A 204 from the capabilities POST is not evidence: the server returns one
+    whether or not the body bound to anything. Only the session readback tells
+    us media control is really advertised, so registration asserts on this.
+    """
+    did = str(device_id or status().get("device_id") or "").strip()
+    if not did:
+        return {}
+    url = _build_url(f"/Sessions?deviceId={_urlparse.quote(did)}")
+    if not url:
+        return {}
+    rows = _get_json(url, timeout=timeout, token=_active_token())
+    if not isinstance(rows, list):
+        return {}
+    for row in rows:
+        if isinstance(row, dict) and str(row.get("DeviceId") or "").strip() == did:
+            return row
+    return {}
+
+
 def register_receiver_once() -> dict[str, object]:
     st = status()
     if not bool(st.get("enabled")) or not bool(st.get("running")):
@@ -2497,69 +2621,53 @@ def register_receiver_once() -> dict[str, object]:
     base = str(st.get("server_url") or "").strip().rstrip("/")
     if not base:
         return {"ok": False, "reason": "no_server_url"}
-    payload_pascal = {
-        "PlayableMediaTypes": ["Video", "Audio"],
-        "SupportedCommands": ["Play", "Stop", "Pause", "Unpause", "Seek", "NextTrack", "PreviousTrack"],
-        "SupportsMediaControl": True,
-        "SupportsPersistentIdentifier": True,
-    }
-    payload_camel = {
-        "playableMediaTypes": ["Video", "Audio"],
-        "supportedCommands": ["Play", "Stop", "Pause", "Unpause", "Seek", "NextTrack", "PreviousTrack"],
-        "supportsMediaControl": True,
-        "supportsPersistentIdentifier": True,
-    }
     did = str(st.get("device_id") or "").strip()
-    q = [
-        ("id", did),
-        ("playableMediaTypes", "Video"),
-        ("playableMediaTypes", "Audio"),
-        ("supportedCommands", "Play"),
-        ("supportedCommands", "Stop"),
-        ("supportedCommands", "Pause"),
-        ("supportedCommands", "Unpause"),
-        ("supportedCommands", "Seek"),
-        ("supportedCommands", "NextTrack"),
-        ("supportedCommands", "PreviousTrack"),
-        ("supportsMediaControl", "true"),
-        ("supportsPersistentIdentifier", "true"),
-    ]
-    cap_qs = _urlparse.urlencode(q, doseq=True)
+    payload = capabilities_payload()
+    # The query-string form is what older Emby builds accept; it stays as a
+    # fallback so an Emby server that rejects the DTO body still registers.
     candidates: list[tuple[str, str, dict | None]] = [
-        ("full_wrapped", f"{base}/Sessions/Capabilities/Full", {"Capabilities": payload_pascal}),
-        ("full_wrapped_with_id", f"{base}/Sessions/Capabilities/Full?id={_urlparse.quote(did)}", {"Capabilities": payload_pascal}),
-        ("full_pascal", f"{base}/Sessions/Capabilities/Full", payload_pascal),
-        ("full_camel", f"{base}/Sessions/Capabilities/Full", payload_camel),
-        ("caps_query", f"{base}/Sessions/Capabilities?{cap_qs}", None),
+        ("full", f"{base}/Sessions/Capabilities/Full", payload),
+        ("caps_query", f"{base}/Sessions/Capabilities?{_capabilities_query(did)}", None),
     ]
     timeout = float(os.getenv("RELAYTV_JELLYFIN_REGISTER_TIMEOUT_SEC", "3"))
     last_err = "register_failed"
     last_name = ""
     last_url = ""
     try:
-        for name, url, payload in candidates:
+        for name, url, body in candidates:
             try:
-                if payload is None:
+                if body is None:
                     _post_no_body(url, timeout=timeout)
                 else:
-                    _post_json(url, payload, timeout=timeout)
-                with _LOCK:
-                    _STATUS["connected"] = True
-                    _STATUS["last_register_ts"] = int(time.time())
-                    _STATUS["last_register_ok"] = True
-                    _STATUS["last_register_error"] = None
-                    _STATUS["last_error"] = None
-                return {"ok": True, "url": url, "method": name}
+                    _post_json(url, body, timeout=timeout)
             except Exception as e:
                 last_err = _format_http_error(e)
                 last_name = name
                 last_url = url
+                continue
+
+            verified = _verify_registration(did, timeout=timeout)
+            if verified is False:
+                last_err = "server did not record media control for this session"
+                last_name = name
+                last_url = url
+                continue
+
+            with _LOCK:
+                _STATUS["connected"] = True
+                _STATUS["last_register_ts"] = int(time.time())
+                _STATUS["last_register_ok"] = True
+                _STATUS["last_register_error"] = None
+                _STATUS["last_error"] = None
+                _STATUS["media_control_verified"] = verified
+            return {"ok": True, "url": url, "method": name, "verified": verified}
         with _LOCK:
             _STATUS["connected"] = False
             _STATUS["last_register_ts"] = int(time.time())
             _STATUS["last_register_ok"] = False
             _STATUS["last_register_error"] = f"{last_name}: {last_err}"
             _STATUS["last_error"] = f"{last_name}: {last_err}"
+            _STATUS["media_control_verified"] = False
         return {"ok": False, "reason": "register_failed", "error": f"{last_name}: {last_err}", "url": last_url}
     except Exception as e:
         msg = _format_http_error(e)
@@ -2570,6 +2678,22 @@ def register_receiver_once() -> dict[str, object]:
             _STATUS["last_register_error"] = msg
             _STATUS["last_error"] = msg
         return {"ok": False, "reason": "register_failed", "error": msg}
+
+
+def _verify_registration(device_id: str, *, timeout: float) -> bool | None:
+    """True if the server advertises media control, False if it does not.
+
+    ``None`` means the readback itself failed — a server that hides ``/Sessions``
+    behind a proxy or an Emby build shaped differently should not be treated as
+    a registration failure, so the caller accepts the POST on its own terms.
+    """
+    try:
+        session = read_session_capabilities(device_id, timeout=timeout)
+    except Exception:
+        return None
+    if not session:
+        return None
+    return bool(session.get("SupportsMediaControl"))
 
 
 def _register_retry_enabled() -> bool:
@@ -2630,6 +2754,38 @@ def _ensure_registration(now_ts: float | None = None) -> None:
     _schedule_register_retry(now_val, failures, delay)
 
 
+def _ensure_control_socket() -> None:
+    """Keep the cast-target socket up. Imported late to avoid an import cycle."""
+    try:
+        from . import jellyfin_ws
+    except Exception:
+        return
+    try:
+        jellyfin_ws.ensure_running()
+    except Exception:
+        pass
+
+
+def _stop_control_socket() -> None:
+    try:
+        from . import jellyfin_ws
+    except Exception:
+        return
+    try:
+        jellyfin_ws.stop()
+    except Exception:
+        pass
+
+
+def _control_socket_status() -> dict[str, object]:
+    try:
+        from . import jellyfin_ws
+
+        return jellyfin_ws.status()
+    except Exception:
+        return {}
+
+
 def _ensure_authentication() -> None:
     if not runtime_config.snapshot().flag("RELAYTV_JELLYFIN_AUTH_ENABLED", True):
         return
@@ -2641,6 +2797,39 @@ def _ensure_authentication() -> None:
     if not bool(st.get("auth_user_configured")):
         return
     authenticate_once()
+
+
+def send_playback_start_once(payload: dict | None = None) -> dict[str, object]:
+    """Report playback start to ``/Sessions/Playing``.
+
+    Progress alone eventually populates the session, but only on the next
+    heartbeat tick. Announcing the start means the phone that just cast shows
+    the item as playing straight away instead of an empty remote for a few
+    seconds.
+    """
+    st = status()
+    if not bool(st.get("enabled")) or not bool(st.get("running")):
+        return {"ok": False, "reason": "disabled"}
+    body = payload if isinstance(payload, dict) else {}
+    if not body:
+        return {"ok": False, "reason": "no_payload"}
+    url = _build_url(os.getenv("RELAYTV_JELLYFIN_PLAYING_PATH", "/Sessions/Playing"))
+    if not url:
+        return {"ok": False, "reason": "no_server_url"}
+    try:
+        _post_json(url, body, timeout=float(os.getenv("RELAYTV_JELLYFIN_PROGRESS_TIMEOUT_SEC", "3")))
+    except Exception as e:
+        msg = _format_http_error(e)
+        with _LOCK:
+            _STATUS["last_playing_ts"] = int(time.time())
+            _STATUS["last_playing_ok"] = False
+            _STATUS["last_playing_error"] = msg
+        return {"ok": False, "reason": "playing_failed", "error": msg}
+    with _LOCK:
+        _STATUS["last_playing_ts"] = int(time.time())
+        _STATUS["last_playing_ok"] = True
+        _STATUS["last_playing_error"] = None
+    return {"ok": True}
 
 
 def send_progress_payload_once(payload: dict | None = None) -> dict[str, object]:
@@ -2741,6 +2930,7 @@ def _heartbeat_worker() -> None:
             _ensure_authentication()
             send_progress_once()
             _ensure_registration()
+            _ensure_control_socket()
             _maybe_retry_detection()
         except Exception:
             pass

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -245,6 +245,22 @@ def _mark_catalog_error(msg: str) -> None:
         _STATUS["catalog_last_error"] = text or None
 
 
+def derive_device_id(device_name: str) -> str:
+    """The Jellyfin DeviceId for a given display name.
+
+    Every path that sets the name must agree on this. Startup used to append
+    the hostname and the rename paths did not, so renaming a device at runtime
+    and then restarting produced two DeviceIds for one TV — and Jellyfin keys
+    sessions, capabilities, and playback history on DeviceId, so the cast list
+    grew a duplicate.
+    """
+    override = (os.getenv("RELAYTV_JELLYFIN_DEVICE_ID") or "").strip()
+    if override:
+        return override
+    slug = str(device_name or "RelayTV").strip().lower().replace(" ", "-") or "relaytv"
+    return f"relaytv-{slug}-{platform.node() or 'host'}".strip()
+
+
 def _read_config() -> dict[str, object]:
     configured_name = ""
     configured_server_type = ""
@@ -272,7 +288,7 @@ def _read_config() -> dict[str, object]:
         "enabled": runtime_config.snapshot().flag("RELAYTV_JELLYFIN_ENABLED", False),
         "server_url": (runtime_config.snapshot().raw("RELAYTV_JELLYFIN_SERVER_URL") or "").strip(),
         "device_name": device_name,
-        "device_id": (os.getenv("RELAYTV_JELLYFIN_DEVICE_ID") or f"relaytv-{device_name.lower().replace(' ', '-')}-{platform.node() or 'host'}").strip(),
+        "device_id": derive_device_id(device_name),
         "client_name": (runtime_config.snapshot().raw("RELAYTV_JELLYFIN_CLIENT_NAME") or device_name).strip() or device_name,
         "client_version": (os.getenv("RELAYTV_JELLYFIN_CLIENT_VERSION") or "1.0").strip() or "1.0",
         "heartbeat_sec": max(2, int(float(os.getenv("RELAYTV_JELLYFIN_HEARTBEAT_SEC") or "5"))),
@@ -611,7 +627,7 @@ def connect(*, server_url: str, api_key: str | None = None, device_name: str | N
         if device_name is not None:
             _STATUS["device_name"] = str(device_name or "").strip() or "RelayTV"
             _STATUS["client_name"] = str(_STATUS["device_name"])
-            _STATUS["device_id"] = f"relaytv-{_STATUS['device_name'].lower().replace(' ', '-')}"
+            _STATUS["device_id"] = derive_device_id(str(_STATUS["device_name"]))
         if heartbeat_sec is not None:
             _STATUS["heartbeat_sec"] = max(2, int(heartbeat_sec))
         if api_key is not None:
@@ -716,7 +732,7 @@ def set_device_identity(name: str) -> dict[str, object]:
     with _LOCK:
         _STATUS["device_name"] = clean
         _STATUS["client_name"] = clean
-        _STATUS["device_id"] = f"relaytv-{clean.lower().replace(' ', '-')}"
+        _STATUS["device_id"] = derive_device_id(clean)
         # Identity changed, drop session token and force fresh auth/register.
         global _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
         _ACCESS_TOKEN = ""

--- a/app/relaytv_app/integrations/jellyfin_service.py
+++ b/app/relaytv_app/integrations/jellyfin_service.py
@@ -285,10 +285,28 @@ def normalize_action(action: str | None, payload: dict | None) -> str:
         "unmuteaudio": "unmute",
         "pauseplayback": "pause",
         "resumeback": "resume",
+        "unpause": "resume",
         "unpauseplayback": "resume",
         "resumeplayback": "resume",
+        # The single button on the Jellyfin remote; the client sends one
+        # command for both directions and expects the device to decide.
+        "playpause": "play_pause",
+        "togglepause": "play_pause",
     }
     return aliases.get(raw, raw)
+
+
+def playback_is_paused() -> bool:
+    """Current pause state, for resolving a PlayPause toggle."""
+    try:
+        if not bool(player.is_playing()):
+            return True
+        props = player.mpv_get_many(["pause"])
+    except Exception:
+        return False
+    if isinstance(props, dict) and props.get("pause") is not None:
+        return bool(props.get("pause"))
+    return str(getattr(state, "SESSION_STATE", "") or "").strip().lower() == "paused"
 
 
 def ticks_to_seconds(value: object) -> float | None:
@@ -1626,6 +1644,34 @@ def emit_progress_hint() -> None:
         pass
 
 
+def emit_playback_start_hint() -> None:
+    """Announce playback start, then the first progress tick, off the request path.
+
+    Ordering matters: Jellyfin builds the session's now-playing item from the
+    start report, so a progress post that beats it describes an item the server
+    does not think is playing yet.
+    """
+    def _run() -> None:
+        try:
+            payload = progress_snapshot()
+        except Exception:
+            payload = None
+        if isinstance(payload, dict) and payload:
+            try:
+                jellyfin_receiver.send_playback_start_once(payload)
+            except Exception:
+                pass
+        try:
+            jellyfin_receiver.send_progress_once()
+        except Exception:
+            pass
+
+    try:
+        threading.Thread(target=_run, daemon=True, name="relaytv-jellyfin-start-hint").start()
+    except Exception:
+        pass
+
+
 def _require_current_jellyfin_item() -> tuple[dict, str]:
     """Return (now_playing, item_id) for the active Jellyfin item or raise 409/502."""
     now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
@@ -2163,6 +2209,16 @@ def emit_stopped_hint(position_sec: float | None = None, duration_sec: float | N
     emit_stopped_payload(stopped_snapshot(position_sec, duration_sec))
 
 
+def play_method(now: dict | None) -> str:
+    """Report how the stream is being served, in Jellyfin's PlayMethod terms.
+
+    RelayTV always pulls a server-produced stream URL rather than the original
+    file, so a direct stream is ``DirectStream``, never ``DirectPlay``.
+    """
+    mode = str((now or {}).get("jellyfin_stream_mode") or "").strip().lower()
+    return "Transcode" if mode == "transcode" else "DirectStream"
+
+
 def progress_snapshot() -> dict | None:
     now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
     if not now:
@@ -2201,6 +2257,10 @@ def progress_snapshot() -> dict | None:
     payload = {
         "ItemId": item_id,
         "IsPaused": bool(props.get("pause")) if is_playing and isinstance(props, dict) else (not is_playing),
+        # Without CanSeek the remote renders a read-only progress bar: the
+        # scrubber cannot be dragged and Jellyfin will not send Seek at all.
+        "CanSeek": True,
+        "PlayMethod": play_method(now),
     }
     play_session_id = str(now.get("jellyfin_play_session_id") or "").strip()
     if play_session_id:
@@ -2982,7 +3042,7 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict):
                     ui["queue_event"]("jellyfin_playlist", queue=queue_snapshot, queue_length=len(queue_snapshot), source="jellyfin")
             if isinstance(stopped_payload, dict) and stopped_payload:
                 emit_stopped_payload(stopped_payload)
-            emit_progress_hint()
+            emit_playback_start_hint()
             ui["jellyfin_event"]("play", refresh_active_tab=True, refresh_status=True, reason=play_mode or "play")
             return {"ok": True, "action": "play", "now_playing": now}
 
@@ -2997,6 +3057,18 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict):
 
         if action in ("resume", "unpause"):
             out = {"ok": True, "action": "resume", "result": controls["resume"]()}
+            emit_progress_hint()
+            return out
+
+        if action == "play_pause":
+            paused = playback_is_paused()
+            resolved = "resume" if paused else "pause"
+            out = {
+                "ok": True,
+                "action": resolved,
+                "toggled_from": "play_pause",
+                "result": controls["resume"]() if paused else controls["pause"](),
+            }
             emit_progress_hint()
             return out
 

--- a/app/relaytv_app/integrations/jellyfin_service.py
+++ b/app/relaytv_app/integrations/jellyfin_service.py
@@ -2244,7 +2244,15 @@ def progress_snapshot() -> dict | None:
     if not item_id:
         return None
     is_playing = bool(player.is_playing())
-    props = player.mpv_get_many(["pause", "time-pos", "duration", "mute", "volume"]) if is_playing else {}
+    if not is_playing:
+        # RelayTV keeps the last item in NOW_PLAYING so its own UI can resume
+        # it, but the Jellyfin session is over: the stopped report already
+        # carried the final position. Posting progress anyway re-creates the
+        # session's NowPlayingItem seconds after Stop cleared it, leaving a
+        # stale "paused" entry on every remote until something else plays.
+        # Pausing does not reach here — a paused mpv still reports playing.
+        return None
+    props = player.mpv_get_many(["pause", "time-pos", "duration", "mute", "volume"])
 
     pos = props.get("time-pos") if isinstance(props, dict) else None
     dur = props.get("duration") if isinstance(props, dict) else None
@@ -2273,7 +2281,7 @@ def progress_snapshot() -> dict | None:
     pos_ticks = max(0, int(pos_f * 10_000_000))
     payload = {
         "ItemId": item_id,
-        "IsPaused": bool(props.get("pause")) if is_playing and isinstance(props, dict) else (not is_playing),
+        "IsPaused": bool(props.get("pause")) if isinstance(props, dict) else False,
         # Without CanSeek the remote renders a read-only progress bar: the
         # scrubber cannot be dragged and Jellyfin will not send Seek at all.
         "CanSeek": True,

--- a/app/relaytv_app/integrations/jellyfin_service.py
+++ b/app/relaytv_app/integrations/jellyfin_service.py
@@ -288,12 +288,20 @@ def normalize_action(action: str | None, payload: dict | None) -> str:
         "unpause": "resume",
         "unpauseplayback": "resume",
         "resumeplayback": "resume",
-        # The single button on the Jellyfin remote; the client sends one
-        # command for both directions and expects the device to decide.
+        # Single buttons on the Jellyfin remote: the client sends one command
+        # for both directions and expects the device to decide which way.
         "playpause": "play_pause",
         "togglepause": "play_pause",
+        "togglemute": "toggle_mute",
+        "fastforward": "fast_forward",
     }
     return aliases.get(raw, raw)
+
+
+# Advertising PlayState authorizes the server to send any PlaystateCommand,
+# including the skip pair. These match Jellyfin's own client defaults.
+SKIP_BACK_SEC = 10.0
+SKIP_FORWARD_SEC = 30.0
 
 
 def playback_is_paused() -> bool:
@@ -307,6 +315,15 @@ def playback_is_paused() -> bool:
     if isinstance(props, dict) and props.get("pause") is not None:
         return bool(props.get("pause"))
     return str(getattr(state, "SESSION_STATE", "") or "").strip().lower() == "paused"
+
+
+def playback_is_muted() -> bool:
+    """Current mute state, for resolving a ToggleMute command."""
+    try:
+        props = player.mpv_get_many(["mute"])
+    except Exception:
+        return False
+    return bool(props.get("mute")) if isinstance(props, dict) else False
 
 
 def ticks_to_seconds(value: object) -> float | None:
@@ -3080,6 +3097,12 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict):
             emit_progress_hint()
             return out
 
+        if action in ("rewind", "fast_forward"):
+            delta = SKIP_FORWARD_SEC if action == "fast_forward" else -SKIP_BACK_SEC
+            out = {"ok": True, "action": action, "seconds": delta, "result": controls["seek_relative"](delta)}
+            emit_progress_hint()
+            return out
+
         if action == "next":
             out = {"ok": True, "action": "next", "result": controls["next"]()}
             emit_progress_hint()
@@ -3105,6 +3128,17 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict):
 
         if action == "unmute":
             out = {"ok": True, "action": "unmute", "result": controls["mute"](False)}
+            emit_progress_hint()
+            return out
+
+        if action == "toggle_mute":
+            muted = playback_is_muted()
+            out = {
+                "ok": True,
+                "action": "unmute" if muted else "mute",
+                "toggled_from": "toggle_mute",
+                "result": controls["mute"](not muted),
+            }
             emit_progress_hint()
             return out
 

--- a/app/relaytv_app/integrations/jellyfin_ws.py
+++ b/app/relaytv_app/integrations/jellyfin_ws.py
@@ -60,6 +60,9 @@ _DEFAULT_KEEPALIVE_SEC = 60.0
 # replays minutes later.
 _COMMAND_QUEUE_MAX = 32
 
+# Closing handshake budget, well under the library's 10s default.
+_CLOSE_TIMEOUT_SEC = 2.0
+
 _LOCK = threading.Lock()
 
 
@@ -271,6 +274,39 @@ def _read_loop(ws, session: _Session) -> None:
             next_keepalive = time.monotonic() + keepalive
 
 
+def _claim(session: _Session, ws) -> bool:
+    """Attach a freshly dialled socket, if this generation is still the live one.
+
+    ``_STATE`` is shared across generations, so only the current one may write
+    to it — otherwise a late handshake reports "connected" for a session that
+    has already been replaced.
+    """
+    with _LOCK:
+        if _CURRENT is not session:
+            return False
+        session.ws = ws
+        _STATE["connected"] = True
+        _STATE["last_connect_ts"] = int(time.time())
+        _STATE["last_error"] = None
+        return True
+
+
+def _release(session: _Session) -> None:
+    with _LOCK:
+        session.ws = None
+        if _CURRENT is session:
+            _STATE["connected"] = False
+
+
+def _close_quietly(ws) -> None:
+    if ws is None:
+        return
+    try:
+        ws.close()
+    except Exception:
+        pass
+
+
 def _connect_once(session: _Session) -> None:
     st = jellyfin_receiver.status()
     url = socket_url(
@@ -282,6 +318,10 @@ def _connect_once(session: _Session) -> None:
         raise RuntimeError("jellyfin socket not configured")
     kwargs: dict[str, object] = {
         "open_timeout": _env_float("RELAYTV_JELLYFIN_WS_CONNECT_TIMEOUT_SEC", 8.0),
+        # The library default is 10s of closing handshake. stop() runs on the
+        # thread saving settings or shutting the app down, so a server that has
+        # already gone away must not hold either of those for ten seconds.
+        "close_timeout": _CLOSE_TIMEOUT_SEC,
         "max_size": 2**20,
     }
     if _PROXY_KWARG_SUPPORTED:
@@ -289,12 +329,15 @@ def _connect_once(session: _Session) -> None:
         # media-server connection through an unrelated proxy.
         kwargs["proxy"] = None
     ws = _ws_connect(url, **kwargs)
-    session.ws = ws
+    # The handshake can take seconds, during which session.ws is None and a
+    # stop() cannot reach this connection. If the session was retired while we
+    # were dialling, drop the socket here: letting it proceed would publish
+    # status and re-assert registration on behalf of a generation that no
+    # longer owns them, corrupting whichever generation replaced it.
+    if session.stop.is_set() or not _claim(session, ws):
+        _close_quietly(ws)
+        return
     try:
-        with _LOCK:
-            _STATE["connected"] = True
-            _STATE["last_connect_ts"] = int(time.time())
-            _STATE["last_error"] = None
         logger.info("jellyfin_ws_connected device_id=%s", st.get("device_id"))
         # A new socket means a new session on the server. Capabilities live in
         # its session state and do not survive a restart, so re-assert them
@@ -303,13 +346,8 @@ def _connect_once(session: _Session) -> None:
         jellyfin_receiver.invalidate_registration("socket_connected")
         _read_loop(ws, session)
     finally:
-        session.ws = None
-        with _LOCK:
-            _STATE["connected"] = False
-        try:
-            ws.close()
-        except Exception:
-            pass
+        _release(session)
+        _close_quietly(ws)
 
 
 def _socket_worker(session: _Session) -> None:
@@ -413,14 +451,15 @@ def stop() -> None:
         return
     session.stop.set()
     # Closing the live connection is what makes this prompt: a reader parked in
-    # recv() would otherwise sit there for the rest of its timeout, and joining
-    # past that would stall every caller of stop().
+    # recv() would otherwise sit there for the rest of its timeout. The close
+    # itself is a handshake with a server that may already be gone, so it runs
+    # off to the side — stop() is called from settings saves and shutdown, and
+    # its cost must stay the bounded joins below, nothing more.
     ws = session.ws
     if ws is not None:
-        try:
-            ws.close()
-        except Exception:
-            pass
+        threading.Thread(
+            target=_close_quietly, args=(ws,), daemon=True, name="relaytv-jellyfin-ws-close"
+        ).start()
     for t in (session.reader, session.worker):
         if t is not None and t.is_alive():
             t.join(timeout=2.0)

--- a/app/relaytv_app/integrations/jellyfin_ws.py
+++ b/app/relaytv_app/integrations/jellyfin_ws.py
@@ -13,6 +13,7 @@ package registers. No playback logic lives here.
 """
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import inspect
 import json
@@ -87,6 +88,19 @@ class _Session:
 
 
 _CURRENT: _Session | None = None
+
+# Serializes start and stop against each other. ``stop()`` spends seconds
+# joining, and for that whole time _CURRENT is None — without this the
+# heartbeat's ensure_running() walks straight into the gap and starts a
+# replacement that the in-flight stop() then resets.
+_LIFECYCLE = threading.RLock()
+
+# Non-zero while a caller is rewriting the configuration the socket dials with.
+# Serializing alone is not enough there: a start that merely waits for stop()
+# still connects to the outgoing server, because the new settings are not
+# installed yet.
+_SUSPENDED = 0
+
 _STATE: dict[str, object] = {
     "connected": False,
     "last_connect_ts": None,
@@ -109,12 +123,16 @@ def _reset_state() -> None:
         _STATE["commands_dropped"] = 0
 
 
-def _mark_error(msg: object) -> None:
+def _mark_error(msg: object, *, session: "_Session | None" = None) -> None:
     # Everything routes through the receiver's sanitizer: the socket URL carries
     # the Jellyfin access token as ``api_key``, and a failed handshake reports
     # the URL it tried.
     text = jellyfin_receiver._sanitize_error_text(msg)
     with _LOCK:
+        # ``_STATE`` is shared across generations; a retired one must not
+        # report on it. Callers with no session in hand are explicit callers.
+        if session is not None and (_CURRENT is not session or session.stop.is_set()):
+            return
         _STATE["last_error"] = text or None
 
 
@@ -241,7 +259,7 @@ def _command_worker(session: _Session) -> None:
         try:
             jellyfin_receiver.dispatch_command(action, payload)
         except Exception as e:
-            _mark_error(e)
+            _mark_error(e, session=session)
             logger.warning("jellyfin_ws_command_failed action=%s err=%s", action or "playstate", jellyfin_receiver._sanitize_error_text(e))
 
 
@@ -361,10 +379,20 @@ def _socket_worker(session: _Session) -> None:
             failures = 0
         except Exception as e:
             failures += 1
-            _mark_error(e)
+            # A dial that fails after this generation was retired is reporting
+            # on a server nobody is talking to any more; letting it write here
+            # would pin someone else's ws_last_error to a dead address.
             with _LOCK:
-                _STATE["reconnects"] = int(_STATE.get("reconnects") or 0) + 1
-            logger.warning("jellyfin_ws_disconnected failures=%d err=%s", failures, jellyfin_receiver._sanitize_error_text(e))
+                owned = _CURRENT is session and not session.stop.is_set()
+                if owned:
+                    _STATE["reconnects"] = int(_STATE.get("reconnects") or 0) + 1
+                    _STATE["last_error"] = jellyfin_receiver._sanitize_error_text(e) or None
+            logger.warning(
+                "jellyfin_ws_disconnected failures=%d owned=%s err=%s",
+                failures,
+                owned,
+                jellyfin_receiver._sanitize_error_text(e),
+            )
         if session.stop.is_set():
             break
         try:
@@ -409,19 +437,48 @@ def ensure_running() -> None:
     """
     if not enabled() or _ws_connect is None:
         return
-    identity = _identity()
-    if identity is None:
-        return
-    with _LOCK:
-        session = _CURRENT
-        alive = session is not None and session.reader is not None and session.reader.is_alive()
-        if alive and session.bound == identity:
+    # Held for the whole decision *and* the act. Checking under one lock and
+    # starting under another is how the heartbeat used to slip a socket into
+    # the middle of a stop().
+    with _LIFECYCLE:
+        if _SUSPENDED:
             return
-        stale = alive
-    if stale:
-        logger.info("jellyfin_ws_restart reason=identity_changed")
-        stop()
-    _start(identity)
+        identity = _identity()
+        if identity is None:
+            return
+        with _LOCK:
+            session = _CURRENT
+            alive = session is not None and session.reader is not None and session.reader.is_alive()
+            if alive and session.bound == identity:
+                return
+            stale = alive
+        if stale:
+            logger.info("jellyfin_ws_restart reason=identity_changed")
+            stop()
+        _start(identity)
+
+
+@contextlib.contextmanager
+def suspended():
+    """Hold the socket down for the length of a configuration change.
+
+    Stopping and then rewriting settings is not enough on its own: the
+    heartbeat runs every few seconds, and one that fires between the two starts
+    a socket to the server being replaced. Callers that change what the socket
+    dials with must wrap the whole transaction.
+    """
+    global _SUSPENDED
+    with _LIFECYCLE:
+        _SUSPENDED += 1
+        try:
+            stop()
+        except Exception:
+            logger.warning("jellyfin_ws_suspend_stop_failed")
+    try:
+        yield
+    finally:
+        with _LIFECYCLE:
+            _SUSPENDED = max(0, _SUSPENDED - 1)
 
 
 def _start(identity: tuple[str, str, str]) -> None:
@@ -443,12 +500,18 @@ def _start(identity: tuple[str, str, str]) -> None:
 
 def stop() -> None:
     global _CURRENT
-    with _LOCK:
-        session = _CURRENT
-        _CURRENT = None
-    if session is None:
-        _reset_state()
-        return
+    with _LIFECYCLE:
+        with _LOCK:
+            session = _CURRENT
+            _CURRENT = None
+        if session is None:
+            _reset_state()
+            return
+        _stop_session(session)
+
+
+def _stop_session(session: _Session) -> None:
+    """Retire one generation. Call with ``_LIFECYCLE`` held."""
     session.stop.set()
     # Closing the live connection is what makes this prompt: a reader parked in
     # recv() would otherwise sit there for the rest of its timeout. The close

--- a/app/relaytv_app/integrations/jellyfin_ws.py
+++ b/app/relaytv_app/integrations/jellyfin_ws.py
@@ -13,6 +13,8 @@ package registers. No playback logic lives here.
 """
 from __future__ import annotations
 
+import hashlib
+import inspect
 import json
 import queue
 import threading
@@ -31,6 +33,24 @@ except Exception:  # pragma: no cover - dependency may be optional in some envs
 
 logger = get_logger("jellyfin_ws")
 
+
+def _supports_proxy_kwarg() -> bool:
+    """Whether this websockets build accepts ``proxy``.
+
+    Added in websockets 15.0. pyproject requires that floor, but a distro or
+    transitive install can still land 13/14, where passing it is a TypeError on
+    every single connection. Feature-detect rather than fail closed.
+    """
+    if _ws_connect is None:
+        return False
+    try:
+        return "proxy" in inspect.signature(_ws_connect).parameters
+    except Exception:
+        return False
+
+
+_PROXY_KWARG_SUPPORTED = _supports_proxy_kwarg()
+
 # The server tells us its keepalive period on connect (``ForceKeepAlive``);
 # this is only what we assume until it does.
 _DEFAULT_KEEPALIVE_SEC = 60.0
@@ -41,10 +61,29 @@ _DEFAULT_KEEPALIVE_SEC = 60.0
 _COMMAND_QUEUE_MAX = 32
 
 _LOCK = threading.Lock()
-_THREAD: threading.Thread | None = None
-_WORKER: threading.Thread | None = None
-_STOP = threading.Event()
-_COMMANDS: queue.Queue | None = None
+
+
+class _Session:
+    """One generation of the socket: its threads, its queue, its own stop flag.
+
+    The stop flag must not be shared between generations. ``stop()`` cannot
+    always join a reader that is parked in ``recv``, so an old thread can
+    outlive the call; with a module-level event, the next ``ensure_running``
+    would clear the flag out from under it and the zombie would carry on
+    dispatching commands from a server nobody is talking to any more. An event
+    owned by the generation can only ever be set, never un-set.
+    """
+
+    def __init__(self, bound: tuple[str, str, str]):
+        self.stop = threading.Event()
+        self.commands: queue.Queue = queue.Queue(maxsize=_COMMAND_QUEUE_MAX)
+        self.bound = bound
+        self.ws = None
+        self.reader: threading.Thread | None = None
+        self.worker: threading.Thread | None = None
+
+
+_CURRENT: _Session | None = None
 _STATE: dict[str, object] = {
     "connected": False,
     "last_connect_ts": None,
@@ -161,15 +200,16 @@ def _keepalive_interval(force_keepalive_data: object) -> float:
 def backoff_sec(failures: int) -> float:
     base = max(0.5, _env_float("RELAYTV_JELLYFIN_WS_RETRY_BASE_SEC", 3.0))
     cap = max(base, _env_float("RELAYTV_JELLYFIN_WS_RETRY_MAX_SEC", 60.0))
-    return min(cap, base * (2 ** max(0, int(failures) - 1)))
+    # Clamp the exponent, not just the result. A server that stays down keeps
+    # incrementing the failure count, and 2**1024 overflows the float multiply
+    # long before the cap is applied — about 17 hours in at the default delay.
+    steps = max(0, min(int(failures) - 1, 32))
+    return min(cap, base * (2**steps))
 
 
-def _submit(action: str, payload: dict[str, object]) -> None:
-    q = _COMMANDS
-    if q is None:
-        return
+def _submit(session: _Session, action: str, payload: dict[str, object]) -> None:
     try:
-        q.put_nowait((action, payload))
+        session.commands.put_nowait((action, payload))
         with _LOCK:
             _STATE["commands_received"] = int(_STATE.get("commands_received") or 0) + 1
     except queue.Full:
@@ -178,21 +218,21 @@ def _submit(action: str, payload: dict[str, object]) -> None:
         logger.warning("jellyfin_ws_command_dropped backlog_full action=%s", action or "playstate")
 
 
-def _command_worker() -> None:
+def _command_worker(session: _Session) -> None:
     """Run commands off the reader thread.
 
     Starting mpv takes several seconds (6-12s on a Pi). Executing a Play on the
     reader would stall keepalives long enough for the server to drop the
     session mid-handoff, so the reader only enqueues.
     """
-    while not _STOP.is_set():
-        q = _COMMANDS
-        if q is None:
-            _STOP.wait(0.2)
-            continue
+    while not session.stop.is_set():
         try:
-            item = q.get(timeout=0.5)
+            item = session.commands.get(timeout=0.5)
         except queue.Empty:
+            continue
+        if session.stop.is_set():
+            # Stopped while this was queued: the command belongs to a session
+            # that is over, and running it now would act on the wrong server.
             continue
         action, payload = item
         try:
@@ -202,10 +242,10 @@ def _command_worker() -> None:
             logger.warning("jellyfin_ws_command_failed action=%s err=%s", action or "playstate", jellyfin_receiver._sanitize_error_text(e))
 
 
-def _read_loop(ws) -> None:
+def _read_loop(ws, session: _Session) -> None:
     keepalive = _DEFAULT_KEEPALIVE_SEC / 2.0
     next_keepalive = time.monotonic() + keepalive
-    while not _STOP.is_set():
+    while not session.stop.is_set():
         timeout = max(0.2, min(5.0, next_keepalive - time.monotonic()))
         try:
             raw = ws.recv(timeout=timeout)
@@ -225,13 +265,13 @@ def _read_loop(ws) -> None:
             else:
                 routed = normalize_message(envelope)
                 if routed is not None:
-                    _submit(routed[0], routed[1])
+                    _submit(session, routed[0], routed[1])
         if time.monotonic() >= next_keepalive:
             ws.send(json.dumps({"MessageType": "KeepAlive"}))
             next_keepalive = time.monotonic() + keepalive
 
 
-def _connect_once() -> None:
+def _connect_once(session: _Session) -> None:
     st = jellyfin_receiver.status()
     url = socket_url(
         server_url=str(st.get("server_url") or ""),
@@ -240,10 +280,17 @@ def _connect_once() -> None:
     )
     if not url:
         raise RuntimeError("jellyfin socket not configured")
-    open_timeout = _env_float("RELAYTV_JELLYFIN_WS_CONNECT_TIMEOUT_SEC", 8.0)
-    # proxy=None: websockets 15+ honours HTTP_PROXY by default, which would send
-    # a LAN media-server connection through an unrelated proxy.
-    with _ws_connect(url, open_timeout=open_timeout, proxy=None, max_size=2**20) as ws:
+    kwargs: dict[str, object] = {
+        "open_timeout": _env_float("RELAYTV_JELLYFIN_WS_CONNECT_TIMEOUT_SEC", 8.0),
+        "max_size": 2**20,
+    }
+    if _PROXY_KWARG_SUPPORTED:
+        # websockets 15+ honours HTTP_PROXY by default, which would route a LAN
+        # media-server connection through an unrelated proxy.
+        kwargs["proxy"] = None
+    ws = _ws_connect(url, **kwargs)
+    session.ws = ws
+    try:
         with _LOCK:
             _STATE["connected"] = True
             _STATE["last_connect_ts"] = int(time.time())
@@ -254,21 +301,25 @@ def _connect_once() -> None:
         # rather than trusting a registration that succeeded against the
         # server instance that just went away.
         jellyfin_receiver.invalidate_registration("socket_connected")
+        _read_loop(ws, session)
+    finally:
+        session.ws = None
+        with _LOCK:
+            _STATE["connected"] = False
         try:
-            _read_loop(ws)
-        finally:
-            with _LOCK:
-                _STATE["connected"] = False
+            ws.close()
+        except Exception:
+            pass
 
 
-def _socket_worker() -> None:
+def _socket_worker(session: _Session) -> None:
     failures = 0
-    while not _STOP.is_set():
+    while not session.stop.is_set():
         if not _ready():
-            _STOP.wait(2.0)
+            session.stop.wait(2.0)
             continue
         try:
-            _connect_once()
+            _connect_once(session)
             failures = 0
         except Exception as e:
             failures += 1
@@ -276,52 +327,101 @@ def _socket_worker() -> None:
             with _LOCK:
                 _STATE["reconnects"] = int(_STATE.get("reconnects") or 0) + 1
             logger.warning("jellyfin_ws_disconnected failures=%d err=%s", failures, jellyfin_receiver._sanitize_error_text(e))
-        if _STOP.is_set():
+        if session.stop.is_set():
             break
-        _STOP.wait(backoff_sec(failures) if failures else 1.0)
+        try:
+            delay = backoff_sec(failures) if failures else 1.0
+        except Exception:
+            delay = 60.0
+        session.stop.wait(delay)
 
 
 def _ready() -> bool:
     """Only dial once there is a session worth attaching a socket to."""
+    return bool(_identity())
+
+
+def _identity() -> tuple[str, str, str] | None:
+    """What this device would connect as right now, or None if it cannot.
+
+    The token is fingerprinted rather than kept: this value is only ever
+    compared, and a secret that is never stored cannot leak from a comparison.
+    """
     st = jellyfin_receiver.status()
     if not bool(st.get("enabled")) or not bool(st.get("running")):
-        return False
-    if not str(st.get("server_url") or "").strip():
-        return False
-    if not str(st.get("device_id") or "").strip():
-        return False
-    if not jellyfin_receiver.active_token():
-        return False
-    return jellyfin_receiver.command_sink_registered()
+        return None
+    server_url = str(st.get("server_url") or "").strip()
+    device_id = str(st.get("device_id") or "").strip()
+    token = jellyfin_receiver.active_token()
+    if not server_url or not device_id or not token:
+        return None
+    if not jellyfin_receiver.command_sink_registered():
+        return None
+    fingerprint = hashlib.sha256(token.encode("utf-8", "ignore")).hexdigest()[:16]
+    return (server_url, device_id, fingerprint)
 
 
 def ensure_running() -> None:
-    """Start the socket threads if they should be up and are not."""
-    global _THREAD, _WORKER, _COMMANDS
+    """Start the socket if it should be up, or restart it if it is stale.
+
+    A socket is bound to the server, device identity, and token it dialled
+    with. Changing any of them in settings leaves the old socket attached to
+    the old server, still receiving playback commands, while the new session
+    has nothing listening — so drift is a restart, not a no-op.
+    """
     if not enabled() or _ws_connect is None:
         return
-    if not _ready():
+    identity = _identity()
+    if identity is None:
         return
     with _LOCK:
-        if _THREAD is not None and _THREAD.is_alive():
+        session = _CURRENT
+        alive = session is not None and session.reader is not None and session.reader.is_alive()
+        if alive and session.bound == identity:
             return
-        _STOP.clear()
-        _COMMANDS = queue.Queue(maxsize=_COMMAND_QUEUE_MAX)
-        _WORKER = threading.Thread(target=_command_worker, daemon=True, name="relaytv-jellyfin-ws-commands")
-        _WORKER.start()
-        _THREAD = threading.Thread(target=_socket_worker, daemon=True, name="relaytv-jellyfin-ws")
-        _THREAD.start()
+        stale = alive
+    if stale:
+        logger.info("jellyfin_ws_restart reason=identity_changed")
+        stop()
+    _start(identity)
+
+
+def _start(identity: tuple[str, str, str]) -> None:
+    global _CURRENT
+    with _LOCK:
+        if _CURRENT is not None and _CURRENT.reader is not None and _CURRENT.reader.is_alive():
+            return
+        session = _Session(identity)
+        session.worker = threading.Thread(
+            target=_command_worker, args=(session,), daemon=True, name="relaytv-jellyfin-ws-commands"
+        )
+        session.reader = threading.Thread(
+            target=_socket_worker, args=(session,), daemon=True, name="relaytv-jellyfin-ws"
+        )
+        _CURRENT = session
+    session.worker.start()
+    session.reader.start()
 
 
 def stop() -> None:
-    global _THREAD, _WORKER, _COMMANDS
-    _STOP.set()
+    global _CURRENT
     with _LOCK:
-        thread, worker = _THREAD, _WORKER
-        _THREAD = None
-        _WORKER = None
-        _COMMANDS = None
-    for t in (thread, worker):
+        session = _CURRENT
+        _CURRENT = None
+    if session is None:
+        _reset_state()
+        return
+    session.stop.set()
+    # Closing the live connection is what makes this prompt: a reader parked in
+    # recv() would otherwise sit there for the rest of its timeout, and joining
+    # past that would stall every caller of stop().
+    ws = session.ws
+    if ws is not None:
+        try:
+            ws.close()
+        except Exception:
+            pass
+    for t in (session.reader, session.worker):
         if t is not None and t.is_alive():
-            t.join(timeout=1.0)
+            t.join(timeout=2.0)
     _reset_state()

--- a/app/relaytv_app/integrations/jellyfin_ws.py
+++ b/app/relaytv_app/integrations/jellyfin_ws.py
@@ -249,6 +249,11 @@ def _connect_once() -> None:
             _STATE["last_connect_ts"] = int(time.time())
             _STATE["last_error"] = None
         logger.info("jellyfin_ws_connected device_id=%s", st.get("device_id"))
+        # A new socket means a new session on the server. Capabilities live in
+        # its session state and do not survive a restart, so re-assert them
+        # rather than trusting a registration that succeeded against the
+        # server instance that just went away.
+        jellyfin_receiver.invalidate_registration("socket_connected")
         try:
             _read_loop(ws)
         finally:

--- a/app/relaytv_app/integrations/jellyfin_ws.py
+++ b/app/relaytv_app/integrations/jellyfin_ws.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Jellyfin/Emby control socket.
+
+Holding a WebSocket open on ``/socket`` is what turns a registered session into
+a *cast target*. The server computes ``SupportsRemoteControl`` as "media
+control advertised **and** a live socket on this session", so without this
+module RelayTV is listed but every command the server sends is dropped on the
+floor.
+
+Transport only, in keeping with ``jellyfin_receiver``: inbound messages are
+normalized to ``(action, payload)`` and handed to the command sink the routes
+package registers. No playback logic lives here.
+"""
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import time
+from urllib.parse import quote, urlsplit
+
+from ..config import env_bool as _env_bool
+from ..config import env_float as _env_float
+from ..debug import get_logger
+from . import jellyfin_receiver
+
+try:
+    from websockets.sync.client import connect as _ws_connect
+except Exception:  # pragma: no cover - dependency may be optional in some envs
+    _ws_connect = None
+
+logger = get_logger("jellyfin_ws")
+
+# The server tells us its keepalive period on connect (``ForceKeepAlive``);
+# this is only what we assume until it does.
+_DEFAULT_KEEPALIVE_SEC = 60.0
+
+# Bound the command backlog. A burst of commands while mpv is still starting
+# should be dropped loudly rather than queued into a stale avalanche that
+# replays minutes later.
+_COMMAND_QUEUE_MAX = 32
+
+_LOCK = threading.Lock()
+_THREAD: threading.Thread | None = None
+_WORKER: threading.Thread | None = None
+_STOP = threading.Event()
+_COMMANDS: queue.Queue | None = None
+_STATE: dict[str, object] = {
+    "connected": False,
+    "last_connect_ts": None,
+    "last_error": None,
+    "reconnects": 0,
+    "keepalive_sec": None,
+    "commands_received": 0,
+    "commands_dropped": 0,
+}
+
+
+def _reset_state() -> None:
+    with _LOCK:
+        _STATE["connected"] = False
+        _STATE["last_connect_ts"] = None
+        _STATE["last_error"] = None
+        _STATE["reconnects"] = 0
+        _STATE["keepalive_sec"] = None
+        _STATE["commands_received"] = 0
+        _STATE["commands_dropped"] = 0
+
+
+def _mark_error(msg: object) -> None:
+    # Everything routes through the receiver's sanitizer: the socket URL carries
+    # the Jellyfin access token as ``api_key``, and a failed handshake reports
+    # the URL it tried.
+    text = jellyfin_receiver._sanitize_error_text(msg)
+    with _LOCK:
+        _STATE["last_error"] = text or None
+
+
+def enabled() -> bool:
+    return _env_bool("RELAYTV_JELLYFIN_WS_ENABLED", True)
+
+
+def status() -> dict[str, object]:
+    """Socket health, for ``/integrations/jellyfin/status``. Never a token."""
+    with _LOCK:
+        out = dict(_STATE)
+    out["enabled"] = enabled()
+    out["available"] = _ws_connect is not None
+    if _ws_connect is None:
+        out["last_error"] = "websockets package not installed"
+    return out
+
+
+def socket_url(*, server_url: str, token: str, device_id: str) -> str:
+    """Build the control-socket URL. The token rides as ``api_key``."""
+    base = str(server_url or "").strip().rstrip("/")
+    if not base or not token or not device_id:
+        return ""
+    parts = urlsplit(base)
+    scheme = "wss" if parts.scheme == "https" else "ws"
+    path = (parts.path or "").rstrip("/")
+    return f"{scheme}://{parts.netloc}{path}/socket?api_key={quote(token)}&deviceId={quote(device_id)}"
+
+
+def normalize_message(raw: object) -> tuple[str, dict[str, object]] | None:
+    """Map one inbound socket message to a command ingress call.
+
+    Returns ``None`` for everything RelayTV does not act on — ``KeepAlive``,
+    ``Sessions``, ``UserDataChanged``, library refreshes and the rest of the
+    server's chatter all arrive on this socket too.
+    """
+    if isinstance(raw, (str, bytes, bytearray)):
+        try:
+            envelope = json.loads(raw)
+        except Exception:
+            return None
+    else:
+        envelope = raw
+    if not isinstance(envelope, dict):
+        return None
+
+    message_type = str(envelope.get("MessageType") or "").strip()
+    data = envelope.get("Data")
+    payload: dict[str, object] = dict(data) if isinstance(data, dict) else {}
+
+    if message_type == "Play":
+        action = "play"
+    elif message_type == "Playstate":
+        # ``normalize_action`` reads payload["Command"] (Pause/Unpause/Seek/...).
+        action = ""
+    elif message_type == "GeneralCommand":
+        # ``normalize_action`` reads payload["Name"]; Arguments are flattened so
+        # extract_volume finds Arguments["Volume"] where it already looks.
+        args = payload.get("Arguments")
+        if isinstance(args, dict):
+            for key, value in args.items():
+                payload.setdefault(str(key), value)
+        action = ""
+    else:
+        return None
+
+    # MessageId is unique per message and is already read by
+    # extract_command_id, so a message the server repeats is deduped for free.
+    message_id = str(envelope.get("MessageId") or "").strip()
+    if message_id:
+        payload.setdefault("MessageId", message_id)
+    return action, payload
+
+
+def _keepalive_interval(force_keepalive_data: object) -> float:
+    """Half the server's timeout, which is the interval it expects."""
+    try:
+        seconds = float(force_keepalive_data)
+    except Exception:
+        seconds = _DEFAULT_KEEPALIVE_SEC
+    if seconds <= 0:
+        seconds = _DEFAULT_KEEPALIVE_SEC
+    return max(1.0, seconds / 2.0)
+
+
+def backoff_sec(failures: int) -> float:
+    base = max(0.5, _env_float("RELAYTV_JELLYFIN_WS_RETRY_BASE_SEC", 3.0))
+    cap = max(base, _env_float("RELAYTV_JELLYFIN_WS_RETRY_MAX_SEC", 60.0))
+    return min(cap, base * (2 ** max(0, int(failures) - 1)))
+
+
+def _submit(action: str, payload: dict[str, object]) -> None:
+    q = _COMMANDS
+    if q is None:
+        return
+    try:
+        q.put_nowait((action, payload))
+        with _LOCK:
+            _STATE["commands_received"] = int(_STATE.get("commands_received") or 0) + 1
+    except queue.Full:
+        with _LOCK:
+            _STATE["commands_dropped"] = int(_STATE.get("commands_dropped") or 0) + 1
+        logger.warning("jellyfin_ws_command_dropped backlog_full action=%s", action or "playstate")
+
+
+def _command_worker() -> None:
+    """Run commands off the reader thread.
+
+    Starting mpv takes several seconds (6-12s on a Pi). Executing a Play on the
+    reader would stall keepalives long enough for the server to drop the
+    session mid-handoff, so the reader only enqueues.
+    """
+    while not _STOP.is_set():
+        q = _COMMANDS
+        if q is None:
+            _STOP.wait(0.2)
+            continue
+        try:
+            item = q.get(timeout=0.5)
+        except queue.Empty:
+            continue
+        action, payload = item
+        try:
+            jellyfin_receiver.dispatch_command(action, payload)
+        except Exception as e:
+            _mark_error(e)
+            logger.warning("jellyfin_ws_command_failed action=%s err=%s", action or "playstate", jellyfin_receiver._sanitize_error_text(e))
+
+
+def _read_loop(ws) -> None:
+    keepalive = _DEFAULT_KEEPALIVE_SEC / 2.0
+    next_keepalive = time.monotonic() + keepalive
+    while not _STOP.is_set():
+        timeout = max(0.2, min(5.0, next_keepalive - time.monotonic()))
+        try:
+            raw = ws.recv(timeout=timeout)
+        except TimeoutError:
+            raw = None
+        if raw is not None:
+            envelope = None
+            try:
+                envelope = json.loads(raw) if isinstance(raw, (str, bytes, bytearray)) else raw
+            except Exception:
+                envelope = None
+            if isinstance(envelope, dict) and str(envelope.get("MessageType") or "") == "ForceKeepAlive":
+                keepalive = _keepalive_interval(envelope.get("Data"))
+                next_keepalive = time.monotonic() + keepalive
+                with _LOCK:
+                    _STATE["keepalive_sec"] = keepalive
+            else:
+                routed = normalize_message(envelope)
+                if routed is not None:
+                    _submit(routed[0], routed[1])
+        if time.monotonic() >= next_keepalive:
+            ws.send(json.dumps({"MessageType": "KeepAlive"}))
+            next_keepalive = time.monotonic() + keepalive
+
+
+def _connect_once() -> None:
+    st = jellyfin_receiver.status()
+    url = socket_url(
+        server_url=str(st.get("server_url") or ""),
+        token=jellyfin_receiver.active_token(),
+        device_id=str(st.get("device_id") or ""),
+    )
+    if not url:
+        raise RuntimeError("jellyfin socket not configured")
+    open_timeout = _env_float("RELAYTV_JELLYFIN_WS_CONNECT_TIMEOUT_SEC", 8.0)
+    # proxy=None: websockets 15+ honours HTTP_PROXY by default, which would send
+    # a LAN media-server connection through an unrelated proxy.
+    with _ws_connect(url, open_timeout=open_timeout, proxy=None, max_size=2**20) as ws:
+        with _LOCK:
+            _STATE["connected"] = True
+            _STATE["last_connect_ts"] = int(time.time())
+            _STATE["last_error"] = None
+        logger.info("jellyfin_ws_connected device_id=%s", st.get("device_id"))
+        try:
+            _read_loop(ws)
+        finally:
+            with _LOCK:
+                _STATE["connected"] = False
+
+
+def _socket_worker() -> None:
+    failures = 0
+    while not _STOP.is_set():
+        if not _ready():
+            _STOP.wait(2.0)
+            continue
+        try:
+            _connect_once()
+            failures = 0
+        except Exception as e:
+            failures += 1
+            _mark_error(e)
+            with _LOCK:
+                _STATE["reconnects"] = int(_STATE.get("reconnects") or 0) + 1
+            logger.warning("jellyfin_ws_disconnected failures=%d err=%s", failures, jellyfin_receiver._sanitize_error_text(e))
+        if _STOP.is_set():
+            break
+        _STOP.wait(backoff_sec(failures) if failures else 1.0)
+
+
+def _ready() -> bool:
+    """Only dial once there is a session worth attaching a socket to."""
+    st = jellyfin_receiver.status()
+    if not bool(st.get("enabled")) or not bool(st.get("running")):
+        return False
+    if not str(st.get("server_url") or "").strip():
+        return False
+    if not str(st.get("device_id") or "").strip():
+        return False
+    if not jellyfin_receiver.active_token():
+        return False
+    return jellyfin_receiver.command_sink_registered()
+
+
+def ensure_running() -> None:
+    """Start the socket threads if they should be up and are not."""
+    global _THREAD, _WORKER, _COMMANDS
+    if not enabled() or _ws_connect is None:
+        return
+    if not _ready():
+        return
+    with _LOCK:
+        if _THREAD is not None and _THREAD.is_alive():
+            return
+        _STOP.clear()
+        _COMMANDS = queue.Queue(maxsize=_COMMAND_QUEUE_MAX)
+        _WORKER = threading.Thread(target=_command_worker, daemon=True, name="relaytv-jellyfin-ws-commands")
+        _WORKER.start()
+        _THREAD = threading.Thread(target=_socket_worker, daemon=True, name="relaytv-jellyfin-ws")
+        _THREAD.start()
+
+
+def stop() -> None:
+    global _THREAD, _WORKER, _COMMANDS
+    _STOP.set()
+    with _LOCK:
+        thread, worker = _THREAD, _WORKER
+        _THREAD = None
+        _WORKER = None
+        _COMMANDS = None
+    for t in (thread, worker):
+        if t is not None and t.is_alive():
+            t.join(timeout=1.0)
+    _reset_state()

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -2412,6 +2412,7 @@ def _jellyfin_integration_command_impl(req: JellyfinCommandReq):
             "pause": lambda: pause(),
             "resume": lambda: resume(),
             "seek": lambda sec: seek_abs(SeekAbsReq(sec=float(sec))),
+            "seek_relative": lambda delta: _seek_relative_result(float(delta)),
             "next": lambda: next_track(),
             "previous": lambda: previous(),
             "set_volume": lambda vol: volume(VolumeReq(set=vol)),

--- a/app/relaytv_app/routes/jellyfin.py
+++ b/app/relaytv_app/routes/jellyfin.py
@@ -130,6 +130,20 @@ def _jellyfin_integration_command_impl(req: JellyfinCommandReq) -> dict[str, obj
     return command(req)
 
 
+def _jellyfin_socket_command(action: str, payload: dict) -> dict[str, object]:
+    """Execute a command that arrived over the Jellyfin control socket.
+
+    Registered into the receiver so the socket reaches the same ingress the
+    HTTP endpoint uses, rather than growing a second copy of command handling.
+    """
+    return _jellyfin_integration_command_impl(
+        _jellyfin_command_req(action=action or None, payload=payload or {})
+    )
+
+
+jellyfin_receiver.register_command_sink(_jellyfin_socket_command)
+
+
 def _jellyfin_progress_snapshot() -> dict | None:
     from . import _jellyfin_progress_snapshot as snapshot
 

--- a/docs/ENV_INVENTORY.md
+++ b/docs/ENV_INVENTORY.md
@@ -163,6 +163,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_JELLYFIN_NATIVE_AUTO_TRANSCODE` | `integrations/jellyfin_service.py` | - | static env |
 | `RELAYTV_JELLYFIN_PASSWORD` | `config.py`<br>`integrations/jellyfin_receiver.py`<br>`main.py`<br>`routes/settings.py`<br>`state.py` | `main.py`<br>`routes/settings.py` | settings bus |
 | `RELAYTV_JELLYFIN_PLAYBACK_MODE` | `config.py`<br>`integrations/jellyfin_service.py`<br>`main.py`<br>`routes/settings.py`<br>`state.py` | `main.py`<br>`routes/settings.py` | settings bus |
+| `RELAYTV_JELLYFIN_PLAYING_PATH` | `integrations/jellyfin_receiver.py` | - | static env |
 | `RELAYTV_JELLYFIN_PLAY_DEBOUNCE_SEC` | `integrations/jellyfin_service.py` | - | static env |
 | `RELAYTV_JELLYFIN_PROGRESS_PATH` | `integrations/jellyfin_receiver.py` | - | static env |
 | `RELAYTV_JELLYFIN_PROGRESS_TIMEOUT_SEC` | `integrations/jellyfin_receiver.py` | - | static env |
@@ -181,6 +182,10 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_JELLYFIN_UI_ACTION_DEDUPE_SEC` | `integrations/jellyfin_service.py` | - | static env |
 | `RELAYTV_JELLYFIN_USERNAME` | `config.py`<br>`integrations/jellyfin_receiver.py`<br>`main.py`<br>`routes/settings.py`<br>`state.py` | `main.py`<br>`routes/settings.py` | settings bus |
 | `RELAYTV_JELLYFIN_USER_ID` | `config.py`<br>`integrations/jellyfin_receiver.py`<br>`main.py`<br>`routes/settings.py`<br>`state.py` | `main.py`<br>`routes/settings.py` | settings bus |
+| `RELAYTV_JELLYFIN_WS_CONNECT_TIMEOUT_SEC` | `integrations/jellyfin_ws.py` | - | static env |
+| `RELAYTV_JELLYFIN_WS_ENABLED` | `integrations/jellyfin_ws.py` | - | static env |
+| `RELAYTV_JELLYFIN_WS_RETRY_BASE_SEC` | `integrations/jellyfin_ws.py` | - | static env |
+| `RELAYTV_JELLYFIN_WS_RETRY_MAX_SEC` | `integrations/jellyfin_ws.py` | - | static env |
 | `RELAYTV_LOGO_IMAGE` | `qt_shell_app.py` | - | child process input |
 | `RELAYTV_LOGO_PATH` | `routes/__init__.py`<br>`routes/assets.py` | - | static env |
 | `RELAYTV_LOG_LEVEL` | `debug.py` | - | static env |

--- a/docs/JELLYFIN_INVENTORY.md
+++ b/docs/JELLYFIN_INVENTORY.md
@@ -94,7 +94,7 @@ duplicate command-id suppression, play through `playback_service`).
 - `_jellyfin_svg`
 - `pwa_jellyfin_svg`
 
-### `routes/jellyfin.py` (40)
+### `routes/jellyfin.py` (41)
 
 - `_extract_jellyfin_audio_stream_index_from_url`
 - `_extract_jellyfin_item_id_from_url_raw`
@@ -106,6 +106,7 @@ duplicate command-id suppression, play through `playback_service`).
 - `_jellyfin_runtime_selected_audio_stream`
 - `_jellyfin_runtime_selected_subtitle_stream`
 - `_jellyfin_should_suppress_duplicate_ui_action`
+- `_jellyfin_socket_command`
 - `_jellyfin_stopped_snapshot`
 - `_require_jellyfin_catalog_ready`
 - `_require_jellyfin_catalog_ready_for_playback`

--- a/docs/JELLYFIN_OPERATIONS.md
+++ b/docs/JELLYFIN_OPERATIONS.md
@@ -67,6 +67,22 @@ run through the same command ingress as `POST /integrations/jellyfin/command`.
 Commands execute on their own worker so a play that takes ten seconds to start
 mpv cannot starve the keepalive and drop the session.
 
+### Device identity
+
+Jellyfin keys sessions, capabilities, and playback history on `DeviceId`, so
+RelayTV derives it from the persisted install id in `/data/device_id` (see
+`ARCHITECTURE.md`) rather than from `device_name`. Renaming a device therefore
+changes only the label in the cast list; it keeps the same Jellyfin session and
+its history. `RELAYTV_JELLYFIN_DEVICE_ID` still pins the value for cloned
+images.
+
+**One-time migration.** Before this change the id was derived from the display
+name, so upgrading gives each device a new `DeviceId` once. The old entry stays
+in Jellyfin's **Dashboard → Devices** with whatever history it accumulated and
+can be deleted there; the device re-registers under the new id within a
+heartbeat and casting is unaffected. Installs that had been renamed may have
+accumulated several stale entries, all safe to remove.
+
 ### Advertised commands
 
 `PlayState` (the whole playstate family: pause, unpause, play/pause toggle,

--- a/docs/JELLYFIN_OPERATIONS.md
+++ b/docs/JELLYFIN_OPERATIONS.md
@@ -58,6 +58,10 @@ Three things must all be true before the server will offer the device:
 
 The socket answers the server's `ForceKeepAlive` on its stated interval, and
 reconnects with exponential backoff (3s doubling to 60s) if the server restarts.
+Capabilities live in the server's in-memory session state and do not survive its
+restart, so a fresh socket invalidates registration and the next heartbeat
+re-posts and re-verifies. Both devices recover in under 20s with no RelayTV
+restart; `last_register_reason` reads `socket_connected` when this is why.
 Inbound `Play`, `Playstate`, and `GeneralCommand` messages are normalized and
 run through the same command ingress as `POST /integrations/jellyfin/command`.
 Commands execute on their own worker so a play that takes ten seconds to start
@@ -299,6 +303,7 @@ Episode adjacency resilience:
 - `next_register_retry_ts`
 - `last_register_backoff_sec`
 - `media_control_verified` (session readback; `null` until attempted)
+- `last_register_reason` (why registration was last invalidated)
 - `last_playing_ts`, `last_playing_ok`, `last_playing_error`
 - `cast_target_ready`
 - `ws_enabled`, `ws_available`, `ws_connected`

--- a/docs/JELLYFIN_OPERATIONS.md
+++ b/docs/JELLYFIN_OPERATIONS.md
@@ -29,6 +29,98 @@ The modern browse shell is the sole supported presentation. The former
 `jfui=modern|classic` comparison switch and its local-storage preference were
 removed after design acceptance.
 
+## Cast Target
+
+Each RelayTV device registers itself as one Jellyfin session and appears in the
+**Cast** menu of the Jellyfin web and mobile clients. Pick it there and the
+server sends playback to that TV; the phone then acts as the remote (play/pause,
+scrubber, next/previous, volume).
+
+Nothing needs configuring beyond the normal Jellyfin credentials. RelayTV is one
+full install per TV, so a household of three RelayTV boxes shows three cast
+targets, each named by its `device_name` setting.
+
+### How it works
+
+Three things must all be true before the server will offer the device:
+
+1. **Authenticated session.** `POST /Users/AuthenticateByName` under this
+   device's `DeviceId`/`Device` identity.
+2. **Capabilities recorded.** `POST /Sessions/Capabilities/Full` with
+   `SupportsMediaControl` and the commands RelayTV implements. RelayTV reads the
+   session back afterwards and only reports `last_register_ok` once the server
+   confirms it — a 204 is not evidence, because the server returns one whether
+   or not the body bound to anything.
+3. **A live control socket.** RelayTV holds a WebSocket open on
+   `/socket?api_key=…&deviceId=…`. The server computes `SupportsRemoteControl`
+   as "media control advertised **and** a socket attached", so without it the
+   device is invisible to casting even with perfect capabilities.
+
+The socket answers the server's `ForceKeepAlive` on its stated interval, and
+reconnects with exponential backoff (3s doubling to 60s) if the server restarts.
+Inbound `Play`, `Playstate`, and `GeneralCommand` messages are normalized and
+run through the same command ingress as `POST /integrations/jellyfin/command`.
+Commands execute on their own worker so a play that takes ten seconds to start
+mpv cannot starve the keepalive and drop the session.
+
+### Advertised commands
+
+`PlayState` (the whole playstate family: pause, unpause, play/pause toggle,
+stop, seek, next, previous), `Play`, `PlayNext`, `SetVolume`, `Mute`, `Unmute`,
+`ToggleMute`.
+
+Only commands RelayTV actually executes are advertised. A command listed here
+without a handler would put a dead button on every Jellyfin remote in the house.
+The list must contain `GeneralCommandType` members only — `Stop`/`Pause`/`Seek`
+and friends are `PlaystateCommand` values and the server rejects a body mixing
+the two with a 400.
+
+### Environment
+
+- `RELAYTV_JELLYFIN_WS_ENABLED=1` (default; set `0` to keep the library
+  integration without offering the device for casting)
+- `RELAYTV_JELLYFIN_WS_CONNECT_TIMEOUT_SEC=8`
+- `RELAYTV_JELLYFIN_WS_RETRY_BASE_SEC=3`
+- `RELAYTV_JELLYFIN_WS_RETRY_MAX_SEC=60`
+
+### Verifying
+
+```bash
+curl -s http://<host>:8787/integrations/jellyfin/status \
+  | jq '{cast_target_ready, media_control_verified, ws_connected, ws_last_error, ws_reconnects}'
+```
+
+`cast_target_ready: true` is the single field that answers "can I cast to this
+device". Server-side confirmation, from a machine with an admin token:
+
+```bash
+curl -s "http://<jellyfin>:8096/Sessions" -H 'Authorization: MediaBrowser Token="<token>"' \
+  | jq '.[] | select(.DeviceId | startswith("relaytv"))
+        | {DeviceName, SupportsRemoteControl, SupportsMediaControl, SupportedCommands}'
+```
+
+### Troubleshooting
+
+**The device never appears in the Cast menu.** Check `cast_target_ready`. If
+`media_control_verified` is false the capabilities POST is being rejected or
+ignored — `last_register_error` says which. If `ws_connected` is false, see the
+next two entries.
+
+**`ws_available: false`.** The `websockets` package is missing from the image.
+The library integration keeps working; only casting is unavailable.
+
+**`ws_connected` flaps, `ws_reconnects` climbing.** The server is restarting, or
+a proxy between RelayTV and Jellyfin is closing idle sockets faster than the
+keepalive interval. `ws_keepalive_sec` shows the interval the server asked for.
+
+**The device appears but commands do nothing.** Sessions are scoped per user:
+the device is only offered to the account RelayTV authenticated as, plus admins.
+Check `auth_user` matches the account casting from.
+
+**`ws_commands_dropped` is non-zero.** Commands arrived faster than playback
+could start and the backlog was capped. Expected under a burst of remote taps;
+sustained growth means playback starts are hanging.
+
 Discovery:
 
 - RelayTV can advertise itself on LAN via mDNS (`_relaytv._tcp`) for server-side auto-discovery/bridge workflows.
@@ -206,6 +298,12 @@ Episode adjacency resilience:
 - `register_retry_failures`
 - `next_register_retry_ts`
 - `last_register_backoff_sec`
+- `media_control_verified` (session readback; `null` until attempted)
+- `last_playing_ts`, `last_playing_ok`, `last_playing_error`
+- `cast_target_ready`
+- `ws_enabled`, `ws_available`, `ws_connected`
+- `ws_last_connect_ts`, `ws_last_error`, `ws_reconnects`, `ws_keepalive_sec`
+- `ws_commands_received`, `ws_commands_dropped`
 - `auth_user_configured`
 - `authenticated`
 - `auth_user`

--- a/docs/release-highlights/0.9.0.md
+++ b/docs/release-highlights/0.9.0.md
@@ -11,4 +11,15 @@ show up under **Found nearby** over mDNS, or add one by address; either way
 nothing is ever added or sent without you asking. See
 [device sync operations](https://github.com/mcgeezy/relaytv/blob/main/docs/DEVICE_SYNC_OPERATIONS.md).
 
+## 📺 New: cast to RelayTV from Jellyfin
+
+Every RelayTV device now shows up in the **Cast** menu of the Jellyfin web and
+mobile apps, named however you named it in settings. Pick a room, hit play, and
+the movie starts on that TV — then your phone becomes the remote, with a
+scrubber you can drag, play/pause, next and previous, and volume. Jellyfin keeps
+track of where you got to, so resume works from any device afterwards. Nothing
+to configure: if RelayTV is already signed in to your server, the cast target is
+there. See
+[Jellyfin operations](https://github.com/mcgeezy/relaytv/blob/main/docs/JELLYFIN_OPERATIONS.md).
+
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,10 @@ dependencies = [
   "uvicorn[standard]>=0.30,<1",
   # Jellyfin control socket. It already arrives via uvicorn[standard], but the
   # cast target is a product feature and must not depend on another package's
-  # extra continuing to pull it in.
-  "websockets>=13,<17",
+  # extra continuing to pull it in. The floor is 15 because that is where
+  # connect() gained the proxy argument; the code still runs on 13/14 without
+  # proxy suppression, but 15 is what we want on a LAN.
+  "websockets>=15,<17",
   "yt-dlp>=2024.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ dependencies = [
   "fastapi>=0.115,<1",
   "python-multipart>=0.0.9,<1",
   "uvicorn[standard]>=0.30,<1",
+  # Jellyfin control socket. It already arrives via uvicorn[standard], but the
+  # cast target is a product feature and must not depend on another package's
+  # extra continuing to pull it in.
+  "websockets>=13,<17",
   "yt-dlp>=2024.1",
 ]
 

--- a/tests/test_jellyfin_inventory.py
+++ b/tests/test_jellyfin_inventory.py
@@ -110,6 +110,9 @@ EXPECTED_JELLYFIN_ROUTE_FUNCTIONS: dict[str, set[str]] = {
         "_jellyfin_runtime_selected_audio_stream",
         "_jellyfin_runtime_selected_subtitle_stream",
         "_jellyfin_should_suppress_duplicate_ui_action",
+        # Transport adapter: hands socket-sourced commands to the same ingress
+        # the HTTP endpoint uses. No product logic of its own.
+        "_jellyfin_socket_command",
         "_jellyfin_stopped_snapshot",
         "_require_jellyfin_catalog_ready",
         "_require_jellyfin_catalog_ready_for_playback",

--- a/tests/test_jellyfin_service.py
+++ b/tests/test_jellyfin_service.py
@@ -642,12 +642,19 @@ def test_register_posts_the_unwrapped_body_and_verifies_it(monkeypatch) -> None:
     monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://jf.lan:8096")
     monkeypatch.setitem(jellyfin_receiver._STATUS, "device_id", "relaytv-den")
     monkeypatch.setattr(
-        jellyfin_receiver, "_post_json", lambda url, payload, timeout=3.0: posts.append((url, payload))
+        jellyfin_receiver,
+        "_post_json_for",
+        lambda context, path, payload, timeout=3.0: posts.append(
+            (jellyfin_receiver._context_url(context, path), payload)
+        ),
     )
     monkeypatch.setattr(
         jellyfin_receiver,
-        "read_session_capabilities",
-        lambda device_id="", timeout=3.0: {"DeviceId": device_id, "SupportsMediaControl": True},
+        "_read_session_capabilities_for",
+        lambda context, device_id="", timeout=3.0: {
+            "DeviceId": device_id,
+            "SupportsMediaControl": True,
+        },
     )
 
     out = jellyfin_receiver.register_receiver_once()
@@ -667,12 +674,23 @@ def test_register_fails_when_the_server_did_not_record_media_control(monkeypatch
     monkeypatch.setitem(jellyfin_receiver._STATUS, "running", True)
     monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://jf.lan:8096")
     monkeypatch.setitem(jellyfin_receiver._STATUS, "device_id", "relaytv-den")
-    monkeypatch.setattr(jellyfin_receiver, "_post_json", lambda url, payload, timeout=3.0: None)
-    monkeypatch.setattr(jellyfin_receiver, "_post_no_body", lambda url, timeout=3.0: None)
     monkeypatch.setattr(
         jellyfin_receiver,
-        "read_session_capabilities",
-        lambda device_id="", timeout=3.0: {"DeviceId": device_id, "SupportsMediaControl": False},
+        "_post_json_for",
+        lambda context, path, payload, timeout=3.0: None,
+    )
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "_post_no_body_for",
+        lambda context, path, timeout=3.0: None,
+    )
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "_read_session_capabilities_for",
+        lambda context, device_id="", timeout=3.0: {
+            "DeviceId": device_id,
+            "SupportsMediaControl": False,
+        },
     )
 
     out = jellyfin_receiver.register_receiver_once()
@@ -688,12 +706,16 @@ def test_register_accepts_a_server_that_hides_its_session_list(monkeypatch) -> N
     monkeypatch.setitem(jellyfin_receiver._STATUS, "running", True)
     monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://jf.lan:8096")
     monkeypatch.setitem(jellyfin_receiver._STATUS, "device_id", "relaytv-den")
-    monkeypatch.setattr(jellyfin_receiver, "_post_json", lambda url, payload, timeout=3.0: None)
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "_post_json_for",
+        lambda context, path, payload, timeout=3.0: None,
+    )
 
-    def _boom(device_id="", timeout=3.0):
+    def _boom(context, device_id="", timeout=3.0):
         raise RuntimeError("404")
 
-    monkeypatch.setattr(jellyfin_receiver, "read_session_capabilities", _boom)
+    monkeypatch.setattr(jellyfin_receiver, "_read_session_capabilities_for", _boom)
 
     out = jellyfin_receiver.register_receiver_once()
 
@@ -708,16 +730,20 @@ def test_register_falls_back_to_the_query_form_for_emby(monkeypatch) -> None:
     monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://emby.lan:8096")
     monkeypatch.setitem(jellyfin_receiver._STATUS, "device_id", "relaytv-den")
 
-    def _reject_body(url, payload, timeout=3.0):
-        attempts.append(url)
+    def _reject_body(context, path, payload, timeout=3.0):
+        attempts.append(jellyfin_receiver._context_url(context, path))
         raise RuntimeError("HTTP 400")
 
-    def _accept_query(url, timeout=3.0):
-        attempts.append(url)
+    def _accept_query(context, path, timeout=3.0):
+        attempts.append(jellyfin_receiver._context_url(context, path))
 
-    monkeypatch.setattr(jellyfin_receiver, "_post_json", _reject_body)
-    monkeypatch.setattr(jellyfin_receiver, "_post_no_body", _accept_query)
-    monkeypatch.setattr(jellyfin_receiver, "read_session_capabilities", lambda device_id="", timeout=3.0: {})
+    monkeypatch.setattr(jellyfin_receiver, "_post_json_for", _reject_body)
+    monkeypatch.setattr(jellyfin_receiver, "_post_no_body_for", _accept_query)
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "_read_session_capabilities_for",
+        lambda context, device_id="", timeout=3.0: {},
+    )
 
     out = jellyfin_receiver.register_receiver_once()
 

--- a/tests/test_jellyfin_service.py
+++ b/tests/test_jellyfin_service.py
@@ -595,3 +595,184 @@ def test_provider_display_name_reflects_server_type(monkeypatch) -> None:
 
     monkeypatch.setattr(state, "get_settings", lambda: {})
     assert resolver._provider_display_name("jellyfin") == "Jellyfin"
+
+
+# --- cast-target registration ----------------------------------------------
+
+# Jellyfin's GeneralCommandType, as served by 10.11's OpenAPI schema. Pinned
+# here because the bug this guards was advertising PlaystateCommand values in
+# a GeneralCommandType field: the server answered 400, and the wrapped-body
+# fallback that "succeeded" instead wrote empty capabilities.
+GENERAL_COMMAND_TYPES = frozenset(
+    {
+        "MoveUp", "MoveDown", "MoveLeft", "MoveRight", "PageUp", "PageDown",
+        "PreviousLetter", "NextLetter", "ToggleOsd", "ToggleContextMenu", "Select",
+        "Back", "TakeScreenshot", "SendKey", "SendString", "GoHome", "GoToSettings",
+        "VolumeUp", "VolumeDown", "Mute", "Unmute", "ToggleMute", "SetVolume",
+        "SetAudioStreamIndex", "SetSubtitleStreamIndex", "ToggleFullscreen",
+        "DisplayContent", "GoToSearch", "DisplayMessage", "SetRepeatMode",
+        "ChannelUp", "ChannelDown", "Guide", "ToggleStats", "PlayMediaSource",
+        "PlayTrailers", "SetShuffleQueue", "PlayState", "PlayNext", "ToggleOsdMenu",
+        "Play", "SetMaxStreamingBitrate", "SetPlaybackOrder",
+    }
+)
+
+
+def test_advertised_commands_are_all_general_command_types() -> None:
+    unknown = set(jellyfin_receiver.CAPABILITY_COMMANDS) - GENERAL_COMMAND_TYPES
+    assert unknown == set(), f"not GeneralCommandType members: {sorted(unknown)}"
+
+
+def test_capabilities_body_is_not_wrapped() -> None:
+    """A wrapped body binds as an all-default DTO and erases capabilities.
+
+    The server still answers 204, so nothing downstream notices.
+    """
+    payload = jellyfin_receiver.capabilities_payload()
+    assert "Capabilities" not in payload
+    assert payload["SupportsMediaControl"] is True
+    assert payload["PlayableMediaTypes"] == ["Video", "Audio"]
+    assert "PlayState" in payload["SupportedCommands"]
+
+
+def test_register_posts_the_unwrapped_body_and_verifies_it(monkeypatch) -> None:
+    posts: list[tuple[str, dict]] = []
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "running", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://jf.lan:8096")
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "device_id", "relaytv-den")
+    monkeypatch.setattr(
+        jellyfin_receiver, "_post_json", lambda url, payload, timeout=3.0: posts.append((url, payload))
+    )
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "read_session_capabilities",
+        lambda device_id="", timeout=3.0: {"DeviceId": device_id, "SupportsMediaControl": True},
+    )
+
+    out = jellyfin_receiver.register_receiver_once()
+
+    assert out["ok"] is True
+    assert out["verified"] is True
+    assert len(posts) == 1
+    url, body = posts[0]
+    assert url == "http://jf.lan:8096/Sessions/Capabilities/Full"
+    assert body == jellyfin_receiver.capabilities_payload()
+    assert jellyfin_receiver._STATUS["media_control_verified"] is True
+
+
+def test_register_fails_when_the_server_did_not_record_media_control(monkeypatch) -> None:
+    """The exact live failure: 204 accepted, capabilities silently empty."""
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "running", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://jf.lan:8096")
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "device_id", "relaytv-den")
+    monkeypatch.setattr(jellyfin_receiver, "_post_json", lambda url, payload, timeout=3.0: None)
+    monkeypatch.setattr(jellyfin_receiver, "_post_no_body", lambda url, timeout=3.0: None)
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "read_session_capabilities",
+        lambda device_id="", timeout=3.0: {"DeviceId": device_id, "SupportsMediaControl": False},
+    )
+
+    out = jellyfin_receiver.register_receiver_once()
+
+    assert out["ok"] is False
+    assert "media control" in str(out["error"])
+    assert jellyfin_receiver._STATUS["connected"] is False
+
+
+def test_register_accepts_a_server_that_hides_its_session_list(monkeypatch) -> None:
+    """A proxy or an Emby build may not answer the readback; that is not a failure."""
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "running", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://jf.lan:8096")
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "device_id", "relaytv-den")
+    monkeypatch.setattr(jellyfin_receiver, "_post_json", lambda url, payload, timeout=3.0: None)
+
+    def _boom(device_id="", timeout=3.0):
+        raise RuntimeError("404")
+
+    monkeypatch.setattr(jellyfin_receiver, "read_session_capabilities", _boom)
+
+    out = jellyfin_receiver.register_receiver_once()
+
+    assert out["ok"] is True
+    assert out["verified"] is None
+
+
+def test_register_falls_back_to_the_query_form_for_emby(monkeypatch) -> None:
+    attempts: list[str] = []
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "running", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://emby.lan:8096")
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "device_id", "relaytv-den")
+
+    def _reject_body(url, payload, timeout=3.0):
+        attempts.append(url)
+        raise RuntimeError("HTTP 400")
+
+    def _accept_query(url, timeout=3.0):
+        attempts.append(url)
+
+    monkeypatch.setattr(jellyfin_receiver, "_post_json", _reject_body)
+    monkeypatch.setattr(jellyfin_receiver, "_post_no_body", _accept_query)
+    monkeypatch.setattr(jellyfin_receiver, "read_session_capabilities", lambda device_id="", timeout=3.0: {})
+
+    out = jellyfin_receiver.register_receiver_once()
+
+    assert out["ok"] is True
+    assert out["method"] == "caps_query"
+    assert "/Sessions/Capabilities?" in attempts[1]
+    assert "supportedCommands=PlayState" in attempts[1]
+
+
+# --- remote-friendly playback reporting ------------------------------------
+
+
+def test_play_pause_toggles_against_current_state(monkeypatch) -> None:
+    calls: list[str] = []
+    controls = {
+        "stop": lambda: None,
+        "pause": lambda: calls.append("pause"),
+        "resume": lambda: calls.append("resume"),
+        "seek": lambda sec: None,
+        "next": lambda: None,
+        "previous": lambda: None,
+        "set_volume": lambda vol: None,
+        "mute": lambda muted: None,
+    }
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setattr(jellyfin_service, "emit_progress_hint", lambda: None)
+
+    monkeypatch.setattr(jellyfin_service, "playback_is_paused", lambda: False)
+    out = jellyfin_service.handle_command(
+        FakeCommandReq(payload={"Command": "PlayPause"}), controls=controls, ui=_noop_ui()
+    )
+    assert out["action"] == "pause"
+
+    monkeypatch.setattr(jellyfin_service, "playback_is_paused", lambda: True)
+    out = jellyfin_service.handle_command(
+        FakeCommandReq(payload={"Command": "PlayPause"}), controls=controls, ui=_noop_ui()
+    )
+    assert out["action"] == "resume"
+
+    assert calls == ["pause", "resume"]
+
+
+def test_progress_payload_lets_the_remote_scrub(monkeypatch) -> None:
+    """Without CanSeek the Jellyfin remote renders a read-only progress bar."""
+    monkeypatch.setattr(state, "NOW_PLAYING", {"jellyfin_item_id": "abc", "url": "http://jf/x"})
+    monkeypatch.setattr(player, "is_playing", lambda: True)
+    monkeypatch.setattr(player, "mpv_get_many", lambda keys: {"pause": False, "time-pos": 12.0, "duration": 100.0})
+
+    payload = jellyfin_service.progress_snapshot()
+
+    assert payload["CanSeek"] is True
+    assert payload["PlayMethod"] == "DirectStream"
+
+
+def test_play_method_follows_the_selected_stream_mode() -> None:
+    assert jellyfin_service.play_method({"jellyfin_stream_mode": "transcode"}) == "Transcode"
+    assert jellyfin_service.play_method({"jellyfin_stream_mode": "direct"}) == "DirectStream"
+    assert jellyfin_service.play_method({}) == "DirectStream"

--- a/tests/test_jellyfin_service.py
+++ b/tests/test_jellyfin_service.py
@@ -870,3 +870,32 @@ def test_skip_commands_seek_by_jellyfin_default_amounts(monkeypatch) -> None:
     jellyfin_service.handle_command(FakeCommandReq(payload={"Command": "FastForward"}), controls=controls, ui=_noop_ui())
 
     assert deltas == [-10.0, 30.0]
+
+
+def test_progress_stops_when_playback_stops(monkeypatch) -> None:
+    """A stopped session must not keep reporting progress.
+
+    NOW_PLAYING is deliberately retained after a stop so RelayTV's own UI can
+    resume it. Reporting that to Jellyfin re-created the session's
+    NowPlayingItem seconds after Stop cleared it, so every remote showed a
+    stale paused entry indefinitely.
+    """
+    monkeypatch.setattr(state, "NOW_PLAYING", {"jellyfin_item_id": "abc", "url": "http://jf/x"})
+    monkeypatch.setattr(player, "is_playing", lambda: False)
+    monkeypatch.setattr(player, "mpv_get_many", lambda keys: {})
+
+    assert jellyfin_service.progress_snapshot() is None
+
+
+def test_progress_still_reports_a_paused_item(monkeypatch) -> None:
+    """Pause is not stop: a paused mpv still reports playing, and the remote
+    needs the position to keep its scrubber honest."""
+    monkeypatch.setattr(state, "NOW_PLAYING", {"jellyfin_item_id": "abc", "url": "http://jf/x"})
+    monkeypatch.setattr(player, "is_playing", lambda: True)
+    monkeypatch.setattr(player, "mpv_get_many", lambda keys: {"pause": True, "time-pos": 42.0, "duration": 100.0})
+
+    payload = jellyfin_service.progress_snapshot()
+
+    assert payload is not None
+    assert payload["IsPaused"] is True
+    assert payload["PositionTicks"] == 420_000_000

--- a/tests/test_jellyfin_service.py
+++ b/tests/test_jellyfin_service.py
@@ -776,3 +776,97 @@ def test_play_method_follows_the_selected_stream_mode() -> None:
     assert jellyfin_service.play_method({"jellyfin_stream_mode": "transcode"}) == "Transcode"
     assert jellyfin_service.play_method({"jellyfin_stream_mode": "direct"}) == "DirectStream"
     assert jellyfin_service.play_method({}) == "DirectStream"
+
+
+# Every message the server is authorized to send by CAPABILITY_COMMANDS, in the
+# shape the control socket delivers it. Advertising PlayState authorizes the
+# whole PlaystateCommand family, not just the ones the web remote happens to
+# use today.
+ADVERTISED_TRAFFIC = [
+    ("PlayState", {"MessageType": "Playstate", "Data": {"Command": "Pause"}}),
+    ("PlayState", {"MessageType": "Playstate", "Data": {"Command": "Unpause"}}),
+    ("PlayState", {"MessageType": "Playstate", "Data": {"Command": "PlayPause"}}),
+    ("PlayState", {"MessageType": "Playstate", "Data": {"Command": "Stop"}}),
+    ("PlayState", {"MessageType": "Playstate", "Data": {"Command": "Seek", "SeekPositionTicks": 10_000_000}}),
+    ("PlayState", {"MessageType": "Playstate", "Data": {"Command": "NextTrack"}}),
+    ("PlayState", {"MessageType": "Playstate", "Data": {"Command": "PreviousTrack"}}),
+    ("PlayState", {"MessageType": "Playstate", "Data": {"Command": "Rewind"}}),
+    ("PlayState", {"MessageType": "Playstate", "Data": {"Command": "FastForward"}}),
+    ("SetVolume", {"MessageType": "GeneralCommand", "Data": {"Name": "SetVolume", "Arguments": {"Volume": "30"}}}),
+    ("Mute", {"MessageType": "GeneralCommand", "Data": {"Name": "Mute"}}),
+    ("Unmute", {"MessageType": "GeneralCommand", "Data": {"Name": "Unmute"}}),
+    ("ToggleMute", {"MessageType": "GeneralCommand", "Data": {"Name": "ToggleMute"}}),
+]
+
+
+@pytest.mark.parametrize("capability,message", ADVERTISED_TRAFFIC, ids=lambda v: v if isinstance(v, str) else "")
+def test_every_advertised_capability_reaches_a_handler(capability, message, monkeypatch) -> None:
+    """Advertising a command RelayTV cannot execute puts a dead button on the remote.
+
+    ToggleMute shipped exactly that way once: accepted by the server, 400 at the
+    ingress, silent on the TV.
+    """
+    from relaytv_app.integrations import jellyfin_ws
+
+    assert capability in jellyfin_receiver.CAPABILITY_COMMANDS
+
+    dispatched: list[str] = []
+    controls = {
+        name: (lambda *a, _n=name, **kw: dispatched.append(_n))
+        for name in ("stop", "pause", "resume", "seek", "seek_relative", "next", "previous", "set_volume", "mute")
+    }
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setattr(jellyfin_service, "emit_progress_hint", lambda: None)
+    monkeypatch.setattr(jellyfin_service, "playback_is_paused", lambda: False)
+    monkeypatch.setattr(jellyfin_service, "playback_is_muted", lambda: False)
+
+    routed = jellyfin_ws.normalize_message(message)
+    assert routed is not None, f"{capability}: socket dropped the message"
+    action, payload = routed
+
+    out = jellyfin_service.handle_command(
+        FakeCommandReq(action=action or None, payload=payload), controls=controls, ui=_noop_ui()
+    )
+    assert out["ok"] is True
+    assert dispatched, f"{capability}: handled but dispatched nothing"
+
+
+def test_toggle_mute_flips_both_ways(monkeypatch) -> None:
+    calls: list[bool] = []
+    controls = {
+        "stop": lambda: None, "pause": lambda: None, "resume": lambda: None,
+        "seek": lambda sec: None, "seek_relative": lambda delta: None,
+        "next": lambda: None, "previous": lambda: None, "set_volume": lambda vol: None,
+        "mute": lambda muted: calls.append(muted),
+    }
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setattr(jellyfin_service, "emit_progress_hint", lambda: None)
+
+    monkeypatch.setattr(jellyfin_service, "playback_is_muted", lambda: False)
+    assert jellyfin_service.handle_command(
+        FakeCommandReq(payload={"Name": "ToggleMute"}), controls=controls, ui=_noop_ui()
+    )["action"] == "mute"
+
+    monkeypatch.setattr(jellyfin_service, "playback_is_muted", lambda: True)
+    assert jellyfin_service.handle_command(
+        FakeCommandReq(payload={"Name": "ToggleMute"}), controls=controls, ui=_noop_ui()
+    )["action"] == "unmute"
+
+    assert calls == [True, False]
+
+
+def test_skip_commands_seek_by_jellyfin_default_amounts(monkeypatch) -> None:
+    deltas: list[float] = []
+    controls = {
+        "stop": lambda: None, "pause": lambda: None, "resume": lambda: None,
+        "seek": lambda sec: None, "seek_relative": lambda delta: deltas.append(delta),
+        "next": lambda: None, "previous": lambda: None, "set_volume": lambda vol: None,
+        "mute": lambda muted: None,
+    }
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setattr(jellyfin_service, "emit_progress_hint", lambda: None)
+
+    jellyfin_service.handle_command(FakeCommandReq(payload={"Command": "Rewind"}), controls=controls, ui=_noop_ui())
+    jellyfin_service.handle_command(FakeCommandReq(payload={"Command": "FastForward"}), controls=controls, ui=_noop_ui())
+
+    assert deltas == [-10.0, 30.0]

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -274,3 +274,46 @@ def test_socket_does_not_dial_before_a_sink_exists() -> None:
     """No point holding a socket we cannot act on."""
     jellyfin_receiver.register_command_sink(None)
     assert jellyfin_ws._ready() is False
+
+
+# --- session re-assertion after a server restart ---------------------------
+
+
+def test_invalidating_registration_forces_a_fresh_verify() -> None:
+    """A Jellyfin restart drops capabilities from its session state.
+
+    Registration short-circuits on its own last success, so without this the
+    device keeps reporting itself castable while the server offers nothing.
+    """
+    jellyfin_receiver._STATUS["connected"] = True
+    jellyfin_receiver._STATUS["last_register_ok"] = True
+    jellyfin_receiver._STATUS["media_control_verified"] = True
+
+    jellyfin_receiver.invalidate_registration("socket_connected")
+
+    assert jellyfin_receiver._STATUS["connected"] is False
+    assert jellyfin_receiver._STATUS["last_register_ok"] is None
+    assert jellyfin_receiver._STATUS["media_control_verified"] is None
+    assert jellyfin_receiver._STATUS["last_register_reason"] == "socket_connected"
+    # Backoff must not delay the re-register.
+    assert jellyfin_receiver._NEXT_REGISTER_RETRY_TS == 0.0
+    assert jellyfin_receiver.status()["cast_target_ready"] is False
+
+
+def test_ensure_registration_reregisters_after_invalidation(monkeypatch) -> None:
+    calls: list[int] = []
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "running", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://jf.lan:8096")
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "authenticated", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "connected", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "last_register_ok", True)
+    monkeypatch.setattr(jellyfin_receiver, "register_receiver_once", lambda: calls.append(1) or {"ok": True})
+
+    # Healthy: nothing to do.
+    jellyfin_receiver._ensure_registration()
+    assert calls == []
+
+    jellyfin_receiver.invalidate_registration("socket_connected")
+    jellyfin_receiver._ensure_registration()
+    assert calls == [1]

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -490,18 +490,167 @@ def test_identity_fingerprints_the_token() -> None:
     assert "super-secret-token" not in "".join(identity)
 
 
-def test_device_id_is_derived_the_same_way_everywhere(monkeypatch) -> None:
-    """Jellyfin keys sessions and history on DeviceId.
-
-    Startup appended the hostname and the rename paths did not, so renaming a
-    device and then restarting made one TV show up as two cast targets.
-    """
+def test_every_path_derives_the_same_device_id(monkeypatch) -> None:
+    """Startup, connect(), and rename must agree, or one TV becomes two."""
     monkeypatch.delenv("RELAYTV_JELLYFIN_DEVICE_ID", raising=False)
-    expected = jellyfin_receiver.derive_device_id("Living Room")
-    assert expected.startswith("relaytv-living-room-")
+    expected = jellyfin_receiver.derive_device_id()
 
     jellyfin_receiver.set_device_identity("Living Room")
     assert jellyfin_receiver._STATUS["device_id"] == expected
+    assert jellyfin_receiver._read_config()["device_id"] == expected
+
+
+# --- review round two ------------------------------------------------------
+
+
+def test_device_id_survives_a_rename(monkeypatch) -> None:
+    """Jellyfin keys history on DeviceId, so a rename must not mint a new one.
+
+    Deriving it from device_name meant renaming "Living Room" to "Den" created
+    a second Jellyfin session and left the first as a duplicate cast target.
+    """
+    monkeypatch.delenv("RELAYTV_JELLYFIN_DEVICE_ID", raising=False)
+
+    jellyfin_receiver.set_device_identity("Living Room")
+    first = jellyfin_receiver._STATUS["device_id"]
+    jellyfin_receiver.set_device_identity("Den")
+    second = jellyfin_receiver._STATUS["device_id"]
+
+    assert first == second, "renaming the device changed its Jellyfin identity"
+    assert jellyfin_receiver._STATUS["device_name"] == "Den", "the display name must still change"
 
     monkeypatch.setenv("RELAYTV_JELLYFIN_DEVICE_ID", "pinned-id")
-    assert jellyfin_receiver.derive_device_id("Anything") == "pinned-id"
+    assert jellyfin_receiver.derive_device_id() == "pinned-id"
+
+
+def test_device_id_follows_the_persisted_install_identity(monkeypatch) -> None:
+    from relaytv_app import device_identity
+
+    monkeypatch.delenv("RELAYTV_JELLYFIN_DEVICE_ID", raising=False)
+    monkeypatch.setattr(device_identity, "device_id", lambda: "stable123")
+    assert jellyfin_receiver.derive_device_id() == "relaytv-stable123"
+
+
+def test_a_late_handshake_cannot_hijack_the_live_session(monkeypatch) -> None:
+    """The dial can outlast the session that started it.
+
+    session.ws is None for the whole handshake, so stop() cannot reach the
+    connection and gives up on the join. If the socket then landed anyway it
+    would publish "connected" and re-assert registration for a generation that
+    no longer owns either.
+    """
+    invalidated: list[str] = []
+    closed = threading.Event()
+
+    class _Conn:
+        def recv(self, timeout=None):
+            raise AssertionError("a retired session must never read")
+
+        def close(self):
+            closed.set()
+
+    monkeypatch.setattr(jellyfin_ws, "_ws_connect", lambda url, **kw: _Conn())
+    monkeypatch.setattr(
+        jellyfin_receiver, "status", lambda: {"server_url": "http://jf.lan:8096", "device_id": "relaytv-den"}
+    )
+    monkeypatch.setattr(jellyfin_receiver, "active_token", lambda: "tok")
+    monkeypatch.setattr(jellyfin_receiver, "invalidate_registration", lambda reason="": invalidated.append(reason))
+
+    retired = jellyfin_ws._Session(("u", "d", "f"))
+    live = jellyfin_ws._Session(("u", "d", "f"))
+    jellyfin_ws._CURRENT = live  # someone else is the live generation now
+    jellyfin_ws._STATE["connected"] = False
+    try:
+        jellyfin_ws._connect_once(retired)
+
+        assert closed.is_set(), "the orphaned socket was left open"
+        assert invalidated == [], "a retired session re-asserted registration"
+        assert jellyfin_ws._STATE["connected"] is False, "a retired session published its status"
+    finally:
+        jellyfin_ws._CURRENT = None
+
+
+def test_the_live_session_still_publishes_and_reasserts(monkeypatch) -> None:
+    """The guard must not break the normal path."""
+    invalidated: list[str] = []
+
+    class _Conn:
+        def recv(self, timeout=None):
+            raise TimeoutError
+
+        def send(self, message):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(jellyfin_ws, "_ws_connect", lambda url, **kw: _Conn())
+    monkeypatch.setattr(
+        jellyfin_receiver, "status", lambda: {"server_url": "http://jf.lan:8096", "device_id": "relaytv-den"}
+    )
+    monkeypatch.setattr(jellyfin_receiver, "active_token", lambda: "tok")
+    monkeypatch.setattr(jellyfin_receiver, "invalidate_registration", lambda reason="": invalidated.append(reason))
+
+    session = _session(deadline_sec=0.5)
+    jellyfin_ws._CURRENT = session
+    try:
+        jellyfin_ws._connect_once(session)
+        assert invalidated == ["socket_connected"]
+        assert jellyfin_ws._STATE["last_connect_ts"] is not None
+    finally:
+        jellyfin_ws._CURRENT = None
+
+
+def test_connect_bounds_the_closing_handshake(monkeypatch) -> None:
+    """websockets defaults to a 10s close; stop() runs on settings-save paths."""
+    seen: dict[str, object] = {}
+
+    class _Conn:
+        def recv(self, timeout=None):
+            raise TimeoutError
+
+        def send(self, message):
+            pass
+
+        def close(self):
+            pass
+
+    def _fake_connect(url, **kwargs):
+        seen.update(kwargs)
+        return _Conn()
+
+    monkeypatch.setattr(jellyfin_ws, "_ws_connect", _fake_connect)
+    monkeypatch.setattr(
+        jellyfin_receiver, "status", lambda: {"server_url": "http://jf.lan:8096", "device_id": "relaytv-den"}
+    )
+    monkeypatch.setattr(jellyfin_receiver, "active_token", lambda: "tok")
+    monkeypatch.setattr(jellyfin_receiver, "invalidate_registration", lambda reason="": None)
+
+    session = _session(deadline_sec=0.0)
+    jellyfin_ws._CURRENT = session
+    try:
+        jellyfin_ws._connect_once(session)
+    finally:
+        jellyfin_ws._CURRENT = None
+
+    assert seen["close_timeout"] == jellyfin_ws._CLOSE_TIMEOUT_SEC
+    assert seen["close_timeout"] < 10
+
+
+def test_stop_does_not_wait_on_the_closing_handshake() -> None:
+    """A server that has gone away must not stall a settings save."""
+
+    class _SlowConn:
+        def close(self):
+            time.sleep(5.0)
+
+    session = jellyfin_ws._Session(("u", "d", "f"))
+    session.ws = _SlowConn()
+    jellyfin_ws._CURRENT = session
+
+    t0 = time.monotonic()
+    jellyfin_ws.stop()
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 1.0, f"stop() blocked {elapsed:.1f}s on the close handshake"
+    assert session.stop.is_set()

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -872,3 +872,92 @@ def test_concurrent_server_switches_do_not_interleave(monkeypatch) -> None:
     product = str(jellyfin_receiver._STATUS["server_product_name"])
     expected = "Server B" if "b.local" in url else "Server A"
     assert product == expected, f"torn state: {url} reported as {product}"
+
+
+# --- heartbeat generations -------------------------------------------------
+
+
+def test_a_retired_heartbeat_generation_stays_retired(monkeypatch) -> None:
+    """The heartbeat had the same reusable-stop-event bug as the socket.
+
+    _stop_worker gives it one second; a worker inside a network call outlives
+    that, and the next start cleared the shared flag out from under it. Two
+    generations then authenticated, registered, posted progress, and probed
+    server identity in parallel.
+    """
+    seen: dict[int, bool] = {}
+    lock = threading.Lock()
+
+    def _probe(stop):
+        me = threading.get_ident()
+        time.sleep(1.2)  # parked in a network call
+        with lock:
+            seen[me] = not stop.is_set()
+
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setattr(jellyfin_receiver, "_heartbeat_worker", _probe)
+
+    jellyfin_receiver._start_worker()
+    first = jellyfin_receiver._THREAD
+    time.sleep(0.1)
+    jellyfin_receiver._stop_worker()  # join times out; `first` is still sleeping
+    jellyfin_receiver._start_worker()  # rapid reconnect
+    second = jellyfin_receiver._THREAD
+    try:
+        assert first is not second
+        time.sleep(2.0)
+        running = sum(1 for v in seen.values() if v)
+        assert len(seen) == 2, "both generations should have reported"
+        assert running == 1, f"{running} generations think they are live"
+    finally:
+        jellyfin_receiver._stop_worker()
+
+
+def test_an_in_flight_probe_cannot_publish_over_new_settings(monkeypatch) -> None:
+    """Serializing transactions does not stop work that started before one.
+
+    A detection probe of the outgoing server takes seconds; landing late left
+    the new server's address labelled with the old server's identity.
+    """
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
+    monkeypatch.setattr(jellyfin_receiver, "_start_worker", lambda: None)
+    monkeypatch.setattr(jellyfin_receiver, "_stop_worker", lambda: None)
+    monkeypatch.setattr(jellyfin_receiver, "authenticate_once", lambda: {"ok": False})
+    monkeypatch.setattr(jellyfin_receiver, "_catalog_cache_clear", lambda: None)
+    for key, value in (
+        ("enabled", True), ("running", True), ("authenticated", True),
+        ("server_url", "http://old.local:8096"), ("server_type", "emby"),
+        ("server_product_name", "Old Server"), ("last_detect_ok", False), ("last_detect_ts", None),
+    ):
+        monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
+
+    def _detect(server_url, timeout_sec=3.0):
+        if "old.local" in server_url:
+            time.sleep(1.2)
+            return {"ok": True, "server_type": "emby", "product_name": "Old Server"}
+        return {"ok": True, "server_type": "jellyfin", "product_name": "New Server"}
+
+    monkeypatch.setattr(jellyfin_receiver, "detect_server_type", _detect)
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "_persist_server_type",
+        lambda st, pn="": jellyfin_receiver._STATUS.update({"server_type": st, "server_product_name": pn}),
+    )
+
+    probe = threading.Thread(target=jellyfin_receiver._maybe_retry_detection, daemon=True)
+    probe.start()
+    time.sleep(0.3)  # the probe is in flight when settings change
+    jellyfin_receiver.connect(server_url="http://new.local:8096")
+    probe.join(timeout=15)
+
+    assert "new.local" in str(jellyfin_receiver._STATUS["server_url"])
+    assert jellyfin_receiver._STATUS["server_product_name"] == "New Server"
+
+
+def test_config_generation_advances_once_per_transaction() -> None:
+    before = jellyfin_receiver.config_generation()
+    with jellyfin_receiver._control_socket_suspended():
+        during = jellyfin_receiver.config_generation()
+    assert during == before + 1
+    assert jellyfin_receiver._config_generation_current(before) is False
+    assert jellyfin_receiver._config_generation_current(during) is True

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -830,3 +830,45 @@ def test_disconnect_cannot_leave_a_socket_behind(monkeypatch) -> None:
         assert started == [], "a late heartbeat opened a socket nothing will retire"
     finally:
         jellyfin_ws._CURRENT = None
+
+
+def test_concurrent_server_switches_do_not_interleave(monkeypatch) -> None:
+    """The connect endpoints are sync defs, so FastAPI runs them on real threads.
+
+    Two overlapping switches each installed their own URL and token and then
+    raced their detection probes; the slower one landing last left the new
+    server's address beside the old server's identity.
+    """
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
+    monkeypatch.setattr(jellyfin_receiver, "_start_worker", lambda: None)
+    monkeypatch.setattr(jellyfin_receiver, "_stop_worker", lambda: None)
+    monkeypatch.setattr(jellyfin_receiver, "authenticate_once", lambda: {"ok": False})
+    monkeypatch.setattr(jellyfin_receiver, "_catalog_cache_clear", lambda: None)
+
+    def _detect(server_url, timeout_sec=3.0):
+        if "a.local" in server_url:
+            time.sleep(1.0)  # the distant or struggling server
+            return {"ok": True, "server_type": "jellyfin", "product_name": "Server A"}
+        return {"ok": True, "server_type": "emby", "product_name": "Server B"}
+
+    monkeypatch.setattr(jellyfin_receiver, "detect_server_type", _detect)
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "_persist_server_type",
+        lambda st, pn="": jellyfin_receiver._STATUS.update({"server_type": st, "server_product_name": pn}),
+    )
+
+    threads = [
+        threading.Thread(target=jellyfin_receiver.connect, kwargs={"server_url": "http://a.local:8096"}, daemon=True),
+        threading.Thread(target=jellyfin_receiver.connect, kwargs={"server_url": "http://b.local:8096"}, daemon=True),
+    ]
+    threads[0].start()
+    time.sleep(0.2)  # B arrives while A is still probing
+    threads[1].start()
+    for t in threads:
+        t.join(timeout=20)
+
+    url = str(jellyfin_receiver._STATUS["server_url"])
+    product = str(jellyfin_receiver._STATUS["server_product_name"])
+    expected = "Server B" if "b.local" in url else "Server A"
+    assert product == expected, f"torn state: {url} reported as {product}"

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -855,7 +855,7 @@ def test_concurrent_server_switches_do_not_interleave(monkeypatch) -> None:
     monkeypatch.setattr(
         jellyfin_receiver,
         "_persist_server_type",
-        lambda st, pn="": jellyfin_receiver._STATUS.update({"server_type": st, "server_product_name": pn}),
+        lambda st, pn="", **kw: jellyfin_receiver._STATUS.update({"server_type": st, "server_product_name": pn}),
     )
 
     threads = [
@@ -941,7 +941,7 @@ def test_an_in_flight_probe_cannot_publish_over_new_settings(monkeypatch) -> Non
     monkeypatch.setattr(
         jellyfin_receiver,
         "_persist_server_type",
-        lambda st, pn="": jellyfin_receiver._STATUS.update({"server_type": st, "server_product_name": pn}),
+        lambda st, pn="", **kw: jellyfin_receiver._STATUS.update({"server_type": st, "server_product_name": pn}),
     )
 
     probe = threading.Thread(target=jellyfin_receiver._maybe_retry_detection, daemon=True)
@@ -954,10 +954,104 @@ def test_an_in_flight_probe_cannot_publish_over_new_settings(monkeypatch) -> Non
     assert jellyfin_receiver._STATUS["server_product_name"] == "New Server"
 
 
-def test_config_generation_advances_once_per_transaction() -> None:
+def test_config_generation_advances_on_entry_and_on_commit() -> None:
+    """Both ends matter.
+
+    Entering invalidates work that started under the previous configuration.
+    Leaving invalidates work that started *mid*-transaction, which would
+    otherwise hold a generation that was current while the settings it read
+    were only half-installed.
+    """
     before = jellyfin_receiver.config_generation()
     with jellyfin_receiver._control_socket_suspended():
         during = jellyfin_receiver.config_generation()
-    assert during == before + 1
+        assert during == before + 1
+    after = jellyfin_receiver.config_generation()
+
+    assert after == during + 1
     assert jellyfin_receiver._config_generation_current(before) is False
-    assert jellyfin_receiver._config_generation_current(during) is True
+    assert jellyfin_receiver._config_generation_current(during) is False
+    assert jellyfin_receiver._config_generation_current(after) is True
+
+
+def test_work_started_mid_transaction_is_also_invalidated(monkeypatch) -> None:
+    """The generation must advance on commit, not only on entry.
+
+    Bumping only on the way in leaves a window: work that captures the new
+    generation while the transaction body is still installing settings read the
+    *old* URL and then published as though it were current. Driven
+    deterministically — the real window is microseconds wide, so racing it with
+    a sleep would prove nothing either way.
+    """
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_type", "emby")
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_product_name", "Old Server")
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "detect_server_type",
+        lambda url, timeout_sec=3.0: {"ok": True, "server_type": "emby", "product_name": "Old Server"},
+    )
+
+    # A probe that captured its generation inside a transaction, before the
+    # settings it read had finished being installed.
+    with jellyfin_receiver._control_socket_suspended():
+        captured = jellyfin_receiver.config_generation()
+
+    result = jellyfin_receiver._run_detection("http://old.local:8096", generation=captured)
+
+    assert result == {"ok": False, "reason": "config_changed"}
+    assert jellyfin_receiver._STATUS["server_product_name"] == "Old Server"
+
+
+def test_an_in_flight_progress_post_cannot_land_after_disconnect(monkeypatch) -> None:
+    """Progress posts take up to three seconds.
+
+    One completing after a disconnect set connected=True while running was
+    already false — a session reported live that nothing was driving.
+    """
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
+    monkeypatch.setattr(jellyfin_receiver, "_start_worker", lambda: None)
+    monkeypatch.setattr(jellyfin_receiver, "_stop_worker", lambda: None)
+    monkeypatch.setattr(jellyfin_receiver, "_catalog_cache_clear", lambda: None)
+    for key, value in (
+        ("enabled", True), ("running", True), ("connected", False),
+        ("server_url", "http://jf.lan:8096"),
+    ):
+        monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
+    monkeypatch.setattr(jellyfin_receiver, "_post_json", lambda url, payload, timeout=3.0: time.sleep(1.0))
+
+    done = threading.Event()
+
+    def _post():
+        jellyfin_receiver.send_progress_payload_once({"ItemId": "x"})
+        done.set()
+
+    t = threading.Thread(target=_post, daemon=True)
+    t.start()
+    time.sleep(0.2)  # the post is in flight
+    jellyfin_receiver.disconnect()
+    assert done.wait(10)
+
+    assert jellyfin_receiver._STATUS["running"] is False
+    assert jellyfin_receiver._STATUS["connected"] is False, "a retired post reported the session live"
+
+
+def test_authentication_captures_its_inputs_with_its_generation(monkeypatch) -> None:
+    """Reading the URL and stamping the generation separately is its own race."""
+    snap = jellyfin_receiver.config_snapshot()
+    assert "generation" in snap and "server_url" in snap and "username" in snap
+    # The snapshot is taken under one lock, so it cannot straddle a transaction.
+    before = snap["generation"]
+    with jellyfin_receiver._control_socket_suspended():
+        pass
+    assert jellyfin_receiver.config_snapshot()["generation"] != before
+
+
+def test_publish_is_a_single_critical_section() -> None:
+    """Check and write must not be separable, or a transaction slips between."""
+    applied: list[int] = []
+    gen = jellyfin_receiver.config_generation()
+    assert jellyfin_receiver._publish(gen, lambda: applied.append(1)) is True
+    assert applied == [1]
+    assert jellyfin_receiver._publish(gen - 1, lambda: applied.append(2)) is False
+    assert applied == [1], "a stale generation was allowed to write"

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -790,3 +790,43 @@ def test_the_live_session_still_reports_its_own_failures(monkeypatch) -> None:
         assert jellyfin_ws.status()["reconnects"] >= 1
     finally:
         jellyfin_ws._CURRENT = None
+
+
+def test_disconnect_cannot_leave_a_socket_behind(monkeypatch) -> None:
+    """Teardown must be a transaction, not a sequence.
+
+    _stop_worker gives the heartbeat one second to notice; a heartbeat parked
+    in a network call outlives that. It only has to reach ensure_running() once
+    while ``running`` is still true to leave a socket connected forever —
+    nothing retires it, because the heartbeat that would is already stopped.
+    """
+    started: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: True)
+    monkeypatch.setattr(jellyfin_ws, "_ws_connect", object())
+    monkeypatch.setattr(jellyfin_ws, "_start", lambda ident: started.append(ident))
+
+    for key, value in (
+        ("enabled", True), ("running", True),
+        ("server_url", "http://jf.lan:8096"), ("device_id", "relaytv-abc"),
+    ):
+        monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
+    monkeypatch.setattr(jellyfin_receiver, "active_token", lambda: "tok")
+    monkeypatch.setattr(jellyfin_receiver, "command_sink_registered", lambda: True)
+    # The real join waits a second for a parked heartbeat and then gives up.
+    monkeypatch.setattr(jellyfin_receiver, "_stop_worker", lambda: time.sleep(1.0))
+
+    jellyfin_ws._CURRENT = _parked_session(("http://jf.lan:8096", "relaytv-abc", "fp"))
+
+    def _late_heartbeat():
+        time.sleep(0.2)  # blocks on the lifecycle lock the teardown is holding
+        jellyfin_receiver._ensure_control_socket()
+
+    hb = threading.Thread(target=_late_heartbeat, daemon=True)
+    hb.start()
+    try:
+        jellyfin_receiver.disconnect()
+        hb.join(timeout=10)
+        assert jellyfin_receiver._STATUS["running"] is False
+        assert started == [], "a late heartbeat opened a socket nothing will retire"
+    finally:
+        jellyfin_ws._CURRENT = None

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Jellyfin control-socket tests (docs/JELLYFIN_OPERATIONS.md, "Cast target").
+
+Everything here runs against a fake socket. The point of the module under test
+is that RelayTV shows up as a cast target and obeys the remote, so the coverage
+is: what the server sends maps to the right command, keepalives keep the
+session alive, a slow command cannot stall them, and the access token never
+escapes into status or logs.
+"""
+import json
+import logging
+import threading
+import time
+
+import pytest
+
+from relaytv_app.integrations import jellyfin_receiver, jellyfin_ws
+
+
+@pytest.fixture(autouse=True)
+def _clean_socket_state():
+    """Leave the process-wide socket and sink exactly as they were found.
+
+    routes/jellyfin.py registers the real sink at import time; a test that
+    clears it must not leak that into the rest of the suite.
+    """
+    sink = jellyfin_receiver._COMMAND_SINK
+    jellyfin_ws.stop()
+    yield
+    jellyfin_ws.stop()
+    jellyfin_receiver.register_command_sink(sink)
+
+
+class FakeSocket:
+    """Minimal stand-in for websockets' sync ClientConnection."""
+
+    def __init__(self, inbound=()):
+        self._inbound = list(inbound)
+        self.sent: list[str] = []
+        self.closed = False
+        self._lock = threading.Lock()
+
+    def recv(self, timeout=None):
+        with self._lock:
+            if self._inbound:
+                return self._inbound.pop(0)
+        raise TimeoutError
+
+    def send(self, message):
+        with self._lock:
+            self.sent.append(message)
+
+    def push(self, message):
+        with self._lock:
+            self._inbound.append(message)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.closed = True
+        return False
+
+
+# --- message routing -------------------------------------------------------
+
+
+def test_play_message_becomes_a_play_command() -> None:
+    routed = jellyfin_ws.normalize_message(
+        json.dumps(
+            {
+                "MessageId": "m-1",
+                "MessageType": "Play",
+                "Data": {"ItemIds": ["abc"], "PlayCommand": "PlayNow", "StartPositionTicks": 90_000_000},
+            }
+        )
+    )
+    assert routed is not None
+    action, payload = routed
+    assert action == "play"
+    assert payload["ItemIds"] == ["abc"]
+    assert payload["PlayCommand"] == "PlayNow"
+    # Carried so extract_command_id dedupes a message the server repeats.
+    assert payload["MessageId"] == "m-1"
+
+
+def test_playstate_leaves_the_action_for_the_normalizer() -> None:
+    """Playstate carries its verb in the body, which normalize_action reads."""
+    from relaytv_app.integrations import jellyfin_service
+
+    for command, expected in (
+        ("Pause", "pause"),
+        ("Unpause", "resume"),
+        ("Stop", "stop"),
+        ("Seek", "seek"),
+        ("NextTrack", "next"),
+        ("PreviousTrack", "previous"),
+        ("PlayPause", "play_pause"),
+    ):
+        routed = jellyfin_ws.normalize_message({"MessageType": "Playstate", "Data": {"Command": command}})
+        assert routed is not None, command
+        action, payload = routed
+        assert action == ""
+        assert jellyfin_service.normalize_action(action or None, payload) == expected
+
+
+def test_general_command_flattens_arguments_for_volume() -> None:
+    routed = jellyfin_ws.normalize_message(
+        {"MessageType": "GeneralCommand", "Data": {"Name": "SetVolume", "Arguments": {"Volume": "42"}}}
+    )
+    assert routed is not None
+    action, payload = routed
+    assert payload["Volume"] == "42"
+
+    from relaytv_app.integrations import jellyfin_service
+
+    assert jellyfin_service.normalize_action(action or None, payload) == "set_volume"
+
+    class _Req:
+        def __init__(self, payload):
+            self.payload = payload
+            self.start_pos = None
+
+    assert jellyfin_service.extract_volume(_Req(payload)) == pytest.approx(42.0)
+
+
+def test_server_chatter_is_ignored() -> None:
+    """The control socket carries library and session events too."""
+    for message in (
+        {"MessageType": "Sessions", "Data": []},
+        {"MessageType": "UserDataChanged", "Data": {}},
+        {"MessageType": "KeepAlive"},
+        {"MessageType": "LibraryChanged", "Data": {}},
+        "not json at all",
+        {"no": "message type"},
+    ):
+        assert jellyfin_ws.normalize_message(message) is None
+
+
+# --- keepalive and reconnect ----------------------------------------------
+
+
+def test_keepalive_interval_is_half_the_server_timeout() -> None:
+    assert jellyfin_ws._keepalive_interval(60) == pytest.approx(30.0)
+    assert jellyfin_ws._keepalive_interval("30") == pytest.approx(15.0)
+    # A nonsense or zero timeout must not turn into a busy loop.
+    assert jellyfin_ws._keepalive_interval(0) == pytest.approx(30.0)
+    assert jellyfin_ws._keepalive_interval("nonsense") == pytest.approx(30.0)
+
+
+def test_read_loop_answers_force_keepalive(monkeypatch) -> None:
+    ws = FakeSocket([json.dumps({"MessageType": "ForceKeepAlive", "Data": 2})])
+    stop_at = time.monotonic() + 3.0
+
+    def _fake_is_set():
+        return time.monotonic() > stop_at
+
+    monkeypatch.setattr(jellyfin_ws._STOP, "is_set", _fake_is_set)
+    jellyfin_ws._read_loop(ws)
+
+    assert ws.sent, "no KeepAlive was ever sent"
+    assert all(json.loads(m)["MessageType"] == "KeepAlive" for m in ws.sent)
+    assert jellyfin_ws.status()["keepalive_sec"] == pytest.approx(1.0)
+
+
+def test_backoff_grows_and_is_capped(monkeypatch) -> None:
+    monkeypatch.setenv("RELAYTV_JELLYFIN_WS_RETRY_BASE_SEC", "3")
+    monkeypatch.setenv("RELAYTV_JELLYFIN_WS_RETRY_MAX_SEC", "60")
+    assert [jellyfin_ws.backoff_sec(n) for n in (1, 2, 3, 4, 5)] == [3.0, 6.0, 12.0, 24.0, 48.0]
+    assert jellyfin_ws.backoff_sec(50) == 60.0
+
+
+def test_a_slow_command_does_not_stall_keepalives(monkeypatch) -> None:
+    """Starting mpv takes seconds; the reader must not wait for it.
+
+    If commands ran inline, this ForceKeepAlive would go unanswered for the
+    length of the play and the server would drop the session mid-handoff.
+    """
+    started = threading.Event()
+    release = threading.Event()
+
+    def _slow_sink(action, payload):
+        started.set()
+        release.wait(5.0)
+        return {"ok": True}
+
+    jellyfin_receiver.register_command_sink(_slow_sink)
+    try:
+        jellyfin_ws._COMMANDS = jellyfin_ws.queue.Queue(maxsize=8)
+        worker = threading.Thread(target=jellyfin_ws._command_worker, daemon=True)
+        jellyfin_ws._STOP.clear()
+        worker.start()
+
+        ws = FakeSocket(
+            [
+                json.dumps({"MessageType": "ForceKeepAlive", "Data": 2}),
+                json.dumps({"MessageType": "Play", "Data": {"ItemIds": ["x"]}}),
+            ]
+        )
+        stop_at = time.monotonic() + 3.0
+        monkeypatch.setattr(jellyfin_ws._STOP, "is_set", lambda: time.monotonic() > stop_at)
+        jellyfin_ws._read_loop(ws)
+
+        assert started.is_set(), "command never reached the worker"
+        assert ws.sent, "keepalive was starved by the in-flight command"
+    finally:
+        release.set()
+        jellyfin_receiver.register_command_sink(None)
+
+
+def test_command_backlog_is_bounded(monkeypatch) -> None:
+    """A burst while playback is starting is dropped, not replayed later."""
+    jellyfin_ws._COMMANDS = jellyfin_ws.queue.Queue(maxsize=2)
+    for _ in range(5):
+        jellyfin_ws._submit("play", {})
+    assert jellyfin_ws.status()["commands_dropped"] == 3
+
+
+# --- secret handling -------------------------------------------------------
+
+
+def test_socket_url_carries_the_token_and_device() -> None:
+    url = jellyfin_ws.socket_url(server_url="http://jf.lan:8096", token="tok-123", device_id="relaytv-den")
+    assert url == "ws://jf.lan:8096/socket?api_key=tok-123&deviceId=relaytv-den"
+    assert jellyfin_ws.socket_url(server_url="https://jf.example/emby", token="t", device_id="d").startswith(
+        "wss://jf.example/emby/socket?"
+    )
+    # Nothing to dial without a session.
+    assert jellyfin_ws.socket_url(server_url="http://jf.lan:8096", token="", device_id="d") == ""
+
+
+def test_the_access_token_never_reaches_status_or_logs(caplog) -> None:
+    """A failed handshake reports the URL it tried, and that URL holds the token."""
+    token = "super-secret-token"
+    url = jellyfin_ws.socket_url(server_url="http://jf.lan:8096", token=token, device_id="relaytv-den")
+    with caplog.at_level(logging.WARNING):
+        jellyfin_ws._mark_error(f"failed to connect to {url}")
+
+    reported = str(jellyfin_ws.status().get("last_error") or "")
+    assert token not in reported
+    assert "<redacted>" in reported
+    assert token not in caplog.text
+    assert all(token not in str(value) for value in jellyfin_ws.status().values())
+
+
+def test_receiver_status_reports_socket_health_without_secrets() -> None:
+    st = jellyfin_receiver.status()
+    for key in ("ws_enabled", "ws_connected", "ws_reconnects", "cast_target_ready"):
+        assert key in st
+    assert st["cast_target_ready"] is False
+
+
+# --- dispatch seam ---------------------------------------------------------
+
+
+def test_dispatch_requires_a_registered_sink() -> None:
+    jellyfin_receiver.register_command_sink(None)
+    assert jellyfin_receiver.command_sink_registered() is False
+    with pytest.raises(RuntimeError):
+        jellyfin_receiver.dispatch_command("play", {})
+
+
+def test_dispatch_reaches_the_registered_sink() -> None:
+    seen: list[tuple[str, dict]] = []
+    jellyfin_receiver.register_command_sink(lambda action, payload: seen.append((action, payload)))
+    try:
+        jellyfin_receiver.dispatch_command("play", {"ItemIds": ["a"]})
+        assert seen == [("play", {"ItemIds": ["a"]})]
+    finally:
+        jellyfin_receiver.register_command_sink(None)
+
+
+def test_socket_does_not_dial_before_a_sink_exists() -> None:
+    """No point holding a socket we cannot act on."""
+    jellyfin_receiver.register_command_sink(None)
+    assert jellyfin_ws._ready() is False

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -14,6 +14,7 @@ import time
 
 import pytest
 
+from relaytv_app import state
 from relaytv_app.integrations import jellyfin_receiver, jellyfin_ws
 
 
@@ -319,7 +320,12 @@ def test_ensure_registration_reregisters_after_invalidation(monkeypatch) -> None
     monkeypatch.setitem(jellyfin_receiver._STATUS, "authenticated", True)
     monkeypatch.setitem(jellyfin_receiver._STATUS, "connected", True)
     monkeypatch.setitem(jellyfin_receiver._STATUS, "last_register_ok", True)
-    monkeypatch.setattr(jellyfin_receiver, "register_receiver_once", lambda: calls.append(1) or {"ok": True})
+    monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "tok")
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "register_receiver_once",
+        lambda **kwargs: calls.append(1) or {"ok": True},
+    )
 
     # Healthy: nothing to do.
     jellyfin_receiver._ensure_registration()
@@ -842,7 +848,7 @@ def test_concurrent_server_switches_do_not_interleave(monkeypatch) -> None:
     monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
     monkeypatch.setattr(jellyfin_receiver, "_start_worker", lambda: None)
     monkeypatch.setattr(jellyfin_receiver, "_stop_worker", lambda: None)
-    monkeypatch.setattr(jellyfin_receiver, "authenticate_once", lambda: {"ok": False})
+    monkeypatch.setattr(jellyfin_receiver, "authenticate_once", lambda **kwargs: {"ok": False})
     monkeypatch.setattr(jellyfin_receiver, "_catalog_cache_clear", lambda: None)
 
     def _detect(server_url, timeout_sec=3.0):
@@ -922,7 +928,7 @@ def test_an_in_flight_probe_cannot_publish_over_new_settings(monkeypatch) -> Non
     monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
     monkeypatch.setattr(jellyfin_receiver, "_start_worker", lambda: None)
     monkeypatch.setattr(jellyfin_receiver, "_stop_worker", lambda: None)
-    monkeypatch.setattr(jellyfin_receiver, "authenticate_once", lambda: {"ok": False})
+    monkeypatch.setattr(jellyfin_receiver, "authenticate_once", lambda **kwargs: {"ok": False})
     monkeypatch.setattr(jellyfin_receiver, "_catalog_cache_clear", lambda: None)
     for key, value in (
         ("enabled", True), ("running", True), ("authenticated", True),
@@ -1018,7 +1024,11 @@ def test_an_in_flight_progress_post_cannot_land_after_disconnect(monkeypatch) ->
         ("server_url", "http://jf.lan:8096"),
     ):
         monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
-    monkeypatch.setattr(jellyfin_receiver, "_post_json", lambda url, payload, timeout=3.0: time.sleep(1.0))
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "_post_json_for",
+        lambda context, path, payload, timeout=3.0: time.sleep(1.0),
+    )
 
     done = threading.Event()
 
@@ -1038,13 +1048,15 @@ def test_an_in_flight_progress_post_cannot_land_after_disconnect(monkeypatch) ->
 
 def test_authentication_captures_its_inputs_with_its_generation(monkeypatch) -> None:
     """Reading the URL and stamping the generation separately is its own race."""
-    snap = jellyfin_receiver.config_snapshot()
-    assert "generation" in snap and "server_url" in snap and "username" in snap
+    context = jellyfin_receiver._request_context()
+    assert isinstance(context.generation, int)
+    assert isinstance(context.server_url, str)
+    assert repr(context).startswith("<relaytv_app.integrations.jellyfin_receiver._RequestContext object at ")
     # The snapshot is taken under one lock, so it cannot straddle a transaction.
-    before = snap["generation"]
+    before = context.generation
     with jellyfin_receiver._control_socket_suspended():
         pass
-    assert jellyfin_receiver.config_snapshot()["generation"] != before
+    assert jellyfin_receiver._request_context().generation != before
 
 
 def test_publish_is_a_single_critical_section() -> None:
@@ -1055,3 +1067,231 @@ def test_publish_is_a_single_critical_section() -> None:
     assert applied == [1]
     assert jellyfin_receiver._publish(gen - 1, lambda: applied.append(2)) is False
     assert applied == [1], "a stale generation was allowed to write"
+
+
+def test_authentication_cannot_publish_after_its_snapshot_is_disconnected(monkeypatch) -> None:
+    """The enabled/running decision belongs to the same snapshot as the token."""
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
+    monkeypatch.setattr(jellyfin_receiver, "_stop_worker", lambda: None)
+    monkeypatch.setattr(jellyfin_receiver, "_catalog_cache_clear", lambda: None)
+    for key, value in (
+        ("enabled", True),
+        ("running", True),
+        ("authenticated", False),
+        ("server_url", "http://old.local:8096"),
+        ("auth_user_configured", True),
+    ):
+        monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
+    monkeypatch.setattr(jellyfin_receiver, "_AUTH_USERNAME", "old-user")
+    monkeypatch.setattr(jellyfin_receiver, "_AUTH_PASSWORD", "old-password")
+    monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "")
+
+    original_context = jellyfin_receiver._request_context
+
+    def _capture_then_disconnect():
+        context = original_context()
+        jellyfin_receiver.disconnect()
+        return context
+
+    monkeypatch.setattr(jellyfin_receiver, "_request_context", _capture_then_disconnect)
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {
+                    "AccessToken": "old-token",
+                    "User": {"Id": "old-user-id"},
+                    "SessionInfo": {"Id": "old-session"},
+                }
+            ).encode()
+
+    monkeypatch.setattr(jellyfin_receiver._urlrequest, "urlopen", lambda req, timeout=5: _Response())
+
+    result = jellyfin_receiver.authenticate_once()
+
+    assert result == {"ok": False, "reason": "config_changed"}
+    assert jellyfin_receiver._STATUS["running"] is False
+    assert jellyfin_receiver._STATUS["authenticated"] is False
+    assert jellyfin_receiver._ACCESS_TOKEN == ""
+
+
+def test_context_http_request_never_reloads_a_new_servers_token(monkeypatch) -> None:
+    """A URL and token captured together stay together even after a switch."""
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
+    with jellyfin_receiver._LOCK:
+        jellyfin_receiver._STATUS.update(
+            {
+                "enabled": True,
+                "running": True,
+                "server_url": "http://old.local:8096",
+                "device_id": "old-device",
+            }
+        )
+        jellyfin_receiver._ACCESS_TOKEN = "old-token"
+    context = jellyfin_receiver._request_context()
+
+    with jellyfin_receiver._control_socket_suspended():
+        with jellyfin_receiver._LOCK:
+            jellyfin_receiver._STATUS["server_url"] = "http://new.local:8096"
+            jellyfin_receiver._STATUS["device_id"] = "new-device"
+            jellyfin_receiver._ACCESS_TOKEN = "new-token"
+
+    requests: list[tuple[str, str | None]] = []
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    def _capture(req, timeout=3.0):
+        requests.append((req.full_url, req.get_header("X-emby-token")))
+        return _Response()
+
+    monkeypatch.setattr(jellyfin_receiver._urlrequest, "urlopen", _capture)
+    jellyfin_receiver._post_json_for(context, "/Sessions/Playing/Progress", {"ItemId": "x"})
+
+    assert requests == [("http://old.local:8096/Sessions/Playing/Progress", "old-token")]
+
+
+def test_registration_post_and_readback_share_one_context(monkeypatch) -> None:
+    seen: list[tuple[str, int, str, str]] = []
+    for key, value in (
+        ("enabled", True),
+        ("running", True),
+        ("server_url", "http://jf.local:8096"),
+        ("device_id", "relaytv-device"),
+    ):
+        monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
+    monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "session-token")
+
+    def _post(context, path, payload, timeout=3.0):
+        seen.append(("post", id(context), context.server_url, context.token))
+
+    def _readback(context, device_id, timeout=3.0):
+        seen.append(("readback", id(context), context.server_url, context.token))
+        return {"DeviceId": device_id, "SupportsMediaControl": True}
+
+    monkeypatch.setattr(jellyfin_receiver, "_post_json_for", _post)
+    monkeypatch.setattr(jellyfin_receiver, "_read_session_capabilities_for", _readback)
+
+    result = jellyfin_receiver.register_receiver_once()
+
+    assert result["ok"] is True
+    assert seen == [
+        ("post", seen[0][1], "http://jf.local:8096", "session-token"),
+        ("readback", seen[0][1], "http://jf.local:8096", "session-token"),
+    ]
+
+
+def test_registration_switch_discards_the_old_context_result(monkeypatch) -> None:
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
+    for key, value in (
+        ("enabled", True),
+        ("running", True),
+        ("connected", False),
+        ("server_url", "http://old.local:8096"),
+        ("device_id", "old-device"),
+        ("media_control_verified", None),
+    ):
+        monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
+    monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "old-token")
+    posted: list[tuple[str, str, str]] = []
+
+    def _post_then_switch(context, path, payload, timeout=3.0):
+        posted.append((_context_url(context, path), context.device_id, context.token))
+        with jellyfin_receiver._control_socket_suspended():
+            with jellyfin_receiver._LOCK:
+                jellyfin_receiver._STATUS["server_url"] = "http://new.local:8096"
+                jellyfin_receiver._STATUS["device_id"] = "new-device"
+                jellyfin_receiver._ACCESS_TOKEN = "new-token"
+
+    def _context_url(context, path):
+        return jellyfin_receiver._context_url(context, path)
+
+    monkeypatch.setattr(jellyfin_receiver, "_post_json_for", _post_then_switch)
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "_read_session_capabilities_for",
+        lambda context, device_id, timeout=3.0: {
+            "DeviceId": device_id,
+            "SupportsMediaControl": True,
+        },
+    )
+
+    result = jellyfin_receiver.register_receiver_once()
+
+    assert result == {"ok": False, "reason": "config_changed"}
+    assert posted == [("http://old.local:8096/Sessions/Capabilities/Full", "old-device", "old-token")]
+    assert jellyfin_receiver._STATUS["server_url"] == "http://new.local:8096"
+    assert jellyfin_receiver._STATUS["connected"] is False
+    assert jellyfin_receiver._STATUS["media_control_verified"] is None
+
+
+def test_manual_server_type_change_invalidates_an_in_flight_detection(monkeypatch) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
+    monkeypatch.setattr(jellyfin_receiver.runtime_config, "set_value", lambda key, value: None)
+    monkeypatch.setattr(state, "update_settings", lambda values: None)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_type", "jellyfin")
+
+    def _detect(url, timeout_sec=3.0):
+        started.set()
+        assert release.wait(5)
+        return {"ok": True, "server_type": "jellyfin", "product_name": "Jellyfin Server"}
+
+    monkeypatch.setattr(jellyfin_receiver, "detect_server_type", _detect)
+    result: list[dict[str, object]] = []
+    probe = threading.Thread(
+        target=lambda: result.append(jellyfin_receiver._run_detection("http://jf.local:8096")),
+        daemon=True,
+    )
+    probe.start()
+    assert started.wait(5)
+    jellyfin_receiver.set_server_type("emby")
+    release.set()
+    probe.join(timeout=5)
+
+    assert result == [{"ok": False, "reason": "config_changed"}]
+    assert jellyfin_receiver._STATUS["server_type"] == "emby"
+
+
+def test_configuration_transaction_advances_generation_when_body_raises() -> None:
+    before = jellyfin_receiver.config_generation()
+    with pytest.raises(RuntimeError):
+        with jellyfin_receiver._configuration_transaction(suspend_socket=False):
+            during = jellyfin_receiver.config_generation()
+            raise RuntimeError("settings failed")
+
+    assert during == before + 1
+    assert jellyfin_receiver.config_generation() == before + 2
+
+
+def test_retired_registration_does_not_schedule_retry_state(monkeypatch) -> None:
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "running", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://old.local:8096")
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "connected", False)
+    monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "old-token")
+    monkeypatch.setattr(jellyfin_receiver, "_REGISTER_RETRY_FAILURES", 0)
+    monkeypatch.setattr(jellyfin_receiver, "_NEXT_REGISTER_RETRY_TS", 0.0)
+
+    def _retire_while_registering(*, _context=None):
+        with jellyfin_receiver._configuration_transaction(suspend_socket=False):
+            pass
+        return {"ok": False, "reason": "config_changed"}
+
+    monkeypatch.setattr(jellyfin_receiver, "register_receiver_once", _retire_while_registering)
+
+    jellyfin_receiver._ensure_registration(now_ts=100.0)
+
+    assert jellyfin_receiver._REGISTER_RETRY_FAILURES == 0
+    assert jellyfin_receiver._NEXT_REGISTER_RETRY_TS == 0.0

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -654,3 +654,139 @@ def test_stop_does_not_wait_on_the_closing_handshake() -> None:
 
     assert elapsed < 1.0, f"stop() blocked {elapsed:.1f}s on the close handshake"
     assert session.stop.is_set()
+
+
+# --- review round three ----------------------------------------------------
+
+
+def _parked_session(bound=("http://old.lan:8096", "relaytv-abc", "fp-old")):
+    """A session whose threads outlive stop()'s join budget."""
+    s = jellyfin_ws._Session(bound)
+    s.reader = threading.Thread(target=lambda: time.sleep(10), daemon=True)
+    s.worker = threading.Thread(target=lambda: time.sleep(10), daemon=True)
+    s.reader.start()
+    s.worker.start()
+    return s
+
+
+def test_stop_and_start_are_serialized(monkeypatch) -> None:
+    """stop() leaves _CURRENT None for seconds while it joins.
+
+    The heartbeat used to walk into that gap, start a replacement, and have its
+    shared state reset by the stop() still in flight.
+    """
+    old = ("http://old.lan:8096", "relaytv-abc", "fp-old")
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: True)
+    monkeypatch.setattr(jellyfin_ws, "_ws_connect", object())
+    monkeypatch.setattr(jellyfin_ws, "_identity", lambda: old)
+
+    victim = _parked_session(old)
+    jellyfin_ws._CURRENT = victim
+    order: list[str] = []
+
+    def _heartbeat():
+        time.sleep(0.3)
+        jellyfin_ws.ensure_running()
+        order.append("ensure_running")
+
+    t = threading.Thread(target=_heartbeat, daemon=True)
+    t.start()
+    try:
+        jellyfin_ws.stop()
+        order.append("stop")
+        t.join(timeout=10)
+    finally:
+        jellyfin_ws._CURRENT = None
+
+    assert order == ["stop", "ensure_running"], f"interleaved: {order}"
+
+
+def test_no_socket_opens_while_configuration_is_changing(monkeypatch) -> None:
+    """Stopping then rewriting settings is not enough on its own.
+
+    A heartbeat firing between the two opened a socket to the server being
+    replaced, which then kept taking commands until a later heartbeat noticed.
+    """
+    old = ("http://old.lan:8096", "relaytv-abc", "fp-old")
+    started: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: True)
+    monkeypatch.setattr(jellyfin_ws, "_ws_connect", object())
+    monkeypatch.setattr(jellyfin_ws, "_identity", lambda: old)
+    monkeypatch.setattr(jellyfin_ws, "_start", lambda ident: started.append(ident))
+
+    jellyfin_ws._CURRENT = _parked_session(old)
+    try:
+        with jellyfin_ws.suspended():
+            for _ in range(5):
+                jellyfin_ws.ensure_running()
+            assert started == [], "a socket was opened mid-transaction"
+        # Normal service resumes once the transaction closes.
+        jellyfin_ws.ensure_running()
+        assert started == [old]
+    finally:
+        jellyfin_ws._CURRENT = None
+
+
+def test_suspension_is_released_even_if_the_body_raises() -> None:
+    """A failed settings save must not wedge the socket down forever."""
+    with pytest.raises(RuntimeError):
+        with jellyfin_ws.suspended():
+            raise RuntimeError("settings write failed")
+    assert jellyfin_ws._SUSPENDED == 0
+
+
+def test_a_retired_dial_failure_does_not_report_on_the_live_session(monkeypatch) -> None:
+    """The success path was guarded; the failure path was not.
+
+    A handshake that fails after its generation was retired would pin the
+    replacement's ws_last_error to an address nobody is talking to.
+    """
+    live = jellyfin_ws._Session(("http://new.lan:8096", "relaytv-abc", "fp-new"))
+    jellyfin_ws._CURRENT = live
+    with jellyfin_ws._LOCK:
+        jellyfin_ws._STATE["last_error"] = None
+        jellyfin_ws._STATE["reconnects"] = 0
+
+    retired = jellyfin_ws._Session(("http://old.lan:8096", "relaytv-abc", "fp-old"))
+
+    def _dial(session):
+        # stop() lands while this handshake is in flight, as it does when
+        # settings are saved mid-dial.
+        session.stop.set()
+        raise RuntimeError("old server refused the handshake at http://old.lan:8096")
+
+    monkeypatch.setattr(jellyfin_ws, "_connect_once", _dial)
+    monkeypatch.setattr(jellyfin_ws, "_ready", lambda: True)
+    try:
+        jellyfin_ws._socket_worker(retired)
+        assert jellyfin_ws.status()["last_error"] is None
+        assert jellyfin_ws.status()["reconnects"] == 0
+    finally:
+        jellyfin_ws._CURRENT = None
+
+
+def test_the_live_session_still_reports_its_own_failures(monkeypatch) -> None:
+    """The guard must not silence the generation that actually owns the state."""
+    live = jellyfin_ws._Session(("http://jf.lan:8096", "relaytv-abc", "fp"))
+    jellyfin_ws._CURRENT = live
+    with jellyfin_ws._LOCK:
+        jellyfin_ws._STATE["last_error"] = None
+        jellyfin_ws._STATE["reconnects"] = 0
+
+    calls = {"n": 0}
+
+    def _dial(session):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            session.stop.set()
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(jellyfin_ws, "_connect_once", _dial)
+    monkeypatch.setattr(jellyfin_ws, "_ready", lambda: True)
+    monkeypatch.setattr(jellyfin_ws, "backoff_sec", lambda failures: 0.01)
+    try:
+        jellyfin_ws._socket_worker(live)
+        assert "connection refused" in str(jellyfin_ws.status()["last_error"])
+        assert jellyfin_ws.status()["reconnects"] >= 1
+    finally:
+        jellyfin_ws._CURRENT = None

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -1295,3 +1295,29 @@ def test_retired_registration_does_not_schedule_retry_state(monkeypatch) -> None
 
     assert jellyfin_receiver._REGISTER_RETRY_FAILURES == 0
     assert jellyfin_receiver._NEXT_REGISTER_RETRY_TS == 0.0
+
+
+def test_stale_retry_scheduling_is_rejected_at_the_publish() -> None:
+    """The guard on _schedule_register_retry covers its own window.
+
+    test_retired_registration_does_not_schedule_retry_state exercises the
+    earlier `config_changed` return, so it passes with or without this guard.
+    The window this closes is narrower: registration fails for an ordinary
+    reason and settings change before the backoff is recorded, which would
+    otherwise pin a retry deadline belonging to the previous server.
+    """
+    stale = jellyfin_receiver.config_generation() - 1
+    before_failures = jellyfin_receiver._REGISTER_RETRY_FAILURES
+    before_ts = jellyfin_receiver._NEXT_REGISTER_RETRY_TS
+
+    assert jellyfin_receiver._schedule_register_retry(100.0, 5, 30.0, generation=stale) is False
+    assert jellyfin_receiver._REGISTER_RETRY_FAILURES == before_failures
+    assert jellyfin_receiver._NEXT_REGISTER_RETRY_TS == before_ts
+
+    assert jellyfin_receiver._clear_register_retry_state(generation=stale) is False
+
+    # The current generation still writes.
+    current = jellyfin_receiver.config_generation()
+    assert jellyfin_receiver._schedule_register_retry(100.0, 5, 30.0, generation=current) is True
+    assert jellyfin_receiver._REGISTER_RETRY_FAILURES == 5
+    jellyfin_receiver._clear_register_retry_state()

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -488,3 +488,20 @@ def test_identity_fingerprints_the_token() -> None:
 
     assert identity is not None
     assert "super-secret-token" not in "".join(identity)
+
+
+def test_device_id_is_derived_the_same_way_everywhere(monkeypatch) -> None:
+    """Jellyfin keys sessions and history on DeviceId.
+
+    Startup appended the hostname and the rename paths did not, so renaming a
+    device and then restarting made one TV show up as two cast targets.
+    """
+    monkeypatch.delenv("RELAYTV_JELLYFIN_DEVICE_ID", raising=False)
+    expected = jellyfin_receiver.derive_device_id("Living Room")
+    assert expected.startswith("relaytv-living-room-")
+
+    jellyfin_receiver.set_device_identity("Living Room")
+    assert jellyfin_receiver._STATUS["device_id"] == expected
+
+    monkeypatch.setenv("RELAYTV_JELLYFIN_DEVICE_ID", "pinned-id")
+    assert jellyfin_receiver.derive_device_id("Anything") == "pinned-id"

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -1321,3 +1321,69 @@ def test_stale_retry_scheduling_is_rejected_at_the_publish() -> None:
     assert jellyfin_receiver._schedule_register_retry(100.0, 5, 30.0, generation=current) is True
     assert jellyfin_receiver._REGISTER_RETRY_FAILURES == 5
     jellyfin_receiver._clear_register_retry_state()
+
+
+def test_teardown_does_not_hang_on_a_heartbeat_blocked_in_a_publish(monkeypatch) -> None:
+    """The one interleaving that looks like a cycle.
+
+    Teardown holds _TRANSACTION and then joins the heartbeat, while the
+    heartbeat wants _TRANSACTION to publish a detection result. The join can
+    never succeed, so it must stay bounded — an unbounded join here is a
+    deadlock, and nothing else in the design would catch it.
+    """
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
+    monkeypatch.setattr(jellyfin_receiver, "_catalog_cache_clear", lambda: None)
+    for key, value in (
+        ("enabled", True), ("running", True), ("authenticated", True),
+        ("server_url", "http://jf.lan:8096"), ("server_type", "emby"),
+        ("server_product_name", "Old Server"),
+        ("last_detect_ok", False), ("last_detect_ts", None),
+    ):
+        monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
+
+    teardown_holds_lock = threading.Event()
+    heartbeat_started = threading.Event()
+    outcome: dict = {}
+
+    def _detect(url, timeout_sec=3.0):
+        # Finish the probe only once teardown owns the transaction, so the
+        # publish that follows is guaranteed to block on it.
+        teardown_holds_lock.wait(10)
+        return {"ok": True, "server_type": "emby", "product_name": "Old Server"}
+
+    monkeypatch.setattr(jellyfin_receiver, "detect_server_type", _detect)
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "_persist_server_type",
+        lambda st, pn="", **kw: jellyfin_receiver._STATUS.update(
+            {"server_type": st, "server_product_name": pn}
+        ),
+    )
+
+    def _heartbeat():
+        gen = jellyfin_receiver.config_generation()
+        heartbeat_started.set()
+        outcome["detection"] = jellyfin_receiver._run_detection("http://jf.lan:8096", generation=gen)
+
+    hb = threading.Thread(target=_heartbeat, daemon=True)
+    hb.start()
+    assert heartbeat_started.wait(5)
+
+    def _stop_worker():
+        teardown_holds_lock.set()
+        time.sleep(0.2)  # let the heartbeat reach the blocked publish
+        hb.join(timeout=1.0)
+
+    monkeypatch.setattr(jellyfin_receiver, "_stop_worker", _stop_worker)
+
+    started = time.monotonic()
+    jellyfin_receiver.disconnect()
+    elapsed = time.monotonic() - started
+    hb.join(timeout=10)
+
+    assert elapsed < 6.0, f"teardown took {elapsed:.1f}s — the join is no longer bounded"
+    assert hb.is_alive() is False
+    assert jellyfin_receiver._STATUS["running"] is False
+    # The heartbeat wakes after teardown releases and discards its own result.
+    assert outcome["detection"] == {"ok": False, "reason": "config_changed"}
+    assert jellyfin_receiver._STATUS["server_product_name"] == "Old Server"

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -148,15 +148,17 @@ def test_keepalive_interval_is_half_the_server_timeout() -> None:
     assert jellyfin_ws._keepalive_interval("nonsense") == pytest.approx(30.0)
 
 
-def test_read_loop_answers_force_keepalive(monkeypatch) -> None:
+def _session(deadline_sec=3.0):
+    """A session whose stop flag trips after a short deadline."""
+    s = jellyfin_ws._Session(("http://jf.lan:8096", "relaytv-den", "fp"))
+    stop_at = time.monotonic() + deadline_sec
+    s.stop.is_set = lambda: time.monotonic() > stop_at  # type: ignore[method-assign]
+    return s
+
+
+def test_read_loop_answers_force_keepalive() -> None:
     ws = FakeSocket([json.dumps({"MessageType": "ForceKeepAlive", "Data": 2})])
-    stop_at = time.monotonic() + 3.0
-
-    def _fake_is_set():
-        return time.monotonic() > stop_at
-
-    monkeypatch.setattr(jellyfin_ws._STOP, "is_set", _fake_is_set)
-    jellyfin_ws._read_loop(ws)
+    jellyfin_ws._read_loop(ws, _session())
 
     assert ws.sent, "no KeepAlive was ever sent"
     assert all(json.loads(m)["MessageType"] == "KeepAlive" for m in ws.sent)
@@ -170,7 +172,18 @@ def test_backoff_grows_and_is_capped(monkeypatch) -> None:
     assert jellyfin_ws.backoff_sec(50) == 60.0
 
 
-def test_a_slow_command_does_not_stall_keepalives(monkeypatch) -> None:
+def test_backoff_survives_a_very_long_outage() -> None:
+    """The failure count keeps climbing while a server stays down.
+
+    Capping only the result still evaluates 2**(n-1) first, which overflows the
+    float multiply around failure 1025 — roughly 17 hours in at the default
+    delay — and the OverflowError took the socket worker down with it.
+    """
+    for failures in (1024, 1025, 100_000, 2**31):
+        assert jellyfin_ws.backoff_sec(failures) == 60.0
+
+
+def test_a_slow_command_does_not_stall_keepalives() -> None:
     """Starting mpv takes seconds; the reader must not wait for it.
 
     If commands ran inline, this ForceKeepAlive would go unanswered for the
@@ -185,10 +198,9 @@ def test_a_slow_command_does_not_stall_keepalives(monkeypatch) -> None:
         return {"ok": True}
 
     jellyfin_receiver.register_command_sink(_slow_sink)
+    session = _session()
     try:
-        jellyfin_ws._COMMANDS = jellyfin_ws.queue.Queue(maxsize=8)
-        worker = threading.Thread(target=jellyfin_ws._command_worker, daemon=True)
-        jellyfin_ws._STOP.clear()
+        worker = threading.Thread(target=jellyfin_ws._command_worker, args=(session,), daemon=True)
         worker.start()
 
         ws = FakeSocket(
@@ -197,9 +209,7 @@ def test_a_slow_command_does_not_stall_keepalives(monkeypatch) -> None:
                 json.dumps({"MessageType": "Play", "Data": {"ItemIds": ["x"]}}),
             ]
         )
-        stop_at = time.monotonic() + 3.0
-        monkeypatch.setattr(jellyfin_ws._STOP, "is_set", lambda: time.monotonic() > stop_at)
-        jellyfin_ws._read_loop(ws)
+        jellyfin_ws._read_loop(ws, session)
 
         assert started.is_set(), "command never reached the worker"
         assert ws.sent, "keepalive was starved by the in-flight command"
@@ -208,11 +218,12 @@ def test_a_slow_command_does_not_stall_keepalives(monkeypatch) -> None:
         jellyfin_receiver.register_command_sink(None)
 
 
-def test_command_backlog_is_bounded(monkeypatch) -> None:
+def test_command_backlog_is_bounded() -> None:
     """A burst while playback is starting is dropped, not replayed later."""
-    jellyfin_ws._COMMANDS = jellyfin_ws.queue.Queue(maxsize=2)
+    session = jellyfin_ws._Session(("u", "d", "f"))
+    session.commands = jellyfin_ws.queue.Queue(maxsize=2)
     for _ in range(5):
-        jellyfin_ws._submit("play", {})
+        jellyfin_ws._submit(session, "play", {})
     assert jellyfin_ws.status()["commands_dropped"] == 3
 
 
@@ -317,3 +328,163 @@ def test_ensure_registration_reregisters_after_invalidation(monkeypatch) -> None
     jellyfin_receiver.invalidate_registration("socket_connected")
     jellyfin_receiver._ensure_registration()
     assert calls == [1]
+
+
+# --- session lifetime ------------------------------------------------------
+
+
+def test_proxy_is_only_passed_when_the_library_accepts_it() -> None:
+    """connect() gained proxy in websockets 15.0.
+
+    On 13.x and 14.x passing it is a TypeError on every single connection, so
+    a build that lands an older websockets must degrade, not fail closed.
+    """
+    import inspect as _inspect
+
+    from websockets.sync.client import connect
+
+    supported = "proxy" in _inspect.signature(connect).parameters
+    assert jellyfin_ws._PROXY_KWARG_SUPPORTED is supported
+
+
+def test_connect_omits_proxy_on_an_older_websockets(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    class _Conn:
+        def recv(self, timeout=None):
+            raise TimeoutError
+
+        def send(self, message):
+            pass
+
+        def close(self):
+            pass
+
+    def _fake_connect(url, **kwargs):
+        if "proxy" in kwargs:
+            raise TypeError("create_connection() got an unexpected keyword argument 'proxy'")
+        seen.update(kwargs)
+        return _Conn()
+
+    monkeypatch.setattr(jellyfin_ws, "_ws_connect", _fake_connect)
+    monkeypatch.setattr(jellyfin_ws, "_PROXY_KWARG_SUPPORTED", False)
+    monkeypatch.setattr(
+        jellyfin_receiver, "status", lambda: {"server_url": "http://jf.lan:8096", "device_id": "relaytv-den"}
+    )
+    monkeypatch.setattr(jellyfin_receiver, "active_token", lambda: "tok")
+    monkeypatch.setattr(jellyfin_receiver, "invalidate_registration", lambda reason="": None)
+
+    session = _session(deadline_sec=0.0)
+    jellyfin_ws._connect_once(session)
+
+    assert "proxy" not in seen
+    assert seen["max_size"] == 2**20
+
+
+def test_each_session_owns_its_stop_flag() -> None:
+    """A reader parked in recv() can outlive stop().
+
+    With one module-level event, the next start would clear the flag out from
+    under the survivor and it would carry on dispatching from a server nobody
+    is talking to any more. A generation's flag can only ever be set.
+    """
+    first = jellyfin_ws._Session(("u", "d", "f1"))
+    first.stop.set()
+    second = jellyfin_ws._Session(("u", "d", "f2"))
+
+    assert second.stop.is_set() is False
+    assert first.stop.is_set() is True, "starting a new session un-stopped the old one"
+
+
+def test_stop_closes_the_live_connection() -> None:
+    """Closing is what makes stop() prompt; joining alone waits out recv."""
+    closed = threading.Event()
+
+    class _Conn:
+        def close(self):
+            closed.set()
+
+    session = jellyfin_ws._Session(("u", "d", "f"))
+    session.ws = _Conn()
+    jellyfin_ws._CURRENT = session
+
+    jellyfin_ws.stop()
+
+    assert closed.is_set()
+    assert session.stop.is_set()
+    assert jellyfin_ws._CURRENT is None
+
+
+def test_a_stopped_session_drops_queued_commands() -> None:
+    """Commands queued before a server switch belong to the old server."""
+    ran: list[str] = []
+    jellyfin_receiver.register_command_sink(lambda action, payload: ran.append(action))
+    try:
+        session = jellyfin_ws._Session(("u", "d", "f"))
+        session.commands.put_nowait(("play", {}))
+        session.stop.set()
+        jellyfin_ws._command_worker(session)
+        assert ran == []
+    finally:
+        jellyfin_receiver.register_command_sink(None)
+
+
+def test_identity_change_restarts_the_socket(monkeypatch) -> None:
+    """Switching server or credentials must not leave the old socket attached.
+
+    ensure_running() used to return on "thread is alive", so the previous
+    Jellyfin server kept a live command channel to this device while the new
+    session had nothing listening.
+    """
+    identity = {"value": ("http://old.lan:8096", "relaytv-den", "fp-old")}
+    started: list[tuple[str, str, str]] = []
+    stopped: list[int] = []
+
+    monkeypatch.setattr(jellyfin_ws, "_identity", lambda: identity["value"])
+    monkeypatch.setattr(jellyfin_ws, "_start", lambda ident: started.append(ident))
+    monkeypatch.setattr(jellyfin_ws, "stop", lambda: stopped.append(1))
+
+    jellyfin_ws.ensure_running()
+    assert started == [("http://old.lan:8096", "relaytv-den", "fp-old")]
+
+    # Pretend that session is now live.
+    live = jellyfin_ws._Session(identity["value"])
+    live.reader = threading.Thread(target=lambda: time.sleep(2.0), daemon=True)
+    live.reader.start()
+    jellyfin_ws._CURRENT = live
+    try:
+        jellyfin_ws.ensure_running()
+        assert stopped == [] and len(started) == 1, "restarted an unchanged session"
+
+        identity["value"] = ("http://new.lan:8096", "relaytv-den", "fp-new")
+        jellyfin_ws.ensure_running()
+        assert stopped == [1], "old socket was left attached to the old server"
+        assert started[-1] == ("http://new.lan:8096", "relaytv-den", "fp-new")
+    finally:
+        jellyfin_ws._CURRENT = None
+
+
+def test_identity_fingerprints_the_token() -> None:
+    """The bound identity is compared, never displayed — keep the token out."""
+    from relaytv_app.integrations import jellyfin_ws as mod
+
+    def _fake_status():
+        return {"enabled": True, "running": True, "server_url": "http://jf.lan:8096", "device_id": "relaytv-den"}
+
+    real_status, real_token, real_sink = (
+        jellyfin_receiver.status,
+        jellyfin_receiver.active_token,
+        jellyfin_receiver.command_sink_registered,
+    )
+    jellyfin_receiver.status = _fake_status
+    jellyfin_receiver.active_token = lambda: "super-secret-token"
+    jellyfin_receiver.command_sink_registered = lambda: True
+    try:
+        identity = mod._identity()
+    finally:
+        jellyfin_receiver.status = real_status
+        jellyfin_receiver.active_token = real_token
+        jellyfin_receiver.command_sink_registered = real_sink
+
+    assert identity is not None
+    assert "super-secret-token" not in "".join(identity)


### PR DESCRIPTION
## User impact

RelayTV now appears in the **Cast** menu of the Jellyfin web and mobile clients.
Pick a room, hit play, and the movie starts on that TV; the phone then acts as
the remote — play/pause, a draggable scrubber, skip, next/previous, volume and
mute. Jellyfin tracks position, so resume works from any device afterwards.
Nothing to configure beyond the Jellyfin credentials RelayTV already has. Each
device is its own cast target, named by its `device_name`.

## What was actually broken

Two independent problems, both reproduced against a live Jellyfin 10.11.11
before any code was written.

**Capabilities registration was a silent no-op.** `register_receiver_once()`
walked five payload shapes and stopped at the first that did not raise. The
first posts `{"Capabilities": {...}}` to `/Sessions/Capabilities/Full`, which
the server answers **204** and binds as an all-default DTO — *erasing* the
session's capabilities while RelayTV recorded `last_register_ok: true`. The
unwrapped candidates could not rescue it either: the command list held
`PlaystateCommand` values (`Stop`, `Pause`, `Seek`, …) in a
`GeneralCommandType` field, so the server returned **400**. The live session
read back:

```json
{"DeviceId": "relaytv-living-room-nuc.lan", "SupportsRemoteControl": false,
 "SupportsMediaControl": false, "PlayableMediaTypes": [], "SupportedCommands": []}
```

**There was no WebSocket.** The server computes `SupportsRemoteControl` as
"media control advertised **and** a live socket on the session", so the device
stayed invisible to casting regardless of capabilities.

## Approach

Registration now posts one correct unwrapped body and **reads the session back**
before claiming success — a 204 is not evidence. `integrations/jellyfin_ws.py`
holds the control socket open, answers `ForceKeepAlive` on the server's stated
interval, reconnects with exponential backoff, and routes
`Play`/`Playstate`/`GeneralCommand` through a command sink the routes package
registers — so the socket reuses the same ingress as
`POST /integrations/jellyfin/command` rather than growing a second copy of
command handling. Commands run on their own worker: starting mpv takes 6–12s on
a Pi and would otherwise starve the keepalive and drop the session mid-handoff.

## Three defects found by live testing, each fixed with a guardrail

1. **`ToggleMute` was advertised but unhandled** — accepted by the server, 400
   at the ingress, silent on the TV: a dead speaker button on every remote in
   the house. Advertising `PlayState` also authorizes `Rewind`/`FastForward`,
   same problem. Fixed, and a parametrized test now walks *every* message
   `CAPABILITY_COMMANDS` authorizes, in the shape the socket delivers it, and
   asserts each reaches a handler that dispatches.

2. **Progress kept reporting after Stop.** RelayTV retains `NOW_PLAYING` so its
   own UI can resume; `progress_snapshot()` read that as something to report and
   built an `IsPaused: true` payload whenever mpv was not running. The stopped
   report cleared the session and the next heartbeat re-created it, leaving both
   rooms stuck as "paused" on the dashboard indefinitely. Progress now reports
   nothing when nothing is playing. Pause is unaffected — a paused mpv still
   reports playing, so the scrubber keeps tracking.

3. **A Jellyfin restart left both rooms permanently un-castable** while
   reporting `cast_target_ready: true`. Capabilities live in the server's
   in-memory session state; `_ensure_registration` short-circuits on its own
   last success, so nothing re-posted them. Sixty seconds after the restart the
   server still had both devices at `SupportsRemoteControl: false`. The socket
   reconnecting is now the signal that the session is new, so connecting
   invalidates registration and the next heartbeat re-verifies.

## Operator impact

New status fields diagnose the path end to end: `cast_target_ready` is the
single field that answers "can I cast to this device", backed by
`media_control_verified` (server readback) and `ws_connected`, plus
`ws_reconnects`, `ws_keepalive_sec`, `ws_last_error`, `ws_commands_dropped`, and
`last_register_reason`.

`RELAYTV_JELLYFIN_WS_ENABLED=0` keeps the library integration without offering
the device for casting. `websockets` is now a declared dependency rather than a
transitive one via `uvicorn[standard]`; the import is optional-guarded, so a
build without it degrades to today's behavior and says so in `ws_available`.

## Breaking changes

None. The existing `POST /integrations/jellyfin/command` ingress, browse shell,
and progress/stopped reporting are unchanged in contract and were re-verified.

## Tests run

`ruff check app tests`; `PYTHONPATH=app pytest -q` → **548 passed**;
`git diff --check`.

New `tests/test_jellyfin_ws.py` covers message routing, keepalive scheduling
from `ForceKeepAlive`, backoff, backlog bounding, that a slow command cannot
stall keepalives, and that the access token reaches neither status nor logs.
The capabilities and advertised-command regression tests were each **confirmed
to fail against the reverted code** before being kept.

### Live verification, two devices (`Living Room` 10.55.55.2, `Mark's Room` 10.55.55.77)

- Server-side, the check that failed before: both devices at
  `SupportsRemoteControl: true`, `SupportsMediaControl: true`, 7 commands.
- Cast from the server → playback starts in ~3s; the server shows the item and a
  moving position with `CanSeek: true`.
- Remote: PlayPause both directions, Seek to an exact position, Rewind −10s,
  FastForward +30s, SetVolume, Mute/Unmute, ToggleMute both directions, Stop.
- Pause holds position with `IsPaused: true`; Stop clears the server's
  now-playing within 5s.
- Casting to one room leaves the other idle.
- Jellyfin container restarted mid-soak: both rooms recovered in under 20s with
  no RelayTV restart, re-verified, and cast successfully afterwards.
- Regression: browse API (home/movies/series/search) 200 on both devices, and
  the HTTP command ingress still plays, pauses and stops.

- `scripts/jellyfin-ui-smoke.js` passes on both devices: phone-dark and
  desktop-light, 96 unique movies across two pages, 8 series / 10 episodes, and
  offline recovery, with no body or shell overflow and no nested interactive
  elements. Confirmed against both the shared Playwright browser server and one
  launched locally on the dev host.

## Review round: five more defects

All four review findings reproduced and fixed, plus one they led me to.

1. **The declared `websockets` floor could not open the socket.** `connect()`
   gained `proxy` in **15.0**; `pyproject` allowed 13, where passing it is a
   `TypeError` on *every* connection. Verified against 13.1 and 14.2 (no
   `proxy`) and 15.0 (has it). Floor moved to `>=15`, and the argument is now
   feature-detected — running the module under 13.1 now reaches
   `ConnectionRefusedError` instead of `TypeError`.

2. **Config changes left the old server's socket attached.** `ensure_running()`
   returned on "thread is alive", so after switching server or credentials the
   *previous* Jellyfin could still push playback commands to the device while
   the new session had nothing listening. A socket is now bound to the identity
   it dialled with (server URL, device id, token fingerprint) and drift
   restarts it; `connect()` and `set_device_identity()` also drop it outright.

3. **A quick stop/start could revive a zombie reader.** The stop flag was
   module-level: a reader parked in `recv()` outlives `stop()`, and the next
   start cleared the flag out from under it. Each generation now owns its
   threads, queue, and stop event — a stopped session can never be un-stopped —
   and `stop()` closes the live connection so `recv()` returns at once. A
   command queued before a switch is discarded rather than run against the
   wrong server.

4. **A long outage killed reconnection.** Backoff capped the result but
   evaluated `2**(n-1)` first, overflowing the float multiply around failure
   1025 (~17h at the default delay) and taking the socket worker down from
   outside the exception handler. Exponent clamped; the delay computation can
   no longer kill the worker.

5. **Found while live-testing #2: the device id was derived two different
   ways.** Startup built `relaytv-{name}-{hostname}`, the rename paths built
   `relaytv-{name}`. Renaming a device changed its identity until the next
   restart, when it changed back — and Jellyfin keys sessions, capabilities and
   playback history on `DeviceId`, so one TV surfaced as two cast targets. Your
   server had accumulated eight such duplicates. All three paths now share
   `derive_device_id()`.

Each fix has a regression test **confirmed to fail against the reverted code**.
Live re-verification: renaming Living Room and back re-dialled the socket under
the new device id within 10s, `cast_target_ready` correctly reported `false`
during the gap rather than lying, and exactly one Living Room session existed at
every point. Cast/PlayPause/Stop re-checked afterwards.

Stale device entries created by this testing were removed from the server;
pre-existing ones from before this branch were left alone.

## Review round two: four more, all confirmed

1. **The device id still changed on rename.** The previous fix made the three
   derivations *agree* but left them name-derived, so renaming still minted a
   fresh Jellyfin session. RelayTV already persists a rename-safe install id —
   `device_identity.py`'s docstring says display names cannot identify a device
   — and `DeviceId` now derives from it. Renaming changes the cast-list label
   and nothing else, verified live: renaming Living Room and back held
   `relaytv-544a0612…` throughout while the server-side name tracked.
   *One-time migration:* every install gets a new `DeviceId` once; the old
   entry is deletable from Dashboard → Devices. Documented.

2. **A slow handshake could hijack the session that replaced it.**
   `session.ws` is `None` for the whole dial, so `stop()` can't reach the
   connection and gives up on the join; the late socket then published
   "connected", re-asserted registration, and later published "disconnected" —
   for a generation that no longer owned any of it. Late sockets are now closed
   and discarded, and every write to shared status is guarded by "am I still
   the live generation".

3. **Switching servers left a command window.** `connect()` swapped server,
   token, and identity, then ran server-type detection — up to three seconds —
   before dropping the socket, so the *outgoing* server could land a command
   that executed against the *incoming* server's state. The socket is now
   stopped before any configuration changes.

4. **`stop()` could block ten seconds.** websockets' default closing handshake
   is 10s (confirmed from the signature) and `stop()` ran it inline, on the
   thread saving settings or shutting down, despite the 2s joins. Connections
   now open with a 2s close budget and `stop()` hands the close to a throwaway
   thread, so its cost is the bounded joins only.

All five regression tests confirmed to fail against their reverted fixes. Live
re-verified after redeploy: both devices `cast_target_ready: true` on stable
ids, cast → PlayPause both ways → Stop.

## Review rounds three and four: lifecycle atomicity

**Server switching was not atomic with the heartbeat.** `stop()` clears
`_CURRENT` immediately then spends up to four seconds joining; the heartbeat
fires every five. Reproduced: `_CURRENT` pointing at a replacement bound to
`http://old.lan` — the *outgoing* server, because `connect()` had not installed
the new settings yet — with `_STATE` reset underneath it by the `stop()` still
in flight. Start and stop now serialize on one lock held for the whole decision
and the whole act, and because a start that merely *waits* for stop still dials
the outgoing server, `jellyfin_ws` grows a `suspended()` context that holds the
socket down for a whole transaction. `connect()` and `set_device_identity()`
each run inside one; the suspension releases even if the body raises, so a
failed settings write cannot wedge the socket down.

**Retired handshake failures overwrote the live generation's health.** The
success path was guarded by `_claim()`, the exception path was not — a dial
failing after its session was retired pinned the replacement's `ws_last_error`
to an address nobody was talking to. Reproduced, then guarded on both
ownership and the session's own stop flag. The log still records every failure
with an `owned=` flag, so nothing goes silent.

**Teardown had the same shape.** `disconnect()` and `stop()` stopped the
heartbeat and socket, then set `running=False`. `_stop_worker` gives the
heartbeat one second; a heartbeat parked in a network call outlives it, blocks
behind the lifecycle lock, and runs the instant it frees — racing the line that
clears `running`. Winning meant opening a socket **nothing would ever retire**,
because the heartbeat that would notice was already stopped: the outgoing
server keeps a live command channel indefinitely. Reproduced with the
one-second join modelled faithfully. Both teardowns are now transactions, so
`running=False` lands before the suspension lifts.

Four regression tests, each confirmed to fail against its reverted fix. Live
re-verified after redeploy: a real `POST /integrations/jellyfin/disconnect`
left `ws_connected: false` with no leaked socket, reconnect returned to
`cast_target_ready: true` in ten seconds, rename held the device id, and
cast → PlayPause → Stop still works. The server now lists exactly the two live
devices.

## Round five: transactions were suspended but not serialized

`suspended()` releases the socket lifecycle lock before yielding — deliberately,
so the heartbeat sails through and finds the suspension flag rather than
blocking on a lock for the length of a network probe. That left the transaction
*bodies* free to interleave with each other.

The connect endpoints are sync defs, so FastAPI runs concurrent requests on real
threads. Two overlapping server switches each install their own URL, token, and
identity, then race their detection probes; the slower one landing last leaves
the new server's address beside the old server's identity. Reproduced exactly:

```
server_url         : http://b.local:8096
server_type        : jellyfin
server_product_name: Server A
```

`_LOCK` could never have caught this — it guards individual `_STATUS` writes,
and a transaction spans several of them plus a three-second probe. A
receiver-level transaction lock now serializes connect, disconnect, rename, and
stop end to end. It lives at the receiver rather than in the socket module
because what needs serializing is receiver *configuration*, not socket
lifecycle, and keeping them separate preserves the non-blocking behaviour the
heartbeat depends on.

Regression test confirmed to fail against the unserialized transaction. Live:
three concurrent connects against the running device settled on one consistent
state with the socket still up and zero reconnects.

## Round six: the heartbeat had both bugs too

Review pointed the same two lenses at the heartbeat worker, and both defects
were there.

**Its stop event was module-level and reused** — the exact pattern already
fixed in the socket module. `_stop_worker` gives it a second and clears
`_THREAD` regardless; a worker inside a network call outlives that, and the
next start cleared the shared flag out from under it. Reproduced two
generations both observing stop as false, free to authenticate, register, post
progress, and probe server identity concurrently and indefinitely. Each
generation now holds an event only it can see.

**Serializing transactions did nothing for work that started before one.** A
detection probe of the outgoing server takes seconds; landing late published
over the new settings:

```
server_url         : http://new.local:8096
server_product_name: Old Server
```

A configuration generation now advances with every transaction. Detection,
authentication, and registration each capture it before their network call and
discard the result if settings moved on — so a token minted against the
previous server is never installed over the current one, and a stale probe
cannot relabel the new one. Discards are logged, not silent.

Both regression tests confirmed to fail against their reverted fixes. Live:
four rapid disconnect/connect cycles left one healthy generation —
`cast_target_ready: true`, `ws_reconnects: 0`, 13 progress posts with zero
failures and no duplicates — then cast → PlayPause → Stop.

## Round seven: the generation guard drawn too loosely

The guard was in the right place but its boundaries were wrong in three ways.

**It advanced only on entry.** Work capturing it while the transaction body was
still installing settings read the outgoing URL and published as current. It now
advances on entry *and* on commit — entering invalidates work from the previous
configuration, leaving invalidates work started mid-transaction.

**Snapshot, check, and publish were three separate steps.** Authentication read
the URL and credentials and stamped the generation *afterwards*, so a change in
between left it dialling the old server while claiming to be current; its
validation was also separate from installing the token. Detection had the same
check/write gap, and registration ran its readback between the two. Inputs and
generation now come from one `config_snapshot()` under a single lock, and every
result lands through `_publish()`, which compares the generation and applies the
mutation under one acquisition.

**Progress, stopped, and playing were unguarded entirely.** A post takes up to
three seconds; one completing after a disconnect set `connected=True` while
`running` was already false — a session reported live that nothing was driving.

Four regression tests, each confirmed to fail against its reverted fix. The
mid-transaction one is driven **deterministically** rather than by racing a
microsecond-wide window with a sleep — an earlier draft raced it and passed
against the broken code, which is worse than no test.

Live: disconnect left `running`/`connected`/`ws_connected` all false with no
straggling report flipping `connected` back; reconnect returned to
`cast_target_ready: true`; cast → PlayPause → Stop.

## Release highlight

Yes — appended to `docs/release-highlights/0.9.0.md` alongside the device-sync
entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
