### PR TITLE
fix: stop the Add URL modal submitting twice

### DIFF
--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -186,7 +186,13 @@ async function pasteIntoAddUrl(){
   inp.select();
 }
 
+// Guards the window between submitting and the modal closing. Resolving a link
+// can take seconds, and the modal stays open and clickable throughout — a
+// second tap in that window used to add the item all over again.
+let addUrlSubmitting = false;
+
 async function submitAddUrl(mode){
+  if (addUrlSubmitting) return;
   const inp = document.getElementById('addUrlInput');
   if (!inp) return;
   const url = normalizeUrl(inp.value);
@@ -196,12 +202,17 @@ async function submitAddUrl(mode){
     return;
   }
 
-  if (mode === 'queue') {
-    await post('/enqueue', {url});
-  } else {
-    await post('/play_now', {url, preserve_current:true, preserve_to:'queue_front', resume_current:true, reason:'add_menu'});
+  addUrlSubmitting = true;
+  try {
+    if (mode === 'queue') {
+      await post('/enqueue', {url});
+    } else {
+      await post('/play_now', {url, preserve_current:true, preserve_to:'queue_front', resume_current:true, reason:'add_menu'});
+    }
+    closeAddUrl();
+  } finally {
+    addUrlSubmitting = false;
   }
-  closeAddUrl();
 }
 
 function _setNotifyHelper(msg, kind){
@@ -2815,10 +2826,18 @@ function bindAddUrlUi(){
 
   window.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') closeAddUrl();
-    // When the modal is open, Enter defaults to Play
+    // When the modal is open, Enter defaults to Play.
     const open = bd && !bd.classList.contains('hidden');
+    if (!open || e.key !== 'Enter') return;
     const target = e.target;
-    if (open && e.key === 'Enter' && !(target && target.closest && target.closest('#notifySection'))) submitAddUrl('play');
+    if (!(target && target.closest)) { submitAddUrl('play'); return; }
+    if (target.closest('#notifySection')) return;
+    // A focused control already turns Enter into a click, so handling it here
+    // too submits twice — and from the Queue button that meant one keypress
+    // firing play_now *and* enqueue, adding the item twice and stealing
+    // playback with it.
+    if (target.closest('button, a[href], select, textarea')) return;
+    submitAddUrl('play');
   });
 }
 


### PR DESCRIPTION
## User impact

Adding a link played or queued it **twice**.

## What was wrong

Reproduced in a real browser by counting the POSTs a single user action issues:

| Action | Before |
| --- | --- |
| Enter, focus in the input | 1 × `/play_now` ✅ |
| Enter, focus on **Play** | **2 × `/play_now`** |
| Enter, focus on **Queue** | **`/play_now` + `/enqueue`** |

Two independent routes in:

1. **A focused button already turns Enter into a click**, and the window
   `keydown` handler then submitted again. From the Queue button this is worse
   than a duplicate — one keypress fired `play_now` *and* `enqueue`, so the item
   was added twice **and** hijacked playback on the way past.

2. **The modal stayed open and clickable for the whole request.** Resolving a
   link takes seconds, so an impatient second tap submitted the whole thing
   again.

## Not a regression from the cast-target work

History shows the pattern from **07-29** onward, well before that branch
existed — 18 adjacent same-URL plays across the retained window, some sharing an
identical timestamp.

## Approach

Enter is left alone when the event target is a `button`, `a[href]`, `select`, or
`textarea` — those activate themselves. And `submitAddUrl` ignores re-entry
while a submission is in flight.

## Breaking changes

None. Enter still defaults to Play from the input, and both buttons behave as
before.

## Tests run

`ruff check app tests`; `PYTHONPATH=app pytest -q` → **586 passed**;
`git diff --check`.

Verified in the browser against the running device — all six trials now issue
exactly one POST:

```
Enter with focus in the input              POSTs=1 ["/play_now"]
Enter with focus on the Play button        POSTs=1 ["/play_now"]
Enter with focus on the Queue button       POSTs=1 ["/enqueue"]
Space with focus on the Queue button       POSTs=1 ["/enqueue"]
Double-click Queue (impatient tap)         POSTs=1 ["/enqueue"]
Triple-click Play (impatient tap)          POSTs=1 ["/play_now"]
```

The pre-fix build on the other device still returns 2 for the same keypress.

## Release highlight

No — a bug fix to existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)