### PR TITLE
docs: correct the yt-dlp update defaults left stale by 0.9.1

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -95,15 +95,26 @@ RELAYTV_YTDLP_USE_NODE=0
 RELAYTV_YTDLP_COOKIES=/data/cookies.txt
 
 # Optional runtime yt-dlp maintenance (disabled by default).
-# When enabled, container startup and a daily background worker attempt a
-# user-level pip upgrade and persist last-check metadata to
-# RELAYTV_YTDLP_AUTO_UPDATE_STATE_FILE. This env value seeds the default for
-# the Settings -> YouTube "Keep yt-dlp up to date" toggle, which can change
-# it at runtime without a container restart.
+# When enabled, container startup and a background worker attempt a pip upgrade
+# and persist last-check metadata to RELAYTV_YTDLP_AUTO_UPDATE_STATE_FILE. This
+# env value seeds the default for the Settings -> YouTube "Keep yt-dlp up to
+# date" toggle, which can change it at runtime without a container restart.
 RELAYTV_YTDLP_AUTO_UPDATE=0
-RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS=24
+RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS=6
 RELAYTV_YTDLP_AUTO_UPDATE_TIMEOUT_SEC=180
 RELAYTV_YTDLP_AUTO_UPDATE_STATE_FILE=/data/.relaytv-ytdlp-update.json
+
+# Where an updated yt-dlp is installed. It lives on the data volume so it
+# survives a container recreate; $HOME is tmpfs, so a user-site install there
+# was discarded on every deploy while the state file above persisted, leaving
+# the device on the image's copy until the interval elapsed again.
+RELAYTV_YTDLP_UPDATE_DIR=/data/ytdlp
+
+# nightly | stable. yt-dlp ships extractor fixes to nightly first, and stable
+# can go weeks between releases while a site change breaks playback. A failed
+# nightly install falls back to stable automatically. Set "stable" to track
+# only released versions.
+RELAYTV_YTDLP_UPDATE_CHANNEL=nightly
 
 # ------------------------------------------------------------------------------
 # Device / hardware configuration variables

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -151,6 +151,19 @@ cover the image as built and published. Runtime auto-update changes playback
 resolver behavior after the image is built and is not part of the audited
 release state.
 
+Opting in tracks yt-dlp's **nightly** channel by default
+(`RELAYTV_YTDLP_UPDATE_CHANNEL=nightly`), so the running resolver may be a
+pre-release build rather than a published version. That is deliberate — site
+changes break extractors faster than the stable channel releases, and stable
+went six weeks between releases while YouTube playback was broken — but it puts
+the resolver further from the audited image than a released version would.
+`RELAYTV_YTDLP_UPDATE_CHANNEL=stable` limits updates to released versions.
+
+Updated copies install to `RELAYTV_YTDLP_UPDATE_DIR` (`/data/ytdlp`) on the data
+volume and therefore persist across container recreates, so the resolver in use
+is not reset by redeploying the image. Removing that directory returns the
+device to the version the image shipped.
+
 ## Source Mapping
 
 For immutable releases, prefer this process:


### PR DESCRIPTION
Follow-up to #57, found while reviewing what the 0.9.1 release notes will say.
Timed to land **before** #58 merges so the release describes itself accurately.

## What was stale

**`.env.defaults`** still advertised `RELAYTV_YTDLP_AUTO_UPDATE_INTERVAL_HOURS=24`
after the app and installer defaults both moved to `6`, so it handed operators a
value contradicting both — and it predated `RELAYTV_YTDLP_UPDATE_DIR` and
`RELAYTV_YTDLP_UPDATE_CHANNEL` entirely.

Nothing in the repo reads this file (verified: not `install.sh`, not compose,
not the app, not tests), so this was never a functional bug. But its own header
says *"Copy values from this file into your local `.env` as needed"* — it is the
reference an operator builds from.

**`docs/RELEASE.md`** understated its own runtime-mutation policy. That section
exists to bound what the audited-image claim covers, and as of 0.9.1 two things
it does not mention are true:

- opting in to auto-update tracks yt-dlp's **nightly** channel by default, so
  the running resolver may be a pre-release build rather than a published one
- updates install to the data volume and **persist across container recreates**,
  so redeploying the image no longer resets the resolver

Both are deliberate — stable went six weeks between releases while YouTube
playback was broken — but they put the resolver further from the audited image
than the section currently admits. Added along with how to opt back to stable
and how to return a device to the image's copy.

## Scope

Documentation only; no behaviour change. Official images and `install.sh` both
still default `RELAYTV_YTDLP_AUTO_UPDATE=0`, so the nightly default only reaches
operators who explicitly opted in.

## Tests run

`ruff check app tests`; `PYTHONPATH=app pytest -q` → **617 passed**;
`git diff --check`.

## Release highlight

No — documentation correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)