### PR TITLE
fix: keep yt-dlp current so playback stops dying on stale extractors

### DIFF
--- a/app/relaytv_app/container_entrypoint.py
+++ b/app/relaytv_app/container_entrypoint.py
@@ -200,10 +200,15 @@ def _write_json_file(path: Path, payload: dict) -> None:
         _eprint(f"entrypoint: failed to write {path}: {exc}")
 
 
-def _yt_dlp_version(env: dict[str, str], *, path: str | None = None) -> str:
+def _yt_dlp_version(env: dict[str, str], *, path: str | None = None, user_site: bool = True) -> str:
     run_env = dict(env)
     if path is not None:
         run_env["PATH"] = path
+    if not user_site:
+        # Dropping the persisted bin from PATH is not enough to see the image's
+        # copy: PYTHONUSERBASE still steers the import, so the console script in
+        # /usr/local/bin would load the persisted package and report its version.
+        run_env.pop("PYTHONUSERBASE", None)
     try:
         p = subprocess.run(
             ["yt-dlp", "--version"],
@@ -249,7 +254,9 @@ def _prune_persisted_ytdlp(env: dict[str, str]) -> None:
         _discard_persisted_ytdlp(update_dir, "not executable")
         return
 
-    image = _yt_dlp_version(env, path=_path_without(env, str(update_dir / "bin")))
+    image = _yt_dlp_version(
+        env, path=_path_without(env, str(update_dir / "bin")), user_site=False
+    )
     if not image:
         return
     if _version_key(image) > _version_key(persisted):

--- a/app/relaytv_app/container_entrypoint.py
+++ b/app/relaytv_app/container_entrypoint.py
@@ -225,15 +225,47 @@ def _yt_dlp_version(env: dict[str, str], *, path: str | None = None, user_site: 
     return (p.stdout or "").strip().splitlines()[0] if (p.stdout or "").strip() else ""
 
 
-def _discard_persisted_ytdlp(update_dir: Path, reason: str) -> None:
+def _persisted_ytdlp_paths(update_dir: Path) -> list[Path]:
+    """Exactly what pip put there for yt-dlp, and nothing else."""
+    found: list[Path] = []
+    bin_dir = update_dir / "bin"
     try:
-        shutil.rmtree(update_dir)
-    except FileNotFoundError:
-        return
-    except Exception as exc:
-        _eprint(f"entrypoint: yt-dlp persisted copy could not be removed ({reason}): {exc}")
-        return
-    _eprint(f"entrypoint: yt-dlp persisted copy discarded ({reason})")
+        found.extend(sorted(bin_dir.glob("yt-dlp*")))
+    except Exception:
+        pass
+    try:
+        for site in update_dir.glob("lib/python*/site-packages"):
+            for pattern in ("yt_dlp", "yt_dlp-*.dist-info", "yt_dlp-*.egg-info"):
+                found.extend(sorted(site.glob(pattern)))
+    except Exception:
+        pass
+    return found
+
+
+def _discard_persisted_ytdlp(update_dir: Path, reason: str) -> None:
+    """Remove the persisted yt-dlp — only ever yt-dlp's own files.
+
+    This deliberately does not rmtree ``update_dir``. It is operator-supplied,
+    and pointing it at a shared directory is an easy mistake to make: with
+    ``RELAYTV_YTDLP_UPDATE_DIR=/data``, pip happily creates ``/data/bin`` and
+    one failed probe would otherwise delete settings, history, peers, the
+    device id and every upload.
+    """
+    removed = 0
+    for target in _persisted_ytdlp_paths(update_dir):
+        try:
+            if target.is_dir() and not target.is_symlink():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+            removed += 1
+        except FileNotFoundError:
+            continue
+        except Exception as exc:
+            _eprint(f"entrypoint: yt-dlp persisted copy could not be removed ({reason}): {exc}")
+            return
+    if removed:
+        _eprint(f"entrypoint: yt-dlp persisted copy discarded ({reason})")
 
 
 def _prune_persisted_ytdlp(env: dict[str, str]) -> None:
@@ -363,7 +395,12 @@ def run_yt_dlp_update(env: dict[str, str], *, force: bool = False) -> bool:
             "before_version": before,
             "after_version": after,
             "updated": changed,
-            "channel": used_channel,
+            # The channel we were asked to track, which is what the staleness
+            # check compares against. A stable fallback must not read as a
+            # channel switch, or an unavailable nightly gets retried on every
+            # poll instead of once per interval.
+            "channel": channel,
+            "installed_channel": used_channel,
             "install_dir": str(_ytdlp_update_dir(env)),
             "error": err,
         },

--- a/app/relaytv_app/container_entrypoint.py
+++ b/app/relaytv_app/container_entrypoint.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -63,14 +64,56 @@ def _sync_legacy_brand_assets() -> None:
             _eprint(f"entrypoint: failed to seed legacy asset {dst}: {exc}")
 
 
+def _ytdlp_update_dir(env: dict[str, str]) -> Path:
+    """Where auto-updated yt-dlp lives.
+
+    Deliberately on the data volume, not ``$HOME/.local``: ``HOME`` is ``/tmp``
+    and ``/tmp`` is tmpfs, so a user-site install evaporated on every container
+    recreate. The update state file already lives on ``/data``, so the old
+    split meant state said "checked recently" while the binary had silently
+    reverted to the image's copy — and the interval gate then suppressed a
+    re-check for hours.
+    """
+    raw = (env.get("RELAYTV_YTDLP_UPDATE_DIR") or "").strip() or "/data/ytdlp"
+    return Path(raw)
+
+
 def _normalize_path_env(env: dict[str, str]) -> None:
-    """Ensure user-level script installs (for yt-dlp auto-update) are callable."""
-    home = (env.get("HOME") or "").strip() or "/tmp"
-    user_bin = str(Path(home) / ".local" / "bin")
+    """Make the persisted yt-dlp install callable by the server and its workers."""
+    update_dir = _ytdlp_update_dir(env)
+    # PYTHONUSERBASE steers `pip install --user` here, and the same variable
+    # makes the interpreter import from it, so the console script and the
+    # package always come from one place.
+    env["PYTHONUSERBASE"] = str(update_dir)
+    user_bin = str(update_dir / "bin")
     cur = env.get("PATH") or ""
     parts = [p for p in cur.split(":") if p]
     if user_bin not in parts:
         env["PATH"] = f"{user_bin}:{cur}" if cur else user_bin
+
+
+def _version_key(raw: str) -> tuple:
+    """Comparable form of a yt-dlp version, for "is the image newer?" checks."""
+    text = str(raw or "").strip()
+    if not text:
+        return ()
+    try:
+        from pip._vendor.packaging.version import parse as _parse  # type: ignore
+
+        return (1, _parse(text))
+    except Exception:
+        pass
+    parts: list[int] = []
+    for chunk in text.replace("-", ".").split("."):
+        digits = "".join(ch for ch in chunk if ch.isdigit())
+        if not digits:
+            break
+        parts.append(int(digits))
+    return (0, tuple(parts))
+
+
+def _path_without(env: dict[str, str], drop: str) -> str:
+    return ":".join(p for p in (env.get("PATH") or "").split(":") if p and p != drop)
 
 
 def _host_model() -> str:
@@ -157,7 +200,10 @@ def _write_json_file(path: Path, payload: dict) -> None:
         _eprint(f"entrypoint: failed to write {path}: {exc}")
 
 
-def _yt_dlp_version(env: dict[str, str]) -> str:
+def _yt_dlp_version(env: dict[str, str], *, path: str | None = None) -> str:
+    run_env = dict(env)
+    if path is not None:
+        run_env["PATH"] = path
     try:
         p = subprocess.run(
             ["yt-dlp", "--version"],
@@ -165,13 +211,49 @@ def _yt_dlp_version(env: dict[str, str]) -> str:
             capture_output=True,
             text=True,
             timeout=10,
-            env=env,
+            env=run_env,
         )
     except Exception:
         return ""
     if p.returncode != 0:
         return ""
     return (p.stdout or "").strip().splitlines()[0] if (p.stdout or "").strip() else ""
+
+
+def _discard_persisted_ytdlp(update_dir: Path, reason: str) -> None:
+    try:
+        shutil.rmtree(update_dir)
+    except FileNotFoundError:
+        return
+    except Exception as exc:
+        _eprint(f"entrypoint: yt-dlp persisted copy could not be removed ({reason}): {exc}")
+        return
+    _eprint(f"entrypoint: yt-dlp persisted copy discarded ({reason})")
+
+
+def _prune_persisted_ytdlp(env: dict[str, str]) -> None:
+    """Drop the persisted install when it is unusable or older than the image.
+
+    A tree on ``/data`` outlives the image around it. Two ways that goes wrong:
+    the console script's shebang names an interpreter a rebuilt image no longer
+    ships, or a newer image ships a yt-dlp ahead of what we once installed. In
+    both cases the persisted copy is first on PATH and would win, so it has to
+    be removed rather than merely ignored.
+    """
+    update_dir = _ytdlp_update_dir(env)
+    if not (update_dir / "bin" / "yt-dlp").exists():
+        return
+
+    persisted = _yt_dlp_version(env)
+    if not persisted:
+        _discard_persisted_ytdlp(update_dir, "not executable")
+        return
+
+    image = _yt_dlp_version(env, path=_path_without(env, str(update_dir / "bin")))
+    if not image:
+        return
+    if _version_key(image) > _version_key(persisted):
+        _discard_persisted_ytdlp(update_dir, f"image {image} is newer than persisted {persisted}")
 
 
 def _yt_dlp_auto_update(env: dict[str, str]) -> None:
@@ -188,53 +270,76 @@ def run_yt_dlp_update(env: dict[str, str], *, force: bool = False) -> bool:
     file so both callers share one schedule. ``force`` bypasses the interval
     (used when the settings toggle is switched on).
     """
-    interval_hours = max(0.0, _parse_float_env(env, "RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS", 24.0))
+    interval_hours = max(0.0, _parse_float_env(env, "RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS", 6.0))
     timeout_sec = max(10.0, _parse_float_env(env, "RELAYTV_YTDLP_AUTO_UPDATE_TIMEOUT_SEC", 180.0))
     state_path_raw = (env.get("RELAYTV_YTDLP_AUTO_UPDATE_STATE_FILE") or "/data/.relaytv-ytdlp-update.json").strip()
     state_path = Path(state_path_raw)
     if not state_path.is_absolute():
         state_path = Path("/data") / state_path
 
+    _prune_persisted_ytdlp(env)
+
     now = float(time.time())
     state = _read_json_file(state_path)
     last_ts = float(state.get("last_check_ts") or 0.0)
     next_due_ts = last_ts + (interval_hours * 3600.0)
-    if (not force) and interval_hours > 0 and last_ts > 0 and now < next_due_ts:
+    before = _yt_dlp_version(env)
+    # The interval alone is not a safe gate. The state file lives on /data and
+    # survives anything, so if the installed copy has moved out from under it —
+    # a rebuilt image, a discarded persisted tree — "checked recently" would
+    # keep us on a stale yt-dlp for hours. Trust the gate only while the
+    # version we are looking at is the one the state describes.
+    reverted = bool(state.get("after_version")) and before != str(state.get("after_version"))
+    if (not force) and (not reverted) and interval_hours > 0 and last_ts > 0 and now < next_due_ts:
         _eprint(
             f"entrypoint: yt-dlp auto-update skipped (next check in {int(next_due_ts - now)}s)"
         )
         return False
+    if reverted:
+        _eprint(
+            f"entrypoint: yt-dlp auto-update forced (installed={before or 'unknown'} "
+            f"state={state.get('after_version') or 'unknown'})"
+        )
 
-    before = _yt_dlp_version(env)
     _eprint(f"entrypoint: yt-dlp auto-update check start (current={before or 'unknown'})")
 
-    rc = -1
-    err = ""
-    try:
-        p = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "--user",
-                "--upgrade",
-                "--no-cache-dir",
-                "yt-dlp",
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=timeout_sec,
-            env=env,
-        )
-        rc = int(p.returncode)
-        if p.returncode != 0:
-            err = (p.stderr or p.stdout or "").strip()[:600]
-    except Exception as exc:
-        err = str(exc)
+    channel = (env.get("RELAYTV_YTDLP_UPDATE_CHANNEL") or "nightly").strip().lower()
+    if channel not in ("nightly", "stable"):
+        channel = "nightly"
+
+    def _pip_install(pre: bool) -> tuple[int, str]:
+        cmd = [sys.executable, "-m", "pip", "install", "--user", "--upgrade", "--no-cache-dir"]
+        if pre:
+            cmd.append("--pre")
+        cmd.append("yt-dlp")
+        try:
+            proc = subprocess.run(
+                cmd, check=False, capture_output=True, text=True, timeout=timeout_sec, env=env
+            )
+        except Exception as exc:
+            return -1, str(exc)
+        if proc.returncode != 0:
+            return int(proc.returncode), (proc.stderr or proc.stdout or "").strip()[:600]
+        return 0, ""
+
+    used_channel = channel
+    rc, err = _pip_install(pre=(channel == "nightly"))
+    if rc != 0 and channel == "nightly":
+        # A broken nightly must not leave the device worse off than the stable
+        # channel it would otherwise have been running.
+        _eprint(f"entrypoint: yt-dlp nightly install failed (rc={rc}); falling back to stable")
+        used_channel = "stable"
+        rc, err = _pip_install(pre=False)
 
     after = _yt_dlp_version(env)
+    if rc == 0 and not after:
+        # Installed but not runnable: almost always a console-script shebang
+        # pointing at an interpreter this image no longer ships.
+        _discard_persisted_ytdlp(_ytdlp_update_dir(env), "installed copy did not run")
+        after = _yt_dlp_version(env)
+        rc = 1
+        err = err or "installed yt-dlp did not execute; reverted to the image copy"
+
     changed = bool(before and after and before != after)
     ok = (rc == 0)
     _write_json_file(
@@ -246,6 +351,8 @@ def run_yt_dlp_update(env: dict[str, str], *, force: bool = False) -> bool:
             "before_version": before,
             "after_version": after,
             "updated": changed,
+            "channel": used_channel,
+            "install_dir": str(_ytdlp_update_dir(env)),
             "error": err,
         },
     )

--- a/app/relaytv_app/container_entrypoint.py
+++ b/app/relaytv_app/container_entrypoint.py
@@ -591,6 +591,12 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         _normalize_path_env(env)
+        # Prune before the update toggle is consulted. The PATH prefix above is
+        # unconditional, so an operator who enabled auto-update once, turned it
+        # off, and then deployed an image with a newer yt-dlp would otherwise
+        # keep running the old persisted copy forever — the update path, which
+        # is where pruning used to live, never runs with the toggle off.
+        _prune_persisted_ytdlp(env)
         _normalize_runtime_defaults(env)
         _sync_legacy_brand_assets()
         _yt_dlp_auto_update(env)

--- a/app/relaytv_app/container_entrypoint.py
+++ b/app/relaytv_app/container_entrypoint.py
@@ -296,23 +296,28 @@ def run_yt_dlp_update(env: dict[str, str], *, force: bool = False) -> bool:
     # a rebuilt image, a discarded persisted tree — "checked recently" would
     # keep us on a stale yt-dlp for hours. Trust the gate only while the
     # version we are looking at is the one the state describes.
-    reverted = bool(state.get("after_version")) and before != str(state.get("after_version"))
-    if (not force) and (not reverted) and interval_hours > 0 and last_ts > 0 and now < next_due_ts:
+    channel = (env.get("RELAYTV_YTDLP_UPDATE_CHANNEL") or "nightly").strip().lower()
+    if channel not in ("nightly", "stable"):
+        channel = "nightly"
+
+    stale_reason = ""
+    if bool(state.get("after_version")) and before != str(state.get("after_version")):
+        stale_reason = f"installed={before or 'unknown'} state={state.get('after_version')}"
+    elif bool(state.get("last_check_ts")) and str(state.get("channel") or "stable") != channel:
+        # The recorded check answered a different question. Switching to the
+        # nightly channel must not wait out an interval that was satisfied by a
+        # stable-only check — that is the whole reason for switching.
+        stale_reason = f"channel={channel} state_channel={state.get('channel') or 'stable'}"
+
+    if (not force) and (not stale_reason) and interval_hours > 0 and last_ts > 0 and now < next_due_ts:
         _eprint(
             f"entrypoint: yt-dlp auto-update skipped (next check in {int(next_due_ts - now)}s)"
         )
         return False
-    if reverted:
-        _eprint(
-            f"entrypoint: yt-dlp auto-update forced (installed={before or 'unknown'} "
-            f"state={state.get('after_version') or 'unknown'})"
-        )
+    if stale_reason:
+        _eprint(f"entrypoint: yt-dlp auto-update forced ({stale_reason})")
 
     _eprint(f"entrypoint: yt-dlp auto-update check start (current={before or 'unknown'})")
-
-    channel = (env.get("RELAYTV_YTDLP_UPDATE_CHANNEL") or "nightly").strip().lower()
-    if channel not in ("nightly", "stable"):
-        channel = "nightly"
 
     def _pip_install(pre: bool) -> tuple[int, str]:
         cmd = [sys.executable, "-m", "pip", "install", "--user", "--upgrade", "--no-cache-dir"]

--- a/app/relaytv_app/playback_service.py
+++ b/app/relaytv_app/playback_service.py
@@ -162,6 +162,17 @@ def natural_end() -> str:
     transition guards, suppression window) stays with the monitor; this is
     the decision policy. Returns the action taken, for logging/tests.
     """
+    # Record why this item ended before deciding what happens next. The
+    # queue-empty handler below also does it, but that branch is only reached
+    # with an empty queue — so playlist and queue users, the common case, got no
+    # diagnostic at all, and the successor's play_item then cleared it.
+    try:
+        player.note_playback_failure_if_no_progress(
+            state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
+        )
+    except Exception:
+        pass
+
     with state.QUEUE_LOCK:
         has_queue = bool(state.QUEUE)
     if not has_queue:

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -2593,9 +2593,10 @@ def _build_mpv_args(
         runtime_profile = {}
     decode_profile = str(runtime_profile.get("decode_profile") or "").strip().lower()
 
-    log_file = (os.getenv("MPV_LOG_FILE") or "").strip()
-    if not log_file and debug:
-        log_file = "/tmp/mpv.log"
+    # Always log. The mpv and Qt external_mpv backends launch through here, and
+    # gating this on debug left last_playback_error reading a file those
+    # backends never create — or worse, a stale one from an earlier session.
+    log_file = (os.getenv("MPV_LOG_FILE") or "").strip() or _mpv_log_path()
     mpv_args: list[str] = [
         "mpv",
         "--fs",
@@ -5236,6 +5237,7 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
 
 _LAST_PLAYBACK_ERROR: str | None = None
 _PLAYBACK_STARTED_POS: float = 0.0
+_PLAYBACK_LOG_OFFSET: int = 0
 _PLAYBACK_ERROR_LOCK = threading.Lock()
 _MPV_ERROR_LINE = re.compile(r"^\[[^\]]*\]\[[ef]\]\[(?P<src>[^\]]+)\]\s*(?P<msg>.+)$")
 
@@ -5251,6 +5253,13 @@ def set_last_playback_error(reason: str | None) -> None:
         _LAST_PLAYBACK_ERROR = (str(reason).strip() or None) if reason else None
 
 
+def _mpv_log_size() -> int:
+    try:
+        return int(os.path.getsize(_mpv_log_path()))
+    except Exception:
+        return 0
+
+
 def note_playback_started(start_pos: float | None) -> None:
     """Remember where this item began playing.
 
@@ -5259,14 +5268,19 @@ def note_playback_started(start_pos: float | None) -> None:
     minutes of progress — and a resumed stream that dies instantly would look
     like a completed play and report nothing.
     """
-    global _PLAYBACK_STARTED_POS, _LAST_PLAYBACK_ERROR
+    global _PLAYBACK_STARTED_POS, _LAST_PLAYBACK_ERROR, _PLAYBACK_LOG_OFFSET
     try:
         value = max(0.0, float(start_pos or 0.0))
     except Exception:
         value = 0.0
+    offset = _mpv_log_size()
     with _PLAYBACK_ERROR_LOCK:
         _PLAYBACK_STARTED_POS = value
         _LAST_PLAYBACK_ERROR = None
+        # Everything already in the log belongs to an earlier item. Without
+        # this, a short clip that ends quietly inherits the previous play's
+        # 403 and /status blames the wrong thing.
+        _PLAYBACK_LOG_OFFSET = offset
 
 
 def playback_started_pos() -> float:
@@ -5279,17 +5293,25 @@ def _mpv_log_path() -> str:
 
 
 def read_mpv_failure_reason(*, tail_bytes: int = 65536) -> str:
-    """The most recent error mpv logged, condensed to one line.
+    """The most recent error mpv logged *for the current item*, as one line.
 
-    URLs are dropped: a googlevideo link is a screenful of signed query string
-    and can carry credentials for other providers.
+    Reading starts where this play began, so an older failure cannot be
+    attributed to a later item. URLs are dropped: a googlevideo link is a
+    screenful of signed query string and can carry credentials for other
+    providers.
     """
     path = _mpv_log_path()
+    with _PLAYBACK_ERROR_LOCK:
+        start = int(_PLAYBACK_LOG_OFFSET)
     try:
         with open(path, "rb") as handle:
             handle.seek(0, os.SEEK_END)
             size = handle.tell()
-            handle.seek(max(0, size - tail_bytes))
+            # A rotated log restarts from zero; the old offset would then skip
+            # past everything this play wrote.
+            if start > size:
+                start = 0
+            handle.seek(max(start, size - tail_bytes))
             chunk = handle.read().decode("utf-8", "ignore")
     except Exception:
         return ""

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -4937,6 +4937,7 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
     provider = item.get("provider") or provider_from_url(raw)
     http_headers = _item_http_headers(item)
     play_t0 = time.monotonic()
+    note_playback_started(start_pos)
     debug_log("player", f"play_item start mode={mode} provider={provider} use_resolver={use_resolver}")
     if provider == "iptv":
         debug_log(
@@ -5234,6 +5235,7 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
 # went idle ten seconds in.
 
 _LAST_PLAYBACK_ERROR: str | None = None
+_PLAYBACK_STARTED_POS: float = 0.0
 _PLAYBACK_ERROR_LOCK = threading.Lock()
 _MPV_ERROR_LINE = re.compile(r"^\[[^\]]*\]\[[ef]\]\[(?P<src>[^\]]+)\]\s*(?P<msg>.+)$")
 
@@ -5247,6 +5249,29 @@ def set_last_playback_error(reason: str | None) -> None:
     global _LAST_PLAYBACK_ERROR
     with _PLAYBACK_ERROR_LOCK:
         _LAST_PLAYBACK_ERROR = (str(reason).strip() or None) if reason else None
+
+
+def note_playback_started(start_pos: float | None) -> None:
+    """Remember where this item began playing.
+
+    Progress has to be measured from here, not from zero. ``resume_pos`` tracks
+    the live position, so an item resumed at 5 minutes already reads as five
+    minutes of progress — and a resumed stream that dies instantly would look
+    like a completed play and report nothing.
+    """
+    global _PLAYBACK_STARTED_POS, _LAST_PLAYBACK_ERROR
+    try:
+        value = max(0.0, float(start_pos or 0.0))
+    except Exception:
+        value = 0.0
+    with _PLAYBACK_ERROR_LOCK:
+        _PLAYBACK_STARTED_POS = value
+        _LAST_PLAYBACK_ERROR = None
+
+
+def playback_started_pos() -> float:
+    with _PLAYBACK_ERROR_LOCK:
+        return float(_PLAYBACK_STARTED_POS)
 
 
 def _mpv_log_path() -> str:
@@ -5292,7 +5317,7 @@ def note_playback_failure_if_no_progress(now: dict | None) -> str:
         position = float((now or {}).get("resume_pos") or 0.0)
     except Exception:
         position = 0.0
-    if position >= 2.0:
+    if (position - playback_started_pos()) >= 2.0:
         set_last_playback_error(None)
         return ""
     reason = read_mpv_failure_reason()

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -5226,10 +5226,92 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
 
 
 
+# --- playback failure reason -------------------------------------------------
+#
+# mpv runs with --no-terminal, so a stream that fails to open says nothing on
+# stdout. The reason only exists in mpv's own log, which is why a 403 could
+# present as a 200 from /play_now, a clean container log, and a TV that quietly
+# went idle ten seconds in.
+
+_LAST_PLAYBACK_ERROR: str | None = None
+_PLAYBACK_ERROR_LOCK = threading.Lock()
+_MPV_ERROR_LINE = re.compile(r"^\[[^\]]*\]\[[ef]\]\[(?P<src>[^\]]+)\]\s*(?P<msg>.+)$")
+
+
+def last_playback_error() -> str | None:
+    with _PLAYBACK_ERROR_LOCK:
+        return _LAST_PLAYBACK_ERROR
+
+
+def set_last_playback_error(reason: str | None) -> None:
+    global _LAST_PLAYBACK_ERROR
+    with _PLAYBACK_ERROR_LOCK:
+        _LAST_PLAYBACK_ERROR = (str(reason).strip() or None) if reason else None
+
+
+def _mpv_log_path() -> str:
+    return (os.getenv("MPV_LOG_FILE") or "").strip() or "/tmp/mpv.log"
+
+
+def read_mpv_failure_reason(*, tail_bytes: int = 65536) -> str:
+    """The most recent error mpv logged, condensed to one line.
+
+    URLs are dropped: a googlevideo link is a screenful of signed query string
+    and can carry credentials for other providers.
+    """
+    path = _mpv_log_path()
+    try:
+        with open(path, "rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - tail_bytes))
+            chunk = handle.read().decode("utf-8", "ignore")
+    except Exception:
+        return ""
+    reason = ""
+    for line in chunk.splitlines():
+        matched = _MPV_ERROR_LINE.match(line.strip())
+        if not matched:
+            continue
+        msg = matched.group("msg").strip()
+        if not msg:
+            continue
+        msg = re.sub(r"https?://\S+", "<url>", msg)
+        reason = f"{matched.group('src')}: {msg}"[:300]
+    return reason
+
+
+def note_playback_failure_if_no_progress(now: dict | None) -> str:
+    """Record why a play produced nothing, when it produced nothing.
+
+    Called where playback has ended: if the item never advanced, this was a
+    failure rather than a finished video, and the operator deserves the reason
+    in the ordinary log instead of having to enable debug and reproduce it.
+    """
+    try:
+        position = float((now or {}).get("resume_pos") or 0.0)
+    except Exception:
+        position = 0.0
+    if position >= 2.0:
+        set_last_playback_error(None)
+        return ""
+    reason = read_mpv_failure_reason()
+    if not reason:
+        return ""
+    set_last_playback_error(reason)
+    logger.info(
+        "playback_failed title=%r reason=%s",
+        str((now or {}).get("title") or "")[:80],
+        reason,
+    )
+    return reason
+
+
 def _handle_playback_idle_no_queue() -> None:
     """Transition app/UI state when playback has ended and queue is empty."""
     global _NATURAL_IDLE_RESET_UNTIL, _NATURAL_IDLE_ENSURE_TIMER
     now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
+    note_playback_failure_if_no_progress(now)
     update_history_progress(now, completed=_history_item_completed(now), force=True)
     _emit_jellyfin_stopped_from_now(now)
     # Only clear now-playing when not in a user-closed resumable session.

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -5243,8 +5243,24 @@ _MPV_ERROR_LINE = re.compile(r"^\[[^\]]*\]\[[ef]\]\[(?P<src>[^\]]+)\]\s*(?P<msg>
 
 
 def last_playback_error() -> str | None:
+    """Why the most recent attempt failed, if it did and nothing has superseded it.
+
+    Reported until the next attempt demonstrably plays, so a failure is still
+    visible while its successor is starting — which is the whole window in
+    which a queue advance would otherwise hide it.
+    """
     with _PLAYBACK_ERROR_LOCK:
-        return _LAST_PLAYBACK_ERROR
+        reason = _LAST_PLAYBACK_ERROR
+    if not reason:
+        return None
+    try:
+        now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
+        position = float((now or {}).get("resume_pos") or 0.0)
+    except Exception:
+        return reason
+    if (position - playback_started_pos()) >= 2.0:
+        return None
+    return reason
 
 
 def set_last_playback_error(reason: str | None) -> None:
@@ -5276,10 +5292,15 @@ def note_playback_started(start_pos: float | None) -> None:
     offset = _mpv_log_size()
     with _PLAYBACK_ERROR_LOCK:
         _PLAYBACK_STARTED_POS = value
-        _LAST_PLAYBACK_ERROR = None
-        # Everything already in the log belongs to an earlier item. Without
-        # this, a short clip that ends quietly inherits the previous play's
-        # 403 and /status blames the wrong thing.
+        # The previous failure is deliberately *not* cleared here. When a queue
+        # advances, the successor starts within milliseconds of the failure
+        # being recorded, so clearing on start meant nothing ever observed it.
+        # It is superseded instead: by this attempt playing (see
+        # last_playback_error) or by how this attempt ends.
+        #
+        # Everything already in the log belongs to an earlier item, so the read
+        # window starts here — a short clip that ends quietly must not inherit
+        # the previous play's 403.
         _PLAYBACK_LOG_OFFSET = offset
 
 
@@ -5374,6 +5395,9 @@ def note_playback_failure_if_no_progress(now: dict | None) -> str:
         return ""
     reason = read_mpv_failure_reason()
     if not reason:
+        # This attempt ended without a diagnosable failure, so whatever was
+        # stored belongs to an older one and has had its chance to be seen.
+        set_last_playback_error(None)
         return ""
     set_last_playback_error(reason)
     logger.info(

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -5288,8 +5288,38 @@ def playback_started_pos() -> float:
         return float(_PLAYBACK_STARTED_POS)
 
 
+# The env vars whose --log-file the launch builders honour instead of adding
+# their own. The reader has to resolve the same override, or it reports nothing
+# for a device whose operator pointed mpv's log somewhere else.
+_MPV_ARG_ENV_VARS = (
+    "RELAYTV_QT_SHELL_MPV_ARGS",
+    "RELAYTV_QT_EXTERNAL_MPV_ARGS",
+    "MPV_ARGS",
+    "MPV_EXTRA_ARGS",
+)
+
+
+def _mpv_log_override() -> str:
+    """An operator-supplied --log-file from the mpv argument overrides."""
+    for name in _MPV_ARG_ENV_VARS:
+        try:
+            parts = shlex.split((os.getenv(name) or "").strip())
+        except Exception:
+            continue
+        for index, token in enumerate(parts):
+            if token.startswith("--log-file="):
+                value = token.split("=", 1)[1].strip()
+                if value:
+                    return value
+            elif token == "--log-file" and index + 1 < len(parts):
+                value = parts[index + 1].strip()
+                if value:
+                    return value
+    return ""
+
+
 def _mpv_log_path() -> str:
-    return (os.getenv("MPV_LOG_FILE") or "").strip() or "/tmp/mpv.log"
+    return (os.getenv("MPV_LOG_FILE") or "").strip() or _mpv_log_override() or "/tmp/mpv.log"
 
 
 def read_mpv_failure_reason(*, tail_bytes: int = 65536) -> str:

--- a/app/relaytv_app/qt_shell_app.py
+++ b/app/relaytv_app/qt_shell_app.py
@@ -492,6 +492,15 @@ def _first_wins_dedupe(args: list[str]) -> list[str]:
     return out
 
 
+def _truncate_mpv_log(path: str, *, max_bytes: int = 2_000_000) -> None:
+    """Keep the mpv log from growing without bound on tmpfs."""
+    try:
+        if os.path.exists(path) and os.path.getsize(path) > max_bytes:
+            os.remove(path)
+    except Exception:
+        pass
+
+
 def _build_mpv_args(
     stream: str,
     wid: int,
@@ -529,10 +538,13 @@ def _build_mpv_args(
         "--osd-playing-msg=",
         "--term-playing-msg=",
     ]
-    log_file = (os.getenv("MPV_LOG_FILE") or "").strip()
-    if not log_file and debug:
-        log_file = "/tmp/mpv.log"
-    if log_file and not _has_opt(args + extra, "--log-file"):
+    # Always keep an mpv log. mpv runs with --no-terminal, so without this its
+    # errors reach nothing at all: a stream that 403s looks, from the outside,
+    # like a successful play that simply stopped. The file is capped and
+    # truncated on each launch, so it stays cheap on tmpfs.
+    log_file = (os.getenv("MPV_LOG_FILE") or "").strip() or "/tmp/mpv.log"
+    _truncate_mpv_log(log_file)
+    if not _has_opt(args + extra, "--log-file"):
         args.append(f"--log-file={log_file}")
     if debug and not _has_opt(args + extra, "--msg-level"):
         args.append("--msg-level=all=debug")
@@ -1091,11 +1103,8 @@ class _QtLibMpvPlayer:
         self._set_opt_best_effort("terminal", "no")
         self._set_opt_best_effort("force-window", "yes")
 
-        log_file = (os.getenv("MPV_LOG_FILE") or "").strip()
-        if not log_file and self.debug:
-            log_file = "/tmp/mpv.log"
-        if log_file:
-            self._set_opt_best_effort("log-file", log_file)
+        log_file = (os.getenv("MPV_LOG_FILE") or "").strip() or "/tmp/mpv.log"
+        self._set_opt_best_effort("log-file", log_file)
         if self.debug:
             self._set_opt_best_effort("msg-level", "all=debug")
 

--- a/app/relaytv_app/qt_shell_app.py
+++ b/app/relaytv_app/qt_shell_app.py
@@ -492,6 +492,30 @@ def _first_wins_dedupe(args: list[str]) -> list[str]:
     return out
 
 
+def _effective_mpv_log_path() -> str:
+    """The log mpv is actually writing, including an operator's override.
+
+    _build_mpv_args suppresses its own --log-file when one arrives through
+    RELAYTV_QT_SHELL_MPV_ARGS or MPV_ARGS, so rotating the default path would
+    leave the real log growing unbounded for the life of the idle player.
+    """
+    explicit = (os.getenv("MPV_LOG_FILE") or "").strip()
+    if explicit:
+        return explicit
+    for name in ("RELAYTV_QT_SHELL_MPV_ARGS", "MPV_ARGS"):
+        parts = _split_env_args(name)
+        for index, token in enumerate(parts):
+            if token.startswith("--log-file="):
+                value = token.split("=", 1)[1].strip()
+                if value:
+                    return value
+            elif token == "--log-file" and index + 1 < len(parts):
+                value = parts[index + 1].strip()
+                if value:
+                    return value
+    return "/tmp/mpv.log"
+
+
 _MPV_LOG_MAX_BYTES = 2_000_000
 _mpv_log_last_check = 0.0
 
@@ -521,7 +545,7 @@ def _rotate_mpv_log_if_needed(reopen) -> None:
     if (now - _mpv_log_last_check) < 60.0:
         return
     _mpv_log_last_check = now
-    path = (os.getenv("MPV_LOG_FILE") or "").strip() or "/tmp/mpv.log"
+    path = _effective_mpv_log_path()
     if not _truncate_mpv_log(path):
         return
     try:
@@ -571,7 +595,7 @@ def _build_mpv_args(
     # errors reach nothing at all: a stream that 403s looks, from the outside,
     # like a successful play that simply stopped. The file is capped and
     # truncated on each launch, so it stays cheap on tmpfs.
-    log_file = (os.getenv("MPV_LOG_FILE") or "").strip() or "/tmp/mpv.log"
+    log_file = _effective_mpv_log_path()
     _truncate_mpv_log(log_file)
     if not _has_opt(args + extra, "--log-file"):
         args.append(f"--log-file={log_file}")

--- a/app/relaytv_app/qt_shell_app.py
+++ b/app/relaytv_app/qt_shell_app.py
@@ -492,11 +492,40 @@ def _first_wins_dedupe(args: list[str]) -> list[str]:
     return out
 
 
-def _truncate_mpv_log(path: str, *, max_bytes: int = 2_000_000) -> None:
-    """Keep the mpv log from growing without bound on tmpfs."""
+_MPV_LOG_MAX_BYTES = 2_000_000
+_mpv_log_last_check = 0.0
+
+
+def _truncate_mpv_log(path: str, *, max_bytes: int = _MPV_LOG_MAX_BYTES) -> bool:
+    """Drop the mpv log once it gets large. Returns True when it was removed."""
     try:
         if os.path.exists(path) and os.path.getsize(path) > max_bytes:
             os.remove(path)
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _rotate_mpv_log_if_needed(reopen) -> None:
+    """Keep the log bounded for the life of the player, not just at launch.
+
+    mpv runs with --idle=yes and is reused across loadfile commands, so a check
+    that only happens when the process starts never runs again on a device that
+    stays up for weeks — and /tmp is tmpfs. Removing the file is not enough
+    either: mpv holds the descriptor and keeps writing at its old offset, so the
+    log-file option is re-set afterwards to make it reopen.
+    """
+    global _mpv_log_last_check
+    now = time.time()
+    if (now - _mpv_log_last_check) < 60.0:
+        return
+    _mpv_log_last_check = now
+    path = (os.getenv("MPV_LOG_FILE") or "").strip() or "/tmp/mpv.log"
+    if not _truncate_mpv_log(path):
+        return
+    try:
+        reopen(path)
     except Exception:
         pass
 
@@ -1001,6 +1030,9 @@ class _QtLibMpvPlayer:
         return self._track_list_cache
 
     def runtime_snapshot(self) -> dict[str, object]:
+        # The libmpv player is long-lived too, and its log had no size check at
+        # all — only the external-mpv launch path did.
+        _rotate_mpv_log_if_needed(lambda p: self.set_property("log-file", p))
         out: dict[str, object] = {
             "mpv_runtime_initialized": True,
             "mpv_runtime_error": "",
@@ -2981,6 +3013,9 @@ def main(argv: list[str] | None = None) -> int:
         cached = _subproc_snapshot_cache.get("data")
         if isinstance(cached, dict) and (now - float(_subproc_snapshot_cache.get("ts") or 0.0)) <= max_age_sec:
             return cached
+        _rotate_mpv_log_if_needed(
+            lambda p: _subprocess_mpv_ipc_request(["set_property", "log-file", p])
+        )
         try:
             props = _subprocess_mpv_get_props(
                 ["pause", "time-pos", "duration", "core-idle", "eof-reached", "path"]

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -612,6 +612,10 @@ def _runtime_capabilities(*, playing: bool | None = None) -> dict:
         "qt_runtime_mode_configured": qt_mode_configured,
         "qt_runtime_mode_effective": qt_mode_effective,
         "player_runtime_engine": player_runtime_engine,
+        # Why the last play produced nothing, when it produced nothing. mpv is
+        # launched with --no-terminal, so this is the only place its reason
+        # surfaces without turning on debug and reproducing the failure.
+        "last_playback_error": (getattr(player, "last_playback_error", lambda: None)() or None),
         "backend_runtime_mismatch": backend_runtime_mismatch,
         "qt_shell_running": qt_running,
         "qt_shell_pid": qt_shell_pid,

--- a/docs/ENV_INVENTORY.md
+++ b/docs/ENV_INVENTORY.md
@@ -337,6 +337,8 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_YTDLP_COOKIES_FROM_BROWSER` | `resolver.py` | - | static env |
 | `RELAYTV_YTDLP_COOKIES_UPLOAD_PATH` | `routes/settings.py` | - | static env |
 | `RELAYTV_YTDLP_JS_RUNTIME` | `resolver.py` | - | static env |
+| `RELAYTV_YTDLP_UPDATE_CHANNEL` | `container_entrypoint.py` | - | pre-app entrypoint |
+| `RELAYTV_YTDLP_UPDATE_DIR` | `container_entrypoint.py` | - | pre-app entrypoint |
 | `RELAYTV_YTDLP_USE_NODE` | `resolver.py` | - | static env |
 | `USE_INVIDIOUS` | `config.py`<br>`main.py`<br>`resolver.py`<br>`routes/settings.py`<br>`state.py` | `main.py`<br>`routes/settings.py` | settings bus |
 | `YTDLP_ARGS` | `resolver.py` | - | static env |

--- a/docs/ENV_INVENTORY.md
+++ b/docs/ENV_INVENTORY.md
@@ -83,6 +83,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | --- | --- | --- | --- |
 | `INVIDIOUS_BASE` | `config.py`<br>`main.py`<br>`resolver.py`<br>`routes/settings.py`<br>`state.py` | `main.py`<br>`routes/settings.py` | settings bus |
 | `MPV_AUDIO_DEVICE` | `config.py`<br>`player.py`<br>`routes/settings.py` | `routes/settings.py` | settings bus |
+| `MPV_EXTRA_ARGS` | `player.py` | - | static env |
 | `RELAYTV_ACCESS_LOG` | `debug.py` | - | static env |
 | `RELAYTV_ACCESS_LOG_HOT_PATHS` | `debug.py` | - | static env |
 | `RELAYTV_ACCESS_LOG_LEVEL` | `debug.py` | - | static env |
@@ -270,7 +271,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_QT_SHELL_FD_LIMIT` | `player.py` | - | static env |
 | `RELAYTV_QT_SHELL_FD_WARN_THRESHOLD` | `player.py` | - | static env |
 | `RELAYTV_QT_SHELL_MODULE` | `container_entrypoint.py`<br>`player.py`<br>`routes/__init__.py` | - | entrypoint input |
-| `RELAYTV_QT_SHELL_MPV_ARGS` | `container_entrypoint.py`<br>`qt_shell_app.py` | - | child process input, entrypoint input |
+| `RELAYTV_QT_SHELL_MPV_ARGS` | `container_entrypoint.py`<br>`player.py`<br>`qt_shell_app.py` | - | child process input, entrypoint input |
 | `RELAYTV_QT_SHELL_SUPERVISOR` | `player.py` | - | static env |
 | `RELAYTV_QT_SHELL_SUPERVISOR_COOLDOWN_SEC` | `player.py` | - | static env |
 | `RELAYTV_QT_SHELL_SUPERVISOR_INTERVAL` | `player.py` | - | static env |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -367,15 +367,45 @@ and tune the schedule:
 
 ```bash
 RELAYTV_YTDLP_AUTO_UPDATE=1
-RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS=24
+RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS=6
 RELAYTV_YTDLP_AUTO_UPDATE_TIMEOUT_SEC=180
 RELAYTV_YTDLP_AUTO_UPDATE_STATE_FILE=/data/.relaytv-ytdlp-update.json
+RELAYTV_YTDLP_UPDATE_DIR=/data/ytdlp
+RELAYTV_YTDLP_UPDATE_CHANNEL=nightly
 ```
+
+Updates install to `RELAYTV_YTDLP_UPDATE_DIR` on the data volume, so they
+survive a container recreate. `$HOME` is `/tmp` and `/tmp` is tmpfs, so the
+older user-site location was discarded on every deploy while the update state
+file (on `/data`) still read "checked recently" — leaving the device on the
+image's yt-dlp until the interval elapsed again.
+
+`RELAYTV_YTDLP_UPDATE_CHANNEL` defaults to `nightly` because yt-dlp ships
+extractor fixes there first; stable can go weeks between releases while a site
+change breaks playback. A failed nightly install falls back to `stable`
+automatically, and `stable` pins the old behaviour. A persisted copy is
+discarded if it will not run or if a rebuilt image ships something newer.
 
 Official release images disable `yt-dlp` auto-update by default for source and
 object traceability. Enabling it is a user opt-in that may improve resolver
 freshness, but audited/reproducible build claims only cover the image as built.
 See [RELEASE.md](RELEASE.md) for release input details.
+
+### Playback starts then stops after a few seconds
+
+Almost always a stale yt-dlp. The resolve succeeds, so `POST /play_now` returns
+200 and the container log looks clean, but the stream URL it produced is one the
+site now rejects and mpv dies on the first fetch. mpv runs with `--no-terminal`,
+so its reason is not on stdout — check instead:
+
+```bash
+curl -s http://<host>:8787/status | jq .last_playback_error
+cat /data/.relaytv-ytdlp-update.json
+```
+
+`last_playback_error` carries mpv's own message (for example
+`stream: Failed to open <url>` after an HTTP 403). If yt-dlp is behind, force a
+check by toggling auto-update off and on in Settings, or restart the container.
 
 ### CEC
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -472,7 +472,10 @@ if [ -z "$YTDLP_AUTO_UPDATE_VAL" ]; then
   YTDLP_AUTO_UPDATE_VAL="0"
 fi
 if [ -z "$YTDLP_AUTO_UPDATE_INTERVAL_HOURS_VAL" ]; then
-  YTDLP_AUTO_UPDATE_INTERVAL_HOURS_VAL="24"
+  # Must match the app default in container_entrypoint.run_yt_dlp_update. The
+  # block below omits the variable when it equals this value, so a mismatch
+  # would silently rewrite an operator's explicit schedule on every regenerate.
+  YTDLP_AUTO_UPDATE_INTERVAL_HOURS_VAL="6"
 fi
 if [ -z "$YTDLP_AUTO_UPDATE_TIMEOUT_SEC_VAL" ]; then
   YTDLP_AUTO_UPDATE_TIMEOUT_SEC_VAL="180"
@@ -1158,7 +1161,7 @@ if [ "${YTDLP_AUTO_UPDATE_VAL}" != "0" ]; then
   YTDLP_ENV_BLOCK+=$(emit_env_line "RELAYTV_YTDLP_AUTO_UPDATE" "${YTDLP_AUTO_UPDATE_VAL}")
   YTDLP_ENV_BLOCK+=$'\n'
 fi
-if [ "${YTDLP_AUTO_UPDATE_INTERVAL_HOURS_VAL}" != "24" ]; then
+if [ "${YTDLP_AUTO_UPDATE_INTERVAL_HOURS_VAL}" != "6" ]; then
   YTDLP_ENV_BLOCK+=$(emit_env_line "RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS" "${YTDLP_AUTO_UPDATE_INTERVAL_HOURS_VAL}")
   YTDLP_ENV_BLOCK+=$'\n'
 fi

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5751,7 +5751,7 @@ def test_a_persisted_copy_older_than_the_image_is_discarded(monkeypatch, tmp_pat
     (update_dir / "bin" / "yt-dlp").write_text("#!/bin/sh\n", encoding="utf-8")
     env = {"PATH": f"{update_dir}/bin:/usr/bin", "RELAYTV_YTDLP_UPDATE_DIR": str(update_dir)}
 
-    def _version(_env, *, path=None):
+    def _version(_env, *, path=None, user_site=True):
         return "2026.01.01" if path is None else "2026.08.19"  # persisted, image
 
     monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", _version)
@@ -5766,7 +5766,7 @@ def test_a_persisted_copy_newer_than_the_image_is_kept(monkeypatch, tmp_path) ->
     (update_dir / "bin" / "yt-dlp").write_text("#!/bin/sh\n", encoding="utf-8")
     env = {"PATH": f"{update_dir}/bin:/usr/bin", "RELAYTV_YTDLP_UPDATE_DIR": str(update_dir)}
 
-    def _version(_env, *, path=None):
+    def _version(_env, *, path=None, user_site=True):
         return "2026.08.19" if path is None else "2026.01.01"
 
     monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", _version)
@@ -5782,7 +5782,7 @@ def test_a_persisted_copy_that_cannot_run_is_discarded(monkeypatch, tmp_path) ->
     (update_dir / "bin" / "yt-dlp").write_text("#!/usr/bin/python3.9\n", encoding="utf-8")
     env = {"PATH": f"{update_dir}/bin:/usr/bin", "RELAYTV_YTDLP_UPDATE_DIR": str(update_dir)}
 
-    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None: "")
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None, user_site=True: "")
     container_entrypoint._prune_persisted_ytdlp(env)
 
     assert not update_dir.exists()
@@ -5813,7 +5813,7 @@ def test_a_reverted_install_forces_a_check_despite_a_fresh_timestamp(monkeypatch
         json.dumps({"last_check_ts": _time.time(), "after_version": "2026.08.19"}), encoding="utf-8"
     )
     pip_calls: list[list[str]] = []
-    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None: "2026.07.04")
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None, user_site=True: "2026.07.04")
     monkeypatch.setattr(
         container_entrypoint.subprocess,
         "run",
@@ -5833,7 +5833,7 @@ def test_a_matching_install_still_honours_the_interval(monkeypatch, tmp_path) ->
         json.dumps({"last_check_ts": _time.time(), "after_version": "2026.08.19"}), encoding="utf-8"
     )
     pip_calls: list[list[str]] = []
-    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None: "2026.08.19")
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None, user_site=True: "2026.08.19")
     monkeypatch.setattr(
         container_entrypoint.subprocess,
         "run",
@@ -5854,7 +5854,7 @@ def test_nightly_channel_passes_pre_and_stable_does_not(monkeypatch, tmp_path) -
         env, _ = _update_env(tmp_path / channel, RELAYTV_YTDLP_UPDATE_CHANNEL=channel)
         (tmp_path / channel).mkdir(parents=True, exist_ok=True)
         pip_calls: list[list[str]] = []
-        monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None: "2026.08.19")
+        monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None, user_site=True: "2026.08.19")
         monkeypatch.setattr(
             container_entrypoint.subprocess,
             "run",
@@ -5876,7 +5876,7 @@ def test_a_failed_nightly_falls_back_to_stable(monkeypatch, tmp_path) -> None:
         rc = 1 if "--pre" in cmd else 0
         return subprocess.CompletedProcess(cmd, rc, "", "boom")
 
-    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None: "2026.08.19")
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None, user_site=True: "2026.08.19")
     monkeypatch.setattr(container_entrypoint.subprocess, "run", _run)
 
     assert container_entrypoint.run_yt_dlp_update(env, force=True) is True
@@ -5894,7 +5894,7 @@ def test_an_install_that_does_not_run_is_reverted(monkeypatch, tmp_path) -> None
     # Prune sees a working copy; the post-install probe finds it unrunnable.
     calls = {"n": 0}
 
-    def _version(_env, *, path=None):
+    def _version(_env, *, path=None, user_site=True):
         calls["n"] += 1
         return "2026.07.04" if calls["n"] <= 3 else ""
 
@@ -5949,3 +5949,26 @@ def test_a_failed_play_records_a_reason_and_a_finished_one_clears_it(monkeypatch
     # An item that actually played is not a failure, whatever the log still holds.
     player.note_playback_failure_if_no_progress({"title": "Something", "resume_pos": 240.0})
     assert player.last_playback_error() is None
+
+
+def test_the_image_version_probe_ignores_the_persisted_install(monkeypatch) -> None:
+    """Stripping PATH alone cannot see the image's yt-dlp.
+
+    PYTHONUSERBASE still steers the import, so /usr/local/bin/yt-dlp would load
+    the persisted package and report its version — making the "is the image
+    newer?" comparison always compare a version against itself.
+    """
+    seen: list[dict] = []
+
+    def _run(cmd, **kw):
+        seen.append(dict(kw.get("env") or {}))
+        return subprocess.CompletedProcess(cmd, 0, "2026.07.04\n", "")
+
+    monkeypatch.setattr(container_entrypoint.subprocess, "run", _run)
+    env = {"PATH": "/data/ytdlp/bin:/usr/local/bin", "PYTHONUSERBASE": "/data/ytdlp"}
+
+    container_entrypoint._yt_dlp_version(env, path="/usr/local/bin", user_site=False)
+    assert "PYTHONUSERBASE" not in seen[-1]
+
+    container_entrypoint._yt_dlp_version(env)
+    assert seen[-1].get("PYTHONUSERBASE") == "/data/ytdlp"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -462,12 +462,19 @@ def test_yt_dlp_update_interval_gate_and_force(monkeypatch: pytest.MonkeyPatch, 
 
     pip_calls: list[object] = []
     state_file = tmp_path / "update.json"
-    state_file.write_text(json.dumps({"last_check_ts": _time.time()}), encoding="utf-8")
+    # Record the channel too: without it the state reads as a stable-era check,
+    # and the channel-switch guard would force a run before the interval.
+    state_file.write_text(
+        json.dumps({"last_check_ts": _time.time(), "channel": "nightly"}), encoding="utf-8"
+    )
     env = {
         "RELAYTV_YTDLP_AUTO_UPDATE_STATE_FILE": str(state_file),
         "RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS": "24",
+        "RELAYTV_YTDLP_UPDATE_DIR": str(tmp_path / "ytdlp"),
     }
-    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda env: "2026.01.01")
+    monkeypatch.setattr(
+        container_entrypoint, "_yt_dlp_version", lambda env, *, path=None, user_site=True: "2026.01.01"
+    )
     monkeypatch.setattr(
         container_entrypoint.subprocess,
         "run",
@@ -5829,8 +5836,13 @@ def test_a_matching_install_still_honours_the_interval(monkeypatch, tmp_path) ->
     import time as _time
 
     env, state_file = _update_env(tmp_path)
+    # Same version and same channel as the state records: nothing has moved, so
+    # the interval is the only thing that should decide.
     state_file.write_text(
-        json.dumps({"last_check_ts": _time.time(), "after_version": "2026.08.19"}), encoding="utf-8"
+        json.dumps(
+            {"last_check_ts": _time.time(), "after_version": "2026.08.19", "channel": "nightly"}
+        ),
+        encoding="utf-8",
     )
     pip_calls: list[list[str]] = []
     monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None, user_site=True: "2026.08.19")
@@ -5972,3 +5984,36 @@ def test_the_image_version_probe_ignores_the_persisted_install(monkeypatch) -> N
 
     container_entrypoint._yt_dlp_version(env)
     assert seen[-1].get("PYTHONUSERBASE") == "/data/ytdlp"
+
+
+def test_switching_channel_forces_a_check(monkeypatch, tmp_path) -> None:
+    """A recorded stable-only check answered a different question.
+
+    Switching to nightly must not wait out an interval that a stable check
+    satisfied, or the switch does nothing for hours — exactly when it is being
+    made because playback is broken right now.
+    """
+    import time as _time
+
+    env, state_file = _update_env(tmp_path, RELAYTV_YTDLP_UPDATE_CHANNEL="nightly")
+    (tmp_path / "ytdlp").mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        json.dumps(
+            {"last_check_ts": _time.time(), "after_version": "2026.07.04", "channel": "stable"}
+        ),
+        encoding="utf-8",
+    )
+    pip_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None, user_site=True: "2026.07.04"
+    )
+    monkeypatch.setattr(
+        container_entrypoint.subprocess,
+        "run",
+        lambda cmd, **kw: pip_calls.append(list(cmd)) or subprocess.CompletedProcess(cmd, 0, "", ""),
+    )
+
+    container_entrypoint.run_yt_dlp_update(env)
+
+    assert pip_calls, "the channel switch was suppressed by the interval"
+    assert "--pre" in pip_calls[0]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5764,7 +5764,7 @@ def test_a_persisted_copy_older_than_the_image_is_discarded(monkeypatch, tmp_pat
     monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", _version)
     container_entrypoint._prune_persisted_ytdlp(env)
 
-    assert not update_dir.exists()
+    assert not (update_dir / "bin" / "yt-dlp").exists()
 
 
 def test_a_persisted_copy_newer_than_the_image_is_kept(monkeypatch, tmp_path) -> None:
@@ -5792,7 +5792,7 @@ def test_a_persisted_copy_that_cannot_run_is_discarded(monkeypatch, tmp_path) ->
     monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None, user_site=True: "")
     container_entrypoint._prune_persisted_ytdlp(env)
 
-    assert not update_dir.exists()
+    assert not (update_dir / "bin" / "yt-dlp").exists()
 
 
 def _update_env(tmp_path, **extra):
@@ -5894,7 +5894,11 @@ def test_a_failed_nightly_falls_back_to_stable(monkeypatch, tmp_path) -> None:
     assert container_entrypoint.run_yt_dlp_update(env, force=True) is True
     assert len(pip_calls) == 2
     assert "--pre" in pip_calls[0] and "--pre" not in pip_calls[1]
-    assert json.loads(state_file.read_text(encoding="utf-8"))["channel"] == "stable"
+    saved = json.loads(state_file.read_text(encoding="utf-8"))
+    # The requested channel is what the staleness check compares against, so a
+    # fallback must not masquerade as a channel switch.
+    assert saved["channel"] == "nightly"
+    assert saved["installed_channel"] == "stable"
 
 
 def test_an_install_that_does_not_run_is_reverted(monkeypatch, tmp_path) -> None:
@@ -6017,3 +6021,121 @@ def test_switching_channel_forces_a_check(monkeypatch, tmp_path) -> None:
 
     assert pip_calls, "the channel switch was suppressed by the interval"
     assert "--pre" in pip_calls[0]
+
+
+def test_pruning_never_touches_anything_but_yt_dlp(tmp_path) -> None:
+    """RELAYTV_YTDLP_UPDATE_DIR is operator-supplied and easy to point at /data.
+
+    pip will happily create bin/ and lib/ inside a shared directory, so pruning
+    must remove yt-dlp's own files rather than the directory it was told to use
+    — otherwise one failed probe deletes settings, history, peers, the device id
+    and every upload.
+    """
+    data = tmp_path / "data"
+    (data / "bin").mkdir(parents=True)
+    (data / "bin" / "yt-dlp").write_text("#!/bin/sh\n", encoding="utf-8")
+    site = data / "lib" / "python3.13" / "site-packages"
+    site.mkdir(parents=True)
+    (site / "yt_dlp").mkdir()
+    (site / "yt_dlp" / "__init__.py").write_text("", encoding="utf-8")
+    (site / "yt_dlp-2026.8.19.dist-info").mkdir()
+    (site / "some_other_package").mkdir()
+
+    precious = ["settings.json", "history.json", "peers.json", "device_id"]
+    for name in precious:
+        (data / name).write_text("precious", encoding="utf-8")
+    (data / "uploads").mkdir()
+    (data / "uploads" / "movie.mp4").write_text("x", encoding="utf-8")
+
+    container_entrypoint._discard_persisted_ytdlp(data, "test")
+
+    assert data.exists(), "the update directory itself was deleted"
+    for name in precious:
+        assert (data / name).read_text(encoding="utf-8") == "precious", name
+    assert (data / "uploads" / "movie.mp4").exists()
+    assert (site / "some_other_package").exists(), "an unrelated package was removed"
+    # ...and yt-dlp really is gone.
+    assert not (data / "bin" / "yt-dlp").exists()
+    assert not (site / "yt_dlp").exists()
+    assert not (site / "yt_dlp-2026.8.19.dist-info").exists()
+
+
+def test_a_stable_fallback_does_not_retrigger_on_every_poll(monkeypatch, tmp_path) -> None:
+    """An unavailable nightly must be retried once per interval, not per poll.
+
+    Driven as a full round trip — write the state by really running a fallback,
+    then run again — because recording the fallback channel as the *requested*
+    one is a write-side bug that reading a hand-built state file cannot catch.
+    """
+    env, _state_file = _update_env(tmp_path, RELAYTV_YTDLP_UPDATE_CHANNEL="nightly")
+    (tmp_path / "ytdlp").mkdir(parents=True, exist_ok=True)
+    pip_calls: list[list[str]] = []
+
+    def _run(cmd, **kw):
+        pip_calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 1 if "--pre" in cmd else 0, "", "no nightly")
+
+    monkeypatch.setattr(
+        container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None, user_site=True: "2026.07.04"
+    )
+    monkeypatch.setattr(container_entrypoint.subprocess, "run", _run)
+
+    # First pass: nightly fails, stable succeeds, and the state is written.
+    container_entrypoint.run_yt_dlp_update(env, force=True)
+    assert len(pip_calls) == 2
+
+    # Second pass, well inside the interval: nothing has actually changed, so
+    # this must skip rather than retry the unavailable nightly.
+    pip_calls.clear()
+    assert container_entrypoint.run_yt_dlp_update(env) is False
+    assert pip_calls == []
+
+
+def test_the_mpv_log_is_rotated_while_the_player_keeps_running(monkeypatch, tmp_path) -> None:
+    """mpv runs --idle=yes and is reused across loadfiles.
+
+    A size check that only happens at launch never runs again on a device that
+    stays up for weeks, and /tmp is tmpfs. Removing the file alone is not
+    enough either — mpv holds the descriptor — so the log-file option has to be
+    re-set to make it reopen.
+    """
+    from relaytv_app import qt_shell_app
+
+    log = tmp_path / "mpv.log"
+    log.write_bytes(b"x" * 10)
+    monkeypatch.setenv("MPV_LOG_FILE", str(log))
+    monkeypatch.setattr(qt_shell_app, "_mpv_log_last_check", 0.0)
+
+    reopened: list[str] = []
+    qt_shell_app._rotate_mpv_log_if_needed(reopened.append)
+    assert log.exists() and reopened == [], "a small log was rotated needlessly"
+
+    log.write_bytes(b"x" * (qt_shell_app._MPV_LOG_MAX_BYTES + 1))
+    monkeypatch.setattr(qt_shell_app, "_mpv_log_last_check", 0.0)
+    qt_shell_app._rotate_mpv_log_if_needed(reopened.append)
+
+    assert not log.exists()
+    assert reopened == [str(log)], "mpv was never told to reopen its log"
+
+
+def test_a_failed_resume_still_reports_its_reason(monkeypatch, tmp_path) -> None:
+    """resume_pos holds the live position, not progress since the start.
+
+    An item resumed at five minutes already reads as five minutes of progress,
+    so a resumed stream that dies instantly used to look like a completed play
+    and report nothing — the exact case this diagnostic exists for.
+    """
+    from relaytv_app import player
+
+    log = tmp_path / "mpv.log"
+    log.write_text("[ 19.85][e][stream] Failed to open http://x/y.\n", encoding="utf-8")
+    monkeypatch.setenv("MPV_LOG_FILE", str(log))
+
+    player.note_playback_started(300.0)   # resumed five minutes in
+    player.note_playback_failure_if_no_progress({"title": "Resumed", "resume_pos": 300.0})
+    assert "Failed to open" in (player.last_playback_error() or "")
+
+    # Real progress from that same resume point is not a failure.
+    player.note_playback_started(300.0)
+    player.note_playback_failure_if_no_progress({"title": "Resumed", "resume_pos": 340.0})
+    assert player.last_playback_error() is None

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5706,3 +5706,246 @@ def test_auto_next_skips_stale_iptv_channel_instead_of_blocking(monkeypatch: pyt
     assert result['skipped_unplayable'] == 1
     assert play_calls == [good_item]
     assert player.state.QUEUE == []
+
+
+# --- yt-dlp update durability ------------------------------------------------
+#
+# A six-week-old yt-dlp broke YouTube playback: the resolve succeeded, mpv got
+# 403 on the stream, and the device went idle ~10s in. The updater had been
+# running and reporting success the whole time, because its install landed in
+# tmpfs while its state file lived on /data.
+
+
+def test_update_path_points_at_the_persistent_volume() -> None:
+    env = {"PATH": "/usr/local/bin:/usr/bin", "HOME": "/tmp"}
+    container_entrypoint._normalize_path_env(env)
+
+    assert env["PYTHONUSERBASE"] == "/data/ytdlp"
+    assert env["PATH"].split(":")[0] == "/data/ytdlp/bin"
+    # $HOME is /tmp and /tmp is tmpfs; an install there dies on every recreate.
+    assert "/tmp/.local/bin" not in env["PATH"]
+
+
+def test_update_dir_is_configurable() -> None:
+    env = {"PATH": "/usr/bin", "RELAYTV_YTDLP_UPDATE_DIR": "/data/custom"}
+    container_entrypoint._normalize_path_env(env)
+    assert env["PYTHONUSERBASE"] == "/data/custom"
+    assert env["PATH"].startswith("/data/custom/bin:")
+
+
+def test_version_key_orders_yt_dlp_versions() -> None:
+    key = container_entrypoint._version_key
+    assert key("2026.8.19") > key("2026.7.4")
+    assert key("2026.8.19") > key("2026.8.4")
+    assert key("") == ()
+
+
+def test_a_persisted_copy_older_than_the_image_is_discarded(monkeypatch, tmp_path) -> None:
+    """A tree on /data outlives the image around it.
+
+    Left alone it stays first on PATH, so a rebuilt image shipping a newer
+    yt-dlp would be shadowed by the old persisted one indefinitely.
+    """
+    update_dir = tmp_path / "ytdlp"
+    (update_dir / "bin").mkdir(parents=True)
+    (update_dir / "bin" / "yt-dlp").write_text("#!/bin/sh\n", encoding="utf-8")
+    env = {"PATH": f"{update_dir}/bin:/usr/bin", "RELAYTV_YTDLP_UPDATE_DIR": str(update_dir)}
+
+    def _version(_env, *, path=None):
+        return "2026.01.01" if path is None else "2026.08.19"  # persisted, image
+
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", _version)
+    container_entrypoint._prune_persisted_ytdlp(env)
+
+    assert not update_dir.exists()
+
+
+def test_a_persisted_copy_newer_than_the_image_is_kept(monkeypatch, tmp_path) -> None:
+    update_dir = tmp_path / "ytdlp"
+    (update_dir / "bin").mkdir(parents=True)
+    (update_dir / "bin" / "yt-dlp").write_text("#!/bin/sh\n", encoding="utf-8")
+    env = {"PATH": f"{update_dir}/bin:/usr/bin", "RELAYTV_YTDLP_UPDATE_DIR": str(update_dir)}
+
+    def _version(_env, *, path=None):
+        return "2026.08.19" if path is None else "2026.01.01"
+
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", _version)
+    container_entrypoint._prune_persisted_ytdlp(env)
+
+    assert update_dir.exists(), "the newer persisted copy was thrown away"
+
+
+def test_a_persisted_copy_that_cannot_run_is_discarded(monkeypatch, tmp_path) -> None:
+    """Usually a console-script shebang naming an interpreter the image dropped."""
+    update_dir = tmp_path / "ytdlp"
+    (update_dir / "bin").mkdir(parents=True)
+    (update_dir / "bin" / "yt-dlp").write_text("#!/usr/bin/python3.9\n", encoding="utf-8")
+    env = {"PATH": f"{update_dir}/bin:/usr/bin", "RELAYTV_YTDLP_UPDATE_DIR": str(update_dir)}
+
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None: "")
+    container_entrypoint._prune_persisted_ytdlp(env)
+
+    assert not update_dir.exists()
+
+
+def _update_env(tmp_path, **extra):
+    state_file = tmp_path / "update.json"
+    env = {
+        "RELAYTV_YTDLP_AUTO_UPDATE_STATE_FILE": str(state_file),
+        "RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS": "6",
+        "RELAYTV_YTDLP_UPDATE_DIR": str(tmp_path / "ytdlp"),
+    }
+    env.update(extra)
+    return env, state_file
+
+
+def test_a_reverted_install_forces_a_check_despite_a_fresh_timestamp(monkeypatch, tmp_path) -> None:
+    """The post-deploy case that kept devices on a stale yt-dlp for hours.
+
+    The state file survives on /data; the install used not to. So after a
+    recreate the state said "checked minutes ago" while the binary had gone
+    back to the image's copy, and the interval gate suppressed the re-check.
+    """
+    import time as _time
+
+    env, state_file = _update_env(tmp_path)
+    state_file.write_text(
+        json.dumps({"last_check_ts": _time.time(), "after_version": "2026.08.19"}), encoding="utf-8"
+    )
+    pip_calls: list[list[str]] = []
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None: "2026.07.04")
+    monkeypatch.setattr(
+        container_entrypoint.subprocess,
+        "run",
+        lambda cmd, **kw: pip_calls.append(list(cmd)) or subprocess.CompletedProcess(cmd, 0, "", ""),
+    )
+
+    container_entrypoint.run_yt_dlp_update(env)
+
+    assert pip_calls, "a reverted install was not re-checked"
+
+
+def test_a_matching_install_still_honours_the_interval(monkeypatch, tmp_path) -> None:
+    import time as _time
+
+    env, state_file = _update_env(tmp_path)
+    state_file.write_text(
+        json.dumps({"last_check_ts": _time.time(), "after_version": "2026.08.19"}), encoding="utf-8"
+    )
+    pip_calls: list[list[str]] = []
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None: "2026.08.19")
+    monkeypatch.setattr(
+        container_entrypoint.subprocess,
+        "run",
+        lambda cmd, **kw: pip_calls.append(list(cmd)) or subprocess.CompletedProcess(cmd, 0, "", ""),
+    )
+
+    assert container_entrypoint.run_yt_dlp_update(env) is False
+    assert pip_calls == []
+
+
+def test_nightly_channel_passes_pre_and_stable_does_not(monkeypatch, tmp_path) -> None:
+    """Every release between 2026.7.4 and 2026.8.19 was a .dev0 pre-release.
+
+    `pip install --upgrade` skips those by design, which is how a device sat on
+    a six-week-old yt-dlp while every check honestly reported "nothing newer".
+    """
+    for channel, expect_pre in (("nightly", True), ("stable", False)):
+        env, _ = _update_env(tmp_path / channel, RELAYTV_YTDLP_UPDATE_CHANNEL=channel)
+        (tmp_path / channel).mkdir(parents=True, exist_ok=True)
+        pip_calls: list[list[str]] = []
+        monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None: "2026.08.19")
+        monkeypatch.setattr(
+            container_entrypoint.subprocess,
+            "run",
+            lambda cmd, **kw: pip_calls.append(list(cmd)) or subprocess.CompletedProcess(cmd, 0, "", ""),
+        )
+        container_entrypoint.run_yt_dlp_update(env, force=True)
+        assert pip_calls, channel
+        assert ("--pre" in pip_calls[0]) is expect_pre, channel
+
+
+def test_a_failed_nightly_falls_back_to_stable(monkeypatch, tmp_path) -> None:
+    """A broken nightly must not leave the device worse off than stable."""
+    env, state_file = _update_env(tmp_path)
+    (tmp_path / "ytdlp").mkdir(parents=True, exist_ok=True)
+    pip_calls: list[list[str]] = []
+
+    def _run(cmd, **kw):
+        pip_calls.append(list(cmd))
+        rc = 1 if "--pre" in cmd else 0
+        return subprocess.CompletedProcess(cmd, rc, "", "boom")
+
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", lambda _env, *, path=None: "2026.08.19")
+    monkeypatch.setattr(container_entrypoint.subprocess, "run", _run)
+
+    assert container_entrypoint.run_yt_dlp_update(env, force=True) is True
+    assert len(pip_calls) == 2
+    assert "--pre" in pip_calls[0] and "--pre" not in pip_calls[1]
+    assert json.loads(state_file.read_text(encoding="utf-8"))["channel"] == "stable"
+
+
+def test_an_install_that_does_not_run_is_reverted(monkeypatch, tmp_path) -> None:
+    env, state_file = _update_env(tmp_path)
+    update_dir = tmp_path / "ytdlp"
+    (update_dir / "bin").mkdir(parents=True)
+    (update_dir / "bin" / "yt-dlp").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    # Prune sees a working copy; the post-install probe finds it unrunnable.
+    calls = {"n": 0}
+
+    def _version(_env, *, path=None):
+        calls["n"] += 1
+        return "2026.07.04" if calls["n"] <= 3 else ""
+
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", _version)
+    monkeypatch.setattr(
+        container_entrypoint.subprocess,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, "", ""),
+    )
+
+    container_entrypoint.run_yt_dlp_update(env, force=True)
+
+    saved = json.loads(state_file.read_text(encoding="utf-8"))
+    assert saved["ok"] is False
+    assert "did not execute" in saved["error"]
+
+
+# --- playback failure visibility ---------------------------------------------
+
+
+def test_mpv_failure_reason_is_extracted_and_redacted(monkeypatch, tmp_path) -> None:
+    """mpv runs with --no-terminal, so its log is the only place this exists."""
+    from relaytv_app import player
+
+    log = tmp_path / "mpv.log"
+    log.write_text(
+        "[   0.10][v][cplayer] Starting playback...\n"
+        "[  19.85][w][ffmpeg] https: HTTP error 403 Forbidden\n"
+        "[  19.85][e][stream] Failed to open https://rr2---sn-x.googlevideo.com/videoplayback?sig=SECRET.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MPV_LOG_FILE", str(log))
+
+    reason = player.read_mpv_failure_reason()
+
+    assert "Failed to open" in reason
+    assert "SECRET" not in reason, "a signed stream URL leaked into the log line"
+    assert "<url>" in reason
+
+
+def test_a_failed_play_records_a_reason_and_a_finished_one_clears_it(monkeypatch, tmp_path) -> None:
+    from relaytv_app import player
+
+    log = tmp_path / "mpv.log"
+    log.write_text("[ 19.85][e][stream] Failed to open http://x/y.\n", encoding="utf-8")
+    monkeypatch.setenv("MPV_LOG_FILE", str(log))
+
+    player.set_last_playback_error(None)
+    player.note_playback_failure_if_no_progress({"title": "Something", "resume_pos": 0.0})
+    assert "Failed to open" in (player.last_playback_error() or "")
+
+    # An item that actually played is not a failure, whatever the log still holds.
+    player.note_playback_failure_if_no_progress({"title": "Something", "resume_pos": 240.0})
+    assert player.last_playback_error() is None

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -6220,3 +6220,70 @@ def test_a_failed_item_is_recorded_even_when_the_queue_advances(monkeypatch) -> 
             state.QUEUE.clear()
 
     assert seen and (seen[0] or {}).get("title") == "Failed item"
+
+
+def test_a_stale_persisted_copy_is_pruned_even_with_updates_disabled(monkeypatch, tmp_path) -> None:
+    """The PATH prefix is unconditional, so pruning must be too.
+
+    Enable auto-update once, turn it off, then deploy an image carrying a newer
+    yt-dlp: the old persisted copy would keep winning indefinitely, because
+    pruning used to live only inside the update path.
+    """
+    update_dir = tmp_path / "ytdlp"
+    (update_dir / "bin").mkdir(parents=True)
+    (update_dir / "bin" / "yt-dlp").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setenv("RELAYTV_YTDLP_UPDATE_DIR", str(update_dir))
+    monkeypatch.setenv("RELAYTV_YTDLP_AUTO_UPDATE", "0")
+
+    def _version(_env, *, path=None, user_site=True):
+        return "2026.01.01" if user_site else "2026.08.19"   # persisted vs image
+
+    monkeypatch.setattr(container_entrypoint, "_yt_dlp_version", _version)
+    monkeypatch.setattr(container_entrypoint, "_normalize_runtime_defaults", lambda env: None)
+    monkeypatch.setattr(container_entrypoint, "_sync_legacy_brand_assets", lambda: None)
+    monkeypatch.setattr(container_entrypoint, "refresh_display_credentials", lambda env: dict(env))
+
+    started: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+
+        def wait(self, *a, **k):
+            return 0
+
+        def poll(self):
+            return 0
+
+    monkeypatch.setattr(
+        container_entrypoint.subprocess, "Popen", lambda args, **kw: started.append(list(args)) or _Proc()
+    )
+
+    container_entrypoint.main(["true"])
+
+    assert not (update_dir / "bin" / "yt-dlp").exists(), "the stale copy still shadows the image"
+
+
+def test_the_reader_follows_an_operator_log_file_override(monkeypatch) -> None:
+    """The builders skip their own --log-file when an operator supplies one.
+
+    If the reader keeps opening /tmp/mpv.log it reports nothing, or a stale
+    reason from a different backend, on exactly those devices.
+    """
+    from relaytv_app import player
+
+    monkeypatch.delenv("MPV_LOG_FILE", raising=False)
+    for name in player._MPV_ARG_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    assert player._mpv_log_path() == "/tmp/mpv.log"
+
+    monkeypatch.setenv("RELAYTV_QT_SHELL_MPV_ARGS", "--gpu-api=opengl --log-file=/data/mpv-custom.log")
+    assert player._mpv_log_path() == "/data/mpv-custom.log"
+
+    # The separated form too, and MPV_LOG_FILE still wins when both are set.
+    monkeypatch.delenv("RELAYTV_QT_SHELL_MPV_ARGS")
+    monkeypatch.setenv("MPV_ARGS", "--log-file /var/log/mpv.log")
+    assert player._mpv_log_path() == "/var/log/mpv.log"
+    monkeypatch.setenv("MPV_LOG_FILE", "/explicit.log")
+    assert player._mpv_log_path() == "/explicit.log"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -6287,3 +6287,72 @@ def test_the_reader_follows_an_operator_log_file_override(monkeypatch) -> None:
     assert player._mpv_log_path() == "/var/log/mpv.log"
     monkeypatch.setenv("MPV_LOG_FILE", "/explicit.log")
     assert player._mpv_log_path() == "/explicit.log"
+
+
+def test_the_installer_interval_default_matches_the_app_default() -> None:
+    """The installer omits the variable when it equals its own default.
+
+    If the two defaults drift, regenerating .env silently rewrites an explicit
+    schedule — an operator who asked for 24h would quietly get the app default
+    instead, with nothing in the file to show it happened.
+    """
+    installer = (ROOT_DIR / "scripts" / "install.sh").read_text(encoding="utf-8")
+    app_default = container_entrypoint._parse_float_env({}, "RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS", 6.0)
+
+    assert f'YTDLP_AUTO_UPDATE_INTERVAL_HOURS_VAL="{int(app_default)}"' in installer
+    assert f'"${{YTDLP_AUTO_UPDATE_INTERVAL_HOURS_VAL}}" != "{int(app_default)}"' in installer
+
+
+def test_a_queued_failure_is_still_visible_while_the_next_item_starts(monkeypatch, tmp_path) -> None:
+    """The successor starts within milliseconds of the failure being recorded.
+
+    Clearing on start meant /status never exposed it whenever a queue advanced,
+    which is the common case — the earlier natural_end fix alone did not help.
+    """
+    from relaytv_app import player, state
+
+    log = tmp_path / "mpv.log"
+    log.write_text("", encoding="utf-8")
+    monkeypatch.setenv("MPV_LOG_FILE", str(log))
+
+    # Item A plays, fails, and its reason is recorded.
+    player.note_playback_started(0.0)
+    with open(log, "a", encoding="utf-8") as handle:
+        handle.write("[ 9.9][e][stream] Failed to open http://a/.\n")
+    monkeypatch.setattr(state, "NOW_PLAYING", {"title": "A", "resume_pos": 0.0})
+    player.note_playback_failure_if_no_progress(state.NOW_PLAYING)
+    assert "Failed to open" in (player.last_playback_error() or "")
+
+    # The queue advances: B starts immediately, before it has played anything.
+    player.note_playback_started(0.0)
+    monkeypatch.setattr(state, "NOW_PLAYING", {"title": "B", "resume_pos": 0.0})
+    assert "Failed to open" in (player.last_playback_error() or ""), \
+        "the failure vanished the moment the queue advanced"
+
+    # Once B is genuinely playing, it supersedes A's failure.
+    monkeypatch.setattr(state, "NOW_PLAYING", {"title": "B", "resume_pos": 30.0})
+    assert player.last_playback_error() is None
+
+
+def test_rotation_follows_an_operator_log_file_override(monkeypatch, tmp_path) -> None:
+    """_build_mpv_args suppresses its own --log-file when an operator supplies one.
+
+    Rotating the default path then leaves the log mpv is really writing to
+    growing unbounded for the life of the idle player — on tmpfs.
+    """
+    from relaytv_app import qt_shell_app
+
+    monkeypatch.delenv("MPV_LOG_FILE", raising=False)
+    monkeypatch.delenv("MPV_ARGS", raising=False)
+    custom = tmp_path / "custom-mpv.log"
+    monkeypatch.setenv("RELAYTV_QT_SHELL_MPV_ARGS", f"--gpu-api=opengl --log-file={custom}")
+
+    assert qt_shell_app._effective_mpv_log_path() == str(custom)
+
+    custom.write_bytes(b"x" * (qt_shell_app._MPV_LOG_MAX_BYTES + 1))
+    monkeypatch.setattr(qt_shell_app, "_mpv_log_last_check", 0.0)
+    reopened: list[str] = []
+    qt_shell_app._rotate_mpv_log_if_needed(reopened.append)
+
+    assert not custom.exists(), "the operator's log was left to grow unbounded"
+    assert reopened == [str(custom)]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -6128,14 +6128,95 @@ def test_a_failed_resume_still_reports_its_reason(monkeypatch, tmp_path) -> None
     from relaytv_app import player
 
     log = tmp_path / "mpv.log"
-    log.write_text("[ 19.85][e][stream] Failed to open http://x/y.\n", encoding="utf-8")
+    log.write_text("", encoding="utf-8")
     monkeypatch.setenv("MPV_LOG_FILE", str(log))
 
     player.note_playback_started(300.0)   # resumed five minutes in
+    # mpv writes its error after the play begins, which is the real ordering.
+    with open(log, "a", encoding="utf-8") as handle:
+        handle.write("[ 19.85][e][stream] Failed to open http://x/y.\n")
     player.note_playback_failure_if_no_progress({"title": "Resumed", "resume_pos": 300.0})
     assert "Failed to open" in (player.last_playback_error() or "")
 
     # Real progress from that same resume point is not a failure.
     player.note_playback_started(300.0)
+    with open(log, "a", encoding="utf-8") as handle:
+        handle.write("[ 25.00][e][stream] Failed to open http://x/y.\n")
     player.note_playback_failure_if_no_progress({"title": "Resumed", "resume_pos": 340.0})
     assert player.last_playback_error() is None
+
+
+def test_a_stale_error_is_not_blamed_on_a_later_item(monkeypatch, tmp_path) -> None:
+    """The log is cumulative; the diagnostic must not be.
+
+    A short clip that ends quietly after an earlier 403 would otherwise inherit
+    that 403, and /status would name the wrong item.
+    """
+    from relaytv_app import player
+
+    log = tmp_path / "mpv.log"
+    monkeypatch.setenv("MPV_LOG_FILE", str(log))
+    log.write_text("[ 19.85][e][stream] Failed to open http://old/item.\n", encoding="utf-8")
+
+    # A new play starts; everything above belongs to the previous item.
+    player.note_playback_started(0.0)
+    player.note_playback_failure_if_no_progress({"title": "Short clip", "resume_pos": 0.5})
+
+    assert player.last_playback_error() is None, "an earlier item's failure was reused"
+
+
+def test_a_rotated_log_does_not_hide_the_current_failure(monkeypatch, tmp_path) -> None:
+    """Rotation restarts the file at zero, so a saved offset would skip past it."""
+    from relaytv_app import player
+
+    log = tmp_path / "mpv.log"
+    monkeypatch.setenv("MPV_LOG_FILE", str(log))
+    log.write_text("x" * 5000, encoding="utf-8")
+
+    player.note_playback_started(0.0)          # offset recorded at 5000
+    log.write_text("[ 1.00][e][stream] Failed to open http://x/y.\n", encoding="utf-8")  # rotated
+
+    player.note_playback_failure_if_no_progress({"title": "After rotate", "resume_pos": 0.0})
+    assert "Failed to open" in (player.last_playback_error() or "")
+
+
+def test_every_mpv_backend_writes_the_diagnostic_log(monkeypatch) -> None:
+    """The mpv and Qt external_mpv backends launch through _build_mpv_args.
+
+    Gating the log on debug there left last_playback_error reading a file those
+    backends never create, despite the feature claiming to explain any failure.
+    """
+    from relaytv_app import player
+
+    monkeypatch.delenv("MPV_LOG_FILE", raising=False)
+    monkeypatch.delenv("RELAYTV_DEBUG", raising=False)
+    monkeypatch.delenv("MPV_DEBUG", raising=False)
+
+    args = player._build_mpv_args("http://example.com/video.mp4", None, "play")
+    joined = " ".join(args)
+    assert "--log-file=" in joined, "no mpv log outside debug: failures would be unexplained"
+
+
+def test_a_failed_item_is_recorded_even_when_the_queue_advances(monkeypatch) -> None:
+    """The common case: a queue is present, so natural_end advances.
+
+    That path never reached the queue-empty handler, and the successor's
+    play_item cleared the error, so playlist users saw nothing at all.
+    """
+    from relaytv_app import playback_service, player, state
+
+    seen: list[object] = []
+    monkeypatch.setattr(player, "note_playback_failure_if_no_progress", lambda now: seen.append(now))
+    monkeypatch.setattr(player, "_set_auto_next_transition", lambda *_a, **_k: None)
+    monkeypatch.setattr(playback_service, "advance_queue", lambda **_k: "advanced")
+    monkeypatch.setattr(state, "NOW_PLAYING", {"title": "Failed item", "resume_pos": 0.0})
+
+    with state.QUEUE_LOCK:
+        state.QUEUE[:] = [{"url": "http://example.com/next"}]
+    try:
+        assert playback_service.natural_end() == "advanced"
+    finally:
+        with state.QUEUE_LOCK:
+            state.QUEUE.clear()
+
+    assert seen and (seen[0] or {}).get("title") == "Failed item"


### PR DESCRIPTION
## User impact

YouTube playback started, then died 10–15s in, on both devices. Fixed: both now
play continuously, and a future failure says why instead of going quiet.

## What was happening

`POST /play_now` returned **200** and the container log looked clean, because
RelayTV's part genuinely succeeded — yt-dlp resolved fine. mpv then got **403**
fetching the stream and the TV went idle.

YouTube now refuses open-ended GETs on those URLs:

| Request | Result |
| --- | --- |
| `Range: bytes=0-1024` | **206** |
| no `Range` | **403** |
| `Range: bytes=0-` | **403** |

ffmpeg only ever issues the latter two, and no ffmpeg option changes it
(`-multiple_requests`, `-seekable`, `-http_persistent` all still 403). A newer
yt-dlp returns URLs without the problem — verified on three videos: **2026.07.04
failed all three, 2026.08.19 played all three.**

So the fix is having a current yt-dlp. Two things prevented that.

### Updates did not survive a deploy

`pip install --user` landed in `$HOME/.local` with `HOME=/tmp`, and **`/tmp` is
tmpfs** — so every container recreate reverted yt-dlp to the image's copy. The
state file lives on `/data` and *did* survive, so it still read "checked
recently" and the interval gate suppressed a re-check for hours. Living Room
logged exactly that: `auto-update skipped (next check in 16470s)`, moments after
reverting to 2026.07.04.

Installs now go to `RELAYTV_YTDLP_UPDATE_DIR` (`/data/ytdlp`) via
`PYTHONUSERBASE`, and the gate forces a check whenever the installed version
disagrees with what the state file records.

### The stable channel had nothing to offer

Every yt-dlp release between `2026.7.4` and `2026.8.19` was a `.dev0`
pre-release, which `pip install --upgrade` skips by design. Six weeks of honest
"nothing newer" while playback was broken. The channel now defaults to
**nightly**, where yt-dlp ships extractor fixes first, falling back to stable if
a nightly install fails. Default interval drops 24h → 6h.

Because a tree on `/data` outlives the image around it, a persisted copy is
discarded when it will not execute (a console-script shebang naming an
interpreter a rebuilt image no longer ships) or when the image itself is newer.

## Failure visibility

mpv runs with `--no-terminal`, so its errors reached nothing — that is why a
200, a clean log, and a dead TV arrived together. mpv now always writes a
size-capped log, and a play that ends without progress logs one INFO line and
sets `last_playback_error` on `/status`. Stream URLs are redacted from it.

It earned its keep during this PR's own rollout: the Pi reported
`ytdl_hook: youtube-dl failed: unexpected error occurred` instead of failing
silently.

## Two bugs found in this PR by live verification

- **The image-version probe could not see the image.** Dropping the persisted
  `bin` from PATH is not enough — `PYTHONUSERBASE` still steers the import, so
  `/usr/local/bin/yt-dlp` loaded the persisted package and reported *its*
  version. The guard was comparing a version against itself and could never
  prune. Confirmed in-container: same probe reports `2026.08.19.233000` with the
  variable set and `2026.07.04` with it cleared.
- **Switching channel did nothing.** Deploying to the Pi changed nothing —
  version matched state, so the gate skipped and kept the broken build with
  `next check in 14884s`. The state was honest; it recorded a *stable-only*
  check. The gate now treats a channel mismatch like a version mismatch.

## Breaking changes

None. New env vars default to today's paths and behaviour beyond the channel
change; `RELAYTV_YTDLP_UPDATE_CHANNEL=stable` pins the old channel.

## Tests run

`ruff check app tests`; `PYTHONPATH=app pytest -q` → **604 passed**;
`git diff --check`.

Twelve new tests. Those covering the persistent install, the revert-aware gate,
the nightly channel, and the stable fallback were each confirmed to fail against
their reverted fix.

### Live, both devices

- Update applied and **survived a container recreate** — the regression that
  motivated the change: `auto-update forced (installed=2026.07.04
  state=2026.08.19)` → `done (after=2026.08.19.233000 updated=1)`, then correctly
  `skipped` on the next recreate with the new version still in place.
- Playback runs continuously past 40s on both devices — the exact check that
  failed at 10–15s.
- Debug knobs I set during diagnosis have been reverted on both.

## Release highlight

No — a bug fix to existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)