### PR TITLE
fix: stop a retired Jellyfin session from driving the player

### DIFF
--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -2582,12 +2582,17 @@ def register_command_sink(fn) -> None:
     _COMMAND_SINK = fn
 
 
-def dispatch_command(action: str, payload: dict[str, object]) -> object:
-    """Run a socket-sourced command through the registered ingress."""
+def dispatch_command(action: str, payload: dict[str, object], *, guard=None) -> object:
+    """Run a socket-sourced command through the registered ingress.
+
+    ``guard`` answers "is the connection that sent this still the live one?".
+    It is re-checked at the point of effect because a command already running
+    cannot be cancelled — see handle_command.
+    """
     sink = _COMMAND_SINK
     if sink is None:
         raise RuntimeError("no jellyfin command sink registered")
-    return sink(action, payload)
+    return sink(action, payload, guard=guard)
 
 
 def command_sink_registered() -> bool:

--- a/app/relaytv_app/integrations/jellyfin_service.py
+++ b/app/relaytv_app/integrations/jellyfin_service.py
@@ -2536,7 +2536,7 @@ def _playlist_entry_display_fields(entry: dict, iid: str, *, api_key: str, serve
     return out
 
 
-def handle_command(req: CommandReqLike, *, controls: dict, ui: dict):
+def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None):
     """Normalized Jellyfin command ingress (v1: Play/Stop/Pause/Resume/Seek/Next).
 
     ``controls`` maps stop/pause/resume/seek/next/previous/set_volume/mute
@@ -2548,6 +2548,22 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict):
     st = jellyfin_receiver.status()
     if not bool(st.get("enabled")):
         raise HTTPException(status_code=503, detail="jellyfin integration disabled")
+
+    def still_owned() -> bool:
+        """Is the connection that sent this command still the live one?
+
+        Resolving an item takes several network round trips and starting mpv
+        takes 6-12s on a Pi, none of which can be cancelled. A disconnect or
+        server switch in that window cannot stop the command, so the check
+        happens again immediately before anything touches the player: a
+        command from a server we have since left must not start playback.
+        """
+        if guard is None:
+            return True
+        try:
+            return bool(guard())
+        except Exception:
+            return True
 
     action = normalize_action(req.action, req.payload)
     jellyfin_receiver.mark_command(action)
@@ -2842,6 +2858,9 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict):
                         }
                     )
                     _remember(iid, qurl, q_media_source_id)
+                if queued and not still_owned():
+                    logger.info("jellyfin_command_discarded action=queue_only reason=session_retired")
+                    return {"ok": False, "action": "queue_only", "reason": "session_retired"}
                 if queued:
                     with state.QUEUE_LOCK:
                         if play_mode == "playnext":
@@ -2910,6 +2929,9 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict):
                             dur = None
                         stopped_payload = stopped_snapshot_from_now(cur_copy, pos, dur)
             clear_queue_for_play = play_mode == "playnow"
+            if not still_owned():
+                logger.info("jellyfin_command_discarded action=play reason=session_retired")
+                return {"ok": False, "action": "play", "reason": "session_retired"}
             playback_service.suppress_auto_next(2.0)
             play_item_payload = smart_item_from_url(source_url, start_pos=start_sec)
             play_target = play_item_payload if isinstance(play_item_payload, dict) else source_url
@@ -3052,6 +3074,8 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict):
                         }
                     )
                     _remember_seen(iid, qurl, q_media_source_id)
+                if queued and not still_owned():
+                    queued = []
                 if queued:
                     with state.QUEUE_LOCK:
                         state.QUEUE.extend(queued)
@@ -3070,6 +3094,10 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict):
             emit_playback_start_hint()
             ui["jellyfin_event"]("play", refresh_active_tab=True, refresh_status=True, reason=play_mode or "play")
             return {"ok": True, "action": "play", "now_playing": now}
+
+        if not still_owned():
+            logger.info("jellyfin_command_discarded action=%s reason=session_retired", action or "unknown")
+            return {"ok": False, "action": action or "unknown", "reason": "session_retired"}
 
         if action == "stop":
             res = controls["stop"]()

--- a/app/relaytv_app/integrations/jellyfin_ws.py
+++ b/app/relaytv_app/integrations/jellyfin_ws.py
@@ -255,9 +255,17 @@ def _command_worker(session: _Session) -> None:
             # Stopped while this was queued: the command belongs to a session
             # that is over, and running it now would act on the wrong server.
             continue
+        # Starting the command is not enough to own it: mpv takes 6-12s to come
+        # up and stop() only joins for two, so the ingress re-checks ownership
+        # immediately before it touches the player.
         action, payload = item
+
+        def _owned(_session=session) -> bool:
+            with _LOCK:
+                return _CURRENT is _session and not _session.stop.is_set()
+
         try:
-            jellyfin_receiver.dispatch_command(action, payload)
+            jellyfin_receiver.dispatch_command(action, payload, guard=_owned)
         except Exception as e:
             _mark_error(e, session=session)
             logger.warning("jellyfin_ws_command_failed action=%s err=%s", action or "playstate", jellyfin_receiver._sanitize_error_text(e))

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -2398,7 +2398,7 @@ _jellyfin_should_suppress_duplicate_play = jellyfin_service.should_suppress_dupl
 _jellyfin_should_suppress_duplicate_ui_action = jellyfin_service.should_suppress_duplicate_ui_action
 
 
-def _jellyfin_integration_command_impl(req: JellyfinCommandReq):
+def _jellyfin_integration_command_impl(req: JellyfinCommandReq, *, guard=None):
     """Normalized Jellyfin command ingress; product logic in jellyfin_service.
 
     This wrapper owns the route-side seams: playback control dispatch and
@@ -2407,6 +2407,7 @@ def _jellyfin_integration_command_impl(req: JellyfinCommandReq):
     """
     return jellyfin_service.handle_command(
         req,
+        guard=guard,
         controls={
             "stop": lambda: stop(),
             "pause": lambda: pause(),

--- a/app/relaytv_app/routes/jellyfin.py
+++ b/app/relaytv_app/routes/jellyfin.py
@@ -124,20 +124,21 @@ def _reset_jellyfin_command_state() -> None:
     reset()
 
 
-def _jellyfin_integration_command_impl(req: JellyfinCommandReq) -> dict[str, object]:
+def _jellyfin_integration_command_impl(req: JellyfinCommandReq, *, guard=None) -> dict[str, object]:
     from . import _jellyfin_integration_command_impl as command
 
-    return command(req)
+    return command(req, guard=guard)
 
 
-def _jellyfin_socket_command(action: str, payload: dict) -> dict[str, object]:
+def _jellyfin_socket_command(action: str, payload: dict, *, guard=None) -> dict[str, object]:
     """Execute a command that arrived over the Jellyfin control socket.
 
     Registered into the receiver so the socket reaches the same ingress the
     HTTP endpoint uses, rather than growing a second copy of command handling.
     """
     return _jellyfin_integration_command_impl(
-        _jellyfin_command_req(action=action or None, payload=payload or {})
+        _jellyfin_command_req(action=action or None, payload=payload or {}),
+        guard=guard,
     )
 
 

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -193,7 +193,7 @@ def test_a_slow_command_does_not_stall_keepalives() -> None:
     started = threading.Event()
     release = threading.Event()
 
-    def _slow_sink(action, payload):
+    def _slow_sink(action, payload, **kw):
         started.set()
         release.wait(5.0)
         return {"ok": True}
@@ -274,7 +274,7 @@ def test_dispatch_requires_a_registered_sink() -> None:
 
 def test_dispatch_reaches_the_registered_sink() -> None:
     seen: list[tuple[str, dict]] = []
-    jellyfin_receiver.register_command_sink(lambda action, payload: seen.append((action, payload)))
+    jellyfin_receiver.register_command_sink(lambda action, payload, **kw: seen.append((action, payload)))
     try:
         jellyfin_receiver.dispatch_command("play", {"ItemIds": ["a"]})
         assert seen == [("play", {"ItemIds": ["a"]})]
@@ -424,7 +424,7 @@ def test_stop_closes_the_live_connection() -> None:
 def test_a_stopped_session_drops_queued_commands() -> None:
     """Commands queued before a server switch belong to the old server."""
     ran: list[str] = []
-    jellyfin_receiver.register_command_sink(lambda action, payload: ran.append(action))
+    jellyfin_receiver.register_command_sink(lambda action, payload, **kw: ran.append(action))
     try:
         session = jellyfin_ws._Session(("u", "d", "f"))
         session.commands.put_nowait(("play", {}))
@@ -1387,3 +1387,104 @@ def test_teardown_does_not_hang_on_a_heartbeat_blocked_in_a_publish(monkeypatch)
     # The heartbeat wakes after teardown releases and discards its own result.
     assert outcome["detection"] == {"ok": False, "reason": "config_changed"}
     assert jellyfin_receiver._STATUS["server_product_name"] == "Old Server"
+
+
+def test_a_retired_session_cannot_start_playback(monkeypatch) -> None:
+    """Setting session.stop cannot cancel a command already running.
+
+    Starting mpv takes 6-12s on a Pi and stop() only joins for two, so a
+    disconnect or server switch mid-Play used to let the retired command drive
+    the player anyway — content from a server we had already left.
+    """
+    effects: list[str] = []
+    started = threading.Event()
+
+    def _slow_ingress(action, payload, *, guard=None):
+        started.set()
+        time.sleep(1.5)  # resolution + mpv startup, uncancellable
+        if guard is not None and not guard():
+            return {"ok": False, "reason": "session_retired"}
+        effects.append(str(payload.get("server")))
+        return {"ok": True}
+
+    jellyfin_receiver.register_command_sink(_slow_ingress)
+    session = jellyfin_ws._Session(("http://old.lan:8096", "relaytv-abc", "fp-old"))
+    jellyfin_ws._CURRENT = session
+    session.worker = threading.Thread(target=jellyfin_ws._command_worker, args=(session,), daemon=True)
+    session.reader = threading.Thread(target=lambda: session.stop.wait(30), daemon=True)
+    session.worker.start()
+    session.reader.start()
+
+    session.commands.put_nowait(("play", {"server": "OLD"}))
+    assert started.wait(5), "command never reached the worker"
+
+    jellyfin_ws.stop()  # server switch lands mid-Play
+    time.sleep(2.5)
+
+    assert effects == [], "a retired session drove the player"
+
+
+def test_the_live_session_still_starts_playback() -> None:
+    """The guard must not block the ordinary path."""
+    effects: list[str] = []
+    done = threading.Event()
+
+    def _ingress(action, payload, *, guard=None):
+        if guard is not None and not guard():
+            done.set()
+            return {"ok": False, "reason": "session_retired"}
+        effects.append(str(payload.get("server")))
+        done.set()
+        return {"ok": True}
+
+    jellyfin_receiver.register_command_sink(_ingress)
+    session = jellyfin_ws._Session(("http://jf.lan:8096", "relaytv-abc", "fp"))
+    jellyfin_ws._CURRENT = session
+    session.worker = threading.Thread(target=jellyfin_ws._command_worker, args=(session,), daemon=True)
+    session.worker.start()
+    try:
+        session.commands.put_nowait(("play", {"server": "LIVE"}))
+        assert done.wait(5)
+        assert effects == ["LIVE"]
+    finally:
+        session.stop.set()
+        jellyfin_ws._CURRENT = None
+
+
+def test_handle_command_rechecks_ownership_before_touching_the_player(monkeypatch) -> None:
+    """The service layer is where the guard has to bite.
+
+    Everything before playback_service.play_now is network work that cannot be
+    interrupted, so the check happens immediately before the transition.
+    """
+    from relaytv_app.integrations import jellyfin_service
+
+    dispatched: list[str] = []
+    controls = {
+        name: (lambda *a, _n=name, **kw: dispatched.append(_n))
+        for name in ("stop", "pause", "resume", "seek", "seek_relative", "next", "previous", "set_volume", "mute")
+    }
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setattr(jellyfin_service, "emit_progress_hint", lambda: None)
+
+    class _Req:
+        action = "pause"
+        url = None
+        start_pos = None
+        use_ytdlp = True
+        payload: dict = {}
+
+    ui = {
+        "toast": lambda **kw: None,
+        "notification_display_sec": lambda: 4.0,
+        "queue_event": lambda event, **kw: None,
+        "jellyfin_event": lambda event, **kw: None,
+    }
+
+    out = jellyfin_service.handle_command(_Req(), controls=controls, ui=ui, guard=lambda: False)
+    assert out["reason"] == "session_retired"
+    assert dispatched == [], "a retired command reached the player"
+
+    out = jellyfin_service.handle_command(_Req(), controls=controls, ui=ui, guard=lambda: True)
+    assert out["ok"] is True
+    assert dispatched == ["pause"]


### PR DESCRIPTION
Follow-up to #54, from a Codex review comment that arrived after that PR merged.

## User impact

Switching Jellyfin servers — or disconnecting — while a cast is starting could
leave the TV playing content from the server you just left. The window is the
6–12 seconds mpv takes to come up on a Pi.

## What was wrong

Setting `session.stop` cannot cancel a command that is already running, and
`stop()` only joins for two seconds. So a `Play` already in flight carried on
past teardown and drove the player anyway. Reproduced:

```
stop() returned in 2.00s
effects at stop(): []
effects after   : [('playback started', 'play', 'OLD')]
```

`stop()` returned at its bound, and playback began afterwards with the outgoing
server's payload.

The configuration-generation guard added in #54 does not cover this. It protects
`_STATUS` publications; the damage here is a playback side effect, which never
passes through `_publish`.

## Approach

Command ownership is now carried through dispatch. The socket supplies a guard —
"is this still the live session?" — and the service layer re-checks it
immediately before anything touches the player:

- before the queue-only mutation
- before `playback_service.play_now`
- before appending playlist extras
- once before the fast transport actions

Everything ahead of those points is network work that cannot be interrupted
(item resolution, detail lookup, stream selection), so the check sits as late as
it can. That narrows the window from twelve seconds to the gap between the check
and the call.

Discarded commands are logged with their action rather than dropped silently.

## Operator impact

None. No new configuration, no status changes.

## Breaking changes

None. `handle_command` and the command sink take an optional `guard`; callers
that do not pass one behave exactly as before, which is what the HTTP ingress at
`POST /integrations/jellyfin/command` does.

## Tests run

`ruff check app tests`; `PYTHONPATH=app pytest -q` → **589 passed**;
`git diff --check`.

Three new regression tests: the retired case, the ordinary case still starting
playback, and the service-layer recheck. The first and third were confirmed to
fail against the reverted guard.

Live on two devices (`Living Room` 10.55.55.2, `Mark's Room` 10.55.55.77): both
`cast_target_ready: true`, cast → PlayPause both directions → Stop still works,
`ws_commands_dropped: 0`, `progress_failure_count: 0`.

## Release highlight

No — this fixes a defect in an unreleased feature, already covered by the 0.9.0
highlight added in #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
