### PR TITLE
docs: record the control socket and the missing MPV_* knobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,8 @@ Boundaries the roadmap established, to preserve in new work:
 - `config.py` owns env parsing and the settings bus; runtime `os.environ`
   writes stay behind its explicit subprocess-mirroring boundary.
 - `integrations/jellyfin_service.py` owns Jellyfin product behavior;
-  `jellyfin_receiver.py` stays transport/session/catalog and never imports
-  the routes package.
+  `jellyfin_receiver.py` and `jellyfin_ws.py` stay transport and never import
+  the routes package — the control socket reaches playback through the command
+  sink the routes package registers, not by importing it.
 - Route modules own public endpoint registration; do not remove endpoint
   aliases without a migration path for companion apps and Home Assistant.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,6 +55,15 @@ milestone logs live in git history.
 - `app/relaytv_app/integrations/jellyfin_receiver.py`: Jellyfin/Emby
   transport, auth, server-type detection, status, catalog cache, and
   progress/stopped calls.
+- `app/relaytv_app/integrations/jellyfin_ws.py`: the control socket that
+  makes the device a cast target. Transport only, like the receiver: it
+  normalizes inbound `Play`/`Playstate`/`GeneralCommand` messages and hands
+  them to a command sink the routes package registers, so the socket reuses
+  the same ingress as `POST /integrations/jellyfin/command` rather than
+  carrying a second copy of command handling. Each connection generation
+  owns its threads, queue, and stop flag, and configuration changes run as
+  transactions that suspend the socket — a retired generation can never be
+  restarted, publish status, or reach the player.
 - `scripts/`: install, doctor, host operations, and release support.
 
 ## Machine-Checked Guardrails

--- a/docs/ENV_INVENTORY.md
+++ b/docs/ENV_INVENTORY.md
@@ -12,7 +12,7 @@ PYTHONPATH=app python3 tests/test_env_inventory.py --write
 ## Scope
 
 In scope: `RELAYTV_*`, `YTDLP_*`, `USE_INVIDIOUS`, `INVIDIOUS_BASE`,
-`MPV_AUDIO_DEVICE`, and `MPV_EXTRA_ARGS` — the app configuration surface
+and the `MPV_*` player knobs — the app configuration surface
 managed behind `RuntimeConfig`.
 
 Out of scope: platform and toolkit variables (`DISPLAY`, `WAYLAND_DISPLAY`,
@@ -82,8 +82,12 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | Variable | Referenced in | Runtime writers | Classification |
 | --- | --- | --- | --- |
 | `INVIDIOUS_BASE` | `config.py`<br>`main.py`<br>`resolver.py`<br>`routes/settings.py`<br>`state.py` | `main.py`<br>`routes/settings.py` | settings bus |
+| `MPV_ARGS` | `player.py`<br>`qt_shell_app.py` | - | child process input |
 | `MPV_AUDIO_DEVICE` | `config.py`<br>`player.py`<br>`routes/settings.py` | `routes/settings.py` | settings bus |
+| `MPV_DEBUG` | `player.py`<br>`qt_shell_app.py` | - | child process input |
 | `MPV_EXTRA_ARGS` | `player.py` | - | static env |
+| `MPV_IPC_PATH` | `player.py`<br>`qt_shell_app.py`<br>`routes/__init__.py` | - | child process input |
+| `MPV_LOG_FILE` | `player.py`<br>`qt_shell_app.py` | - | child process input |
 | `RELAYTV_ACCESS_LOG` | `debug.py` | - | static env |
 | `RELAYTV_ACCESS_LOG_HOT_PATHS` | `debug.py` | - | static env |
 | `RELAYTV_ACCESS_LOG_LEVEL` | `debug.py` | - | static env |

--- a/tests/test_env_inventory.py
+++ b/tests/test_env_inventory.py
@@ -25,8 +25,15 @@ TABLE_END = "<!-- END GENERATED ENV TABLE -->"
 
 # App-config variables: the settings/env bus Phase 2 is migrating. Platform and
 # toolkit variables (DISPLAY, QT_*, XDG_*, ...) are intentionally out of scope.
+# MPV_* variables are named individually rather than matched as a family: the
+# tree also contains module attributes like MPV_PROC that are read with getattr
+# and would otherwise be reported as configuration. MPV_ARGS, MPV_DEBUG,
+# MPV_IPC_PATH and MPV_LOG_FILE were missing from the original pair even though
+# they are read the same way, which hid operator-facing knobs from the inventory
+# that is supposed to be the app configuration surface.
 _CONFIG_VAR = re.compile(
-    r"""["'](RELAYTV_[A-Z0-9_]+|YTDLP_[A-Z0-9_]+|USE_INVIDIOUS|INVIDIOUS_BASE|MPV_AUDIO_DEVICE|MPV_EXTRA_ARGS)["']"""
+    r"""["'](RELAYTV_[A-Z0-9_]+|YTDLP_[A-Z0-9_]+|USE_INVIDIOUS|INVIDIOUS_BASE"""
+    r"""|MPV_ARGS|MPV_AUDIO_DEVICE|MPV_DEBUG|MPV_EXTRA_ARGS|MPV_IPC_PATH|MPV_LOG_FILE)["']"""
 )
 
 # Runtime writes to the process environment (the in-process config bus).


### PR DESCRIPTION
Second pass over the docs after #57/#59. Two gaps, both in documents whose whole
job is to be complete.

## `jellyfin_ws.py` was never added to the boundary docs

`ARCHITECTURE.md` lists every module and what it owns, and `AGENTS.md` carries
the matching rule — but the control socket was added in #54 without an entry in
either. It is the module whose rules are *least* guessable from its name:

- transport only, like the receiver — it reaches playback through the command
  sink the routes package registers, rather than importing routes
- each connection generation owns its threads, queue, and stop flag, so a
  retired one cannot restart, publish status, or touch the player
- configuration changes run as transactions that suspend it

Most of those rules exist because each was violated at some point during #54–#57
and cost a review round to find. They belong in the document people read before
changing that code.

## `ENV_INVENTORY` was missing four MPV_* variables

The inventory is meant to be *the* app configuration surface, but its scan named
only `MPV_AUDIO_DEVICE` and `MPV_EXTRA_ARGS` while the app reads six.
`MPV_ARGS`, `MPV_DEBUG`, `MPV_IPC_PATH` and `MPV_LOG_FILE` were invisible to it —
which matters more now that mpv always writes a log and `MPV_LOG_FILE` relocates
it.

Worth noting how this was nearly shipped wrong: matching the family as
`MPV_[A-Z0-9_]+` is tidier and I did it first, but it reported `MPV_PROC` — a
module attribute read through `getattr` — as configuration. The variables are
named individually instead, which is what the scan already did; it was just
incomplete. The comment now says why.

## Also reviewed, no change made

`README.md`'s "A living-room endpoint—not another casting dependency" heading now
sits alongside RelayTV *being* a Jellyfin cast target. The body still reads
correctly — it argues RelayTV owns playback locally rather than depending on a
casting service — so I left it. Flagging it as a judgement call on positioning
rather than rewriting it unilaterally.

`API.md` does not enumerate `/status` fields for any endpoint, so the new
`last_playback_error` is not an omission by that document's convention. It is
documented where an operator would look for it, in `INSTALL.md`'s troubleshooting
section.

## Scope

Documentation and the inventory scan only; no behaviour change.

## Tests run

`ruff check app tests`; `PYTHONPATH=app pytest -q` → **617 passed**;
`git diff --check`. `ENV_INVENTORY.md` regenerated with
`tests/test_env_inventory.py --write` per `AGENTS.md`.

## Release highlight

No — documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)