### PR TITLE
fix: report control and snapshot failures honestly

### DIFF
--- a/app/relaytv_app/routes/snapshots.py
+++ b/app/relaytv_app/routes/snapshots.py
@@ -1,4 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-only
+"""Frame capture endpoints.
+
+Capture used to report success the moment the mpv command was dispatched:
+the result was discarded and the response named an ``image_url`` before any
+file existed. Clients got ``ok: true`` followed by a 404, or a URL that stayed
+empty forever when mpv had rejected the command outright. Both endpoints now
+wait, briefly and with a bound, for a frame that is actually on disk.
+"""
 import os
 import time
 
@@ -9,6 +17,53 @@ from .. import player
 
 
 router = APIRouter()
+
+# How long to wait for mpv to land the frame. Writing a screenshot is fast on
+# the NUC and slower on the Pi's SD card, so this is an operator knob rather
+# than a constant; the point is that it is bounded, not that it is generous.
+_DEFAULT_SNAPSHOT_TIMEOUT_SEC = 2.0
+_SNAPSHOT_POLL_SEC = 0.05
+
+
+def _snapshot_timeout_sec() -> float:
+    # A startup knob, not a settings-bus variable: read from the environment
+    # directly, the same way RELAYTV_SNAPSHOT_DIR is read below.
+    raw = os.getenv("RELAYTV_SNAPSHOT_TIMEOUT_SEC", "")
+    try:
+        value = float(str(raw).strip())
+    except (TypeError, ValueError):
+        return _DEFAULT_SNAPSHOT_TIMEOUT_SEC
+    if value <= 0:
+        return _DEFAULT_SNAPSHOT_TIMEOUT_SEC
+    return min(value, 30.0)
+
+
+def _mpv_command_succeeded(result: object) -> bool:
+    """Interpret ``player.mpv_command``'s heterogeneous result.
+
+    The IPC path returns mpv's own reply dict, the Qt runtime path returns a
+    bool, and a dropped command returns ``None``. Only an explicit success
+    counts; everything else is a failure we must not report as a capture.
+    """
+    if isinstance(result, bool):
+        return result
+    if isinstance(result, dict):
+        return str(result.get("error") or "").strip().lower() == "success"
+    return False
+
+
+def _wait_for_frame(path: str, timeout_sec: float) -> bool:
+    """Return True once ``path`` holds a non-empty file, else False on timeout."""
+    deadline = time.monotonic() + timeout_sec
+    while True:
+        try:
+            if os.path.getsize(path) > 0:
+                return True
+        except OSError:
+            pass
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_SNAPSHOT_POLL_SEC)
 
 
 @router.get("/snapshots/{filename}")
@@ -31,5 +86,19 @@ def snapshot():
     os.makedirs(snap_dir, exist_ok=True)
     name = f"snapshot-{int(time.time() * 1000)}.jpg"
     path = os.path.join(snap_dir, name)
-    player.mpv_command(["screenshot-to-file", path, "video"])
+
+    result = player.mpv_command(["screenshot-to-file", path, "video"])
+    if not _mpv_command_succeeded(result):
+        raise HTTPException(status_code=502, detail="Player rejected the snapshot command")
+
+    if not _wait_for_frame(path, _snapshot_timeout_sec()):
+        # Nothing usable landed. Clear the stub so /snapshots does not serve a
+        # zero-byte image, and tell the caller rather than handing them a URL
+        # that will 404.
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        raise HTTPException(status_code=504, detail="Snapshot did not complete in time")
+
     return {"ok": True, "image_url": f"/snapshots/{name}"}

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -1211,6 +1211,14 @@
       background: linear-gradient(180deg, rgba(60,42,18,.94), rgba(38,26,10,.96));
       box-shadow: 0 0 18px rgba(255,180,80,.20), 0 10px 24px rgba(0,0,0,.45);
     }
+    /* A rejected command, not a lost connection: different cause, different
+       colour, and no dimming of the controls that are still working. */
+    .connBadge.cmdErr{
+      color: #ffd7d1;
+      border-color: rgba(255,140,120,.5);
+      background: linear-gradient(180deg, rgba(72,26,22,.94), rgba(46,14,12,.96));
+      box-shadow: 0 0 18px rgba(255,110,90,.22), 0 10px 24px rgba(0,0,0,.45);
+    }
     body.connLost .remoteCard,
     body.connLost .queueCard{
       filter: saturate(.55) brightness(.78);

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -66,6 +66,23 @@ function _fetchWithTimeout(url, opts, timeoutMs){
   return fetch(url, finalOpts).finally(() => clearTimeout(timer));
 }
 
+// Turn a rejected response into one short line worth showing the user.
+async function _commandErrorDetail(response){
+  const status = Number(response && response.status) || 0;
+  if (status === 401 || status === 403) return 'Not authorized — check API token';
+  let detail = '';
+  try {
+    const payload = await response.json();
+    if (payload && typeof payload === 'object'){
+      detail = String(payload.detail || payload.message || '').trim();
+    }
+  } catch(_e) {}
+  // Collapse to a single short line: it goes in a one-line badge, and the
+  // server's detail is free text we do not control the length of.
+  detail = detail.replace(/\s+/g, ' ').trim().slice(0, 120);
+  return detail || `Command failed (HTTP ${status || '?'})`;
+}
+
 async function post(path, body, postOpts) {
   const opts = {
     method: 'POST',
@@ -74,25 +91,44 @@ async function post(path, body, postOpts) {
   };
   // Generous timeout: Android wifi power-save adds seconds of first-packet
   // latency right when the user picks the phone up.
-  let ok = false;
+  let response = null;
+  let unreachable = false;
   try {
-    await _fetchWithTimeout(path, opts, 5000);
-    ok = true;
+    response = await _fetchWithTimeout(path, opts, 5000);
   } catch(_e) {
     // A network error doesn't prove the request never reached the server (the
     // connection can drop after the command lands), and most commands are
     // toggles or relative seeks where a resend would double-apply. Only
     // retry commands the caller marked idempotent (absolute sets); everything
     // else surfaces the failure so the user can retap.
+    unreachable = true;
     if (postOpts && postOpts.idempotent) {
       try {
-        await _fetchWithTimeout(path, opts, 5000);
-        ok = true;
+        response = await _fetchWithTimeout(path, opts, 5000);
+        unreachable = false;
       } catch(_e2) {}
     }
   }
-  if (!ok) _connSignal(false, {sticky: true, message: 'Command failed — check connection'});
+
+  if (unreachable || !response){
+    _connSignal(false, {sticky: true, message: 'Command failed — check connection'});
+    refresh().catch(() => null);
+    return {ok: false, status: 0, detail: 'unreachable', reached: false};
+  }
+
+  // The request arrived and the server answered. A resend would double-apply,
+  // so a rejection is never retried here regardless of `idempotent` — it is
+  // reported instead.
+  if (!response.ok){
+    const detail = await _commandErrorDetail(response);
+    _commandRejected(detail);
+    refresh().catch(() => null);
+    return {ok: false, status: response.status, detail, reached: true};
+  }
+
+  _connSignal(true);
   refresh().catch(() => null);
+  return {ok: true, status: response.status, detail: '', reached: true};
 }
 
 // --- Manual URL modal + clipboard helpers
@@ -204,10 +240,14 @@ async function submitAddUrl(mode){
 
   addUrlSubmitting = true;
   try {
-    if (mode === 'queue') {
-      await post('/enqueue', {url});
-    } else {
-      await post('/play_now', {url, preserve_current:true, preserve_to:'queue_front', resume_current:true, reason:'add_menu'});
+    const result = (mode === 'queue')
+      ? await post('/enqueue', {url})
+      : await post('/play_now', {url, preserve_current:true, preserve_to:'queue_front', resume_current:true, reason:'add_menu'});
+    // Keep the modal open when the server refused, so the link is still there
+    // to retry or correct. Closing it used to look exactly like success.
+    if (result && result.ok === false){
+      _setAddHelper(result.detail || 'Could not add that link.', 'err');
+      return;
     }
     closeAddUrl();
   } finally {
@@ -432,6 +472,7 @@ function _connSignal(ok, opts){
     __connFailStreak = 0;
     if (badge && Date.now() >= __connBadgeStickyUntil){
       badge.classList.add('hidden');
+      badge.classList.remove('cmdErr');
       document.body.classList.remove('connLost');
     }
     return;
@@ -442,10 +483,26 @@ function _connSignal(ok, opts){
   if (__connFailStreak >= 2 || o.sticky){
     if (badge){
       badge.textContent = o.message || 'Reconnecting…';
+      badge.classList.remove('cmdErr');
       badge.classList.remove('hidden');
     }
     document.body.classList.add('connLost');
   }
+}
+
+// A command the server actively rejected is not a connection problem: the
+// request arrived, was understood, and was refused. Reporting it as
+// "Reconnecting…" sends the user to check their wifi over a 409 or an expired
+// token, and dimming the remote implies the whole app is offline. Rejections
+// get their own badge and leave the connLost state alone.
+function _commandRejected(message){
+  __connFailStreak = 0;
+  __connBadgeStickyUntil = Date.now() + 3500;
+  const badge = document.getElementById('connBadge');
+  if (!badge) return;
+  badge.textContent = String(message || 'Command rejected');
+  badge.classList.add('cmdErr');
+  badge.classList.remove('hidden');
 }
 
 function _scheduleUiEventReconnect(){

--- a/docs/ENV_INVENTORY.md
+++ b/docs/ENV_INVENTORY.md
@@ -307,6 +307,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_SHELL_V2_NATIVE_PLAYING_GRACE_SEC` | `player.py` | - | static env |
 | `RELAYTV_SLOW_REQUEST_MS` | `debug.py` | - | static env |
 | `RELAYTV_SNAPSHOT_DIR` | `routes/snapshots.py` | - | static env |
+| `RELAYTV_SNAPSHOT_TIMEOUT_SEC` | `routes/snapshots.py` | - | static env |
 | `RELAYTV_SPLASH` | `player.py` | - | static env |
 | `RELAYTV_SPLASH_ARGS` | `player.py` | - | static env |
 | `RELAYTV_SPLASH_IMAGE` | `player.py` | - | static env |

--- a/tests/js/command_failures.test.js
+++ b/tests/js/command_failures.test.js
@@ -1,0 +1,175 @@
+'use strict';
+
+// post() used to set ok = true whenever the fetch settled, so a 401, 409, or
+// 500 was indistinguishable from success: the UI applied its optimistic state
+// and the next poll quietly reverted it. These tests pin the three outcomes
+// apart — success, server rejection, and unreachable server — because the
+// difference is what the user acts on.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const APP_JS = fs.readFileSync(
+  path.join(__dirname, '../../app/relaytv_app/static/ui/app.js'),
+  'utf8',
+);
+
+function extractFunction(name){
+  for(const prefix of [`async function ${name}(`, `function ${name}(`]){
+    const start = APP_JS.indexOf(prefix);
+    if(start === -1) continue;
+    let depth = 0;
+    let seenBody = false;
+    for(let i = start; i < APP_JS.length; i++){
+      const ch = APP_JS[i];
+      if(ch === '{'){ depth++; seenBody = true; }
+      else if(ch === '}'){
+        depth--;
+        if(seenBody && depth === 0) return APP_JS.slice(start, i + 1);
+      }
+    }
+  }
+  throw new Error(`${name} not found in app.js`);
+}
+
+function fixture(responder){
+  const calls = {fetches: [], rejected: [], conn: [], refreshes: 0};
+  const badge = {
+    textContent: '',
+    _classes: new Set(['hidden']),
+    classList: {
+      add: (...n) => n.forEach(x => badge._classes.add(x)),
+      remove: (...n) => n.forEach(x => badge._classes.delete(x)),
+      contains: x => badge._classes.has(x),
+    },
+  };
+  const bodyClasses = new Set();
+  const context = vm.createContext({
+    console,
+    Date,
+    Number,
+    String,
+    document: {
+      getElementById: id => (id === 'connBadge' ? badge : null),
+      body: {classList: {
+        add: x => bodyClasses.add(x),
+        remove: x => bodyClasses.delete(x),
+        contains: x => bodyClasses.has(x),
+      }},
+    },
+    __connFailStreak: 0,
+    __connBadgeStickyUntil: 0,
+    _fetchWithTimeout: async(url, opts) => {
+      calls.fetches.push({url, method: opts.method});
+      return responder(calls.fetches.length);
+    },
+    refresh: async() => { calls.refreshes++; },
+    _setAddHelper(){},
+  });
+  for(const fn of ['_connSignal', '_commandRejected', '_commandErrorDetail', 'post']){
+    vm.runInContext(extractFunction(fn), context, {filename:'app.js'});
+  }
+  return {
+    context,
+    calls,
+    badge,
+    bodyClasses,
+    post: (p, body, opts) =>
+      vm.runInContext(`post(${JSON.stringify(p)}, ${JSON.stringify(body || null)}, ${JSON.stringify(opts || null)})`, context),
+  };
+}
+
+function jsonResponse(status, payload){
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async() => payload,
+  };
+}
+
+test('a successful command reports ok and clears the badge', async() => {
+  const state = fixture(() => jsonResponse(200, {ok: true}));
+  const result = await state.post('/pause');
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 200);
+  assert.equal(state.badge.classList.contains('hidden'), true);
+  assert.equal(state.calls.refreshes, 1);
+});
+
+test('401 surfaces an authorization message, not a connection error', async() => {
+  const state = fixture(() => jsonResponse(401, {detail: 'api token required'}));
+  const result = await state.post('/pause');
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 401);
+  assert.equal(result.reached, true);
+  assert.match(state.badge.textContent, /API token/i);
+  // A rejection must not claim the connection is down.
+  assert.equal(state.bodyClasses.has('connLost'), false);
+  assert.equal(state.badge.classList.contains('cmdErr'), true);
+});
+
+test('409 shows the server detail verbatim', async() => {
+  const state = fixture(() => jsonResponse(409, {detail: 'No active playback for snapshot'}));
+  const result = await state.post('/snapshot');
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 409);
+  assert.equal(state.badge.textContent, 'No active playback for snapshot');
+  assert.equal(state.bodyClasses.has('connLost'), false);
+});
+
+test('500 without a parseable body still names the failure', async() => {
+  const state = fixture(() => ({
+    ok: false,
+    status: 500,
+    json: async() => { throw new Error('not json'); },
+  }));
+  const result = await state.post('/next');
+
+  assert.equal(result.ok, false);
+  assert.equal(state.badge.textContent, 'Command failed (HTTP 500)');
+});
+
+test('a rejected command is never retried, even when marked idempotent', async() => {
+  // The server answered. Resending would apply the command twice.
+  const state = fixture(() => jsonResponse(409, {detail: 'nope'}));
+  const result = await state.post('/volume', {set: 50}, {idempotent: true});
+
+  assert.equal(result.ok, false);
+  assert.equal(state.calls.fetches.length, 1);
+});
+
+test('an unreachable server is reported as a connection failure', async() => {
+  const state = fixture(() => { throw new Error('network down'); });
+  const result = await state.post('/pause');
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reached, false);
+  assert.equal(state.bodyClasses.has('connLost'), true);
+  assert.match(state.badge.textContent, /check connection/i);
+});
+
+test('an idempotent command retries once on a network error and can succeed', async() => {
+  const state = fixture(attempt => {
+    if(attempt === 1) throw new Error('first packet lost');
+    return jsonResponse(200, {ok: true});
+  });
+  const result = await state.post('/volume', {set: 50}, {idempotent: true});
+
+  assert.equal(result.ok, true);
+  assert.equal(state.calls.fetches.length, 2);
+  assert.equal(state.bodyClasses.has('connLost'), false);
+});
+
+test('a non-idempotent command is not retried on a network error', async() => {
+  const state = fixture(() => { throw new Error('network down'); });
+  const result = await state.post('/next');
+
+  assert.equal(result.ok, false);
+  assert.equal(state.calls.fetches.length, 1);
+});

--- a/tests/test_snapshot_routes.py
+++ b/tests/test_snapshot_routes.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Snapshot capture must not report a frame it does not have.
+
+Capture used to discard mpv's result and return ``ok: true`` with an
+``image_url`` before any file existed, so a client could be handed a URL that
+404s immediately or stays empty forever.
+"""
+import os
+import threading
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from relaytv_app import player
+from relaytv_app.main import create_app
+from relaytv_app.routes import snapshots
+
+
+@pytest.fixture
+def snap_dir(tmp_path, monkeypatch):
+    path = tmp_path / "snapshots"
+    monkeypatch.setenv("RELAYTV_SNAPSHOT_DIR", str(path))
+    monkeypatch.setattr(player, "is_playing", lambda: True)
+    return path
+
+
+@pytest.fixture
+def client():
+    return TestClient(create_app(testing=True))
+
+
+def _written_files(snap_dir) -> list[str]:
+    if not snap_dir.exists():
+        return []
+    return sorted(p.name for p in snap_dir.iterdir())
+
+
+# --- the command itself ------------------------------------------------------
+
+
+def test_mpv_command_success_predicate() -> None:
+    assert snapshots._mpv_command_succeeded({"error": "success"}) is True
+    assert snapshots._mpv_command_succeeded({"error": "property not found"}) is False
+    assert snapshots._mpv_command_succeeded(True) is True
+    assert snapshots._mpv_command_succeeded(False) is False
+    # A dropped command returns None; that is not a capture.
+    assert snapshots._mpv_command_succeeded(None) is False
+    assert snapshots._mpv_command_succeeded("success") is False
+
+
+def test_rejected_command_is_not_reported_as_success(snap_dir, client, monkeypatch) -> None:
+    monkeypatch.setattr(player, "mpv_command", lambda cmd: {"error": "property not found"})
+
+    response = client.post("/snapshot")
+
+    assert response.status_code == 502
+    assert "rejected" in response.json()["detail"].lower()
+
+
+def test_dropped_command_is_not_reported_as_success(snap_dir, client, monkeypatch) -> None:
+    monkeypatch.setattr(player, "mpv_command", lambda cmd: None)
+
+    assert client.post("/snapshot").status_code == 502
+
+
+# --- waiting for the frame ---------------------------------------------------
+
+
+def test_success_requires_a_frame_on_disk(snap_dir, client, monkeypatch) -> None:
+    def _write(cmd):
+        target = cmd[1]
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "wb") as handle:
+            handle.write(b"\xff\xd8jpegbytes")
+        return {"error": "success"}
+
+    monkeypatch.setattr(player, "mpv_command", _write)
+
+    response = client.post("/snapshot")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    served = client.get(payload["image_url"])
+    assert served.status_code == 200
+    assert served.content == b"\xff\xd8jpegbytes"
+
+
+def test_delayed_frame_still_succeeds(snap_dir, client, monkeypatch) -> None:
+    """mpv can land the file just after the command returns."""
+
+    def _write_late(cmd):
+        target = cmd[1]
+
+        def _later():
+            time.sleep(0.15)
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            with open(target, "wb") as handle:
+                handle.write(b"late-but-real")
+
+        threading.Thread(target=_later, daemon=True).start()
+        return {"error": "success"}
+
+    monkeypatch.setattr(player, "mpv_command", _write_late)
+
+    response = client.post("/snapshot")
+
+    assert response.status_code == 200
+    assert client.get(response.json()["image_url"]).content == b"late-but-real"
+
+
+def test_frame_that_never_arrives_times_out(snap_dir, client, monkeypatch) -> None:
+    monkeypatch.setenv("RELAYTV_SNAPSHOT_TIMEOUT_SEC", "0.2")
+    monkeypatch.setattr(player, "mpv_command", lambda cmd: {"error": "success"})
+
+    started = time.monotonic()
+    response = client.post("/snapshot")
+    elapsed = time.monotonic() - started
+
+    assert response.status_code == 504
+    # Bounded: it must not hang the request thread waiting forever.
+    assert elapsed < 5.0
+    assert _written_files(snap_dir) == []
+
+
+def test_empty_frame_is_treated_as_missing(snap_dir, client, monkeypatch) -> None:
+    """A zero-byte file is what a failed write leaves behind."""
+    monkeypatch.setenv("RELAYTV_SNAPSHOT_TIMEOUT_SEC", "0.2")
+
+    def _touch_empty(cmd):
+        target = cmd[1]
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        open(target, "wb").close()
+        return {"error": "success"}
+
+    monkeypatch.setattr(player, "mpv_command", _touch_empty)
+
+    assert client.post("/snapshot").status_code == 504
+    # The stub is removed so /snapshots never serves an empty image.
+    assert _written_files(snap_dir) == []
+
+
+# --- unchanged behavior ------------------------------------------------------
+
+
+def test_idle_playback_still_conflicts(snap_dir, client, monkeypatch) -> None:
+    monkeypatch.setattr(player, "is_playing", lambda: False)
+    assert client.post("/snapshot").status_code == 409
+
+
+def test_get_alias_behaves_the_same(snap_dir, client, monkeypatch) -> None:
+    monkeypatch.setattr(player, "mpv_command", lambda cmd: {"error": "property not found"})
+    assert client.get("/snapshot").status_code == 502
+
+
+def test_timeout_setting_falls_back_on_garbage(monkeypatch) -> None:
+    for raw in ("", "abc", "0", "-1", None):
+        monkeypatch.setenv("RELAYTV_SNAPSHOT_TIMEOUT_SEC", "" if raw is None else str(raw))
+        assert snapshots._snapshot_timeout_sec() == snapshots._DEFAULT_SNAPSHOT_TIMEOUT_SEC
+
+    monkeypatch.setenv("RELAYTV_SNAPSHOT_TIMEOUT_SEC", "900")
+    # Clamped: an operator typo must not turn into a hung request thread.
+    assert snapshots._snapshot_timeout_sec() == 30.0


### PR DESCRIPTION
Roadmap PR 2 of 11 — closes **F07** and **F11**. See #67 for the audit; #68 is PR 1.

Two places told the user something had worked when it had not.

## `post()` never read `response.ok`

It set `ok = true` whenever the fetch *settled*. A 401 from a cleared token, a 409 from a command the player refused, a 500 — all three looked exactly like success. The UI applied its optimistic state and the next poll quietly reverted it.

It now inspects the status, parses the server's `detail`, and returns `{ok, status, detail, reached}`.

**The distinction that matters is rejection vs. unreachability.** A rejected command *arrived* and was refused, so resending would double-apply it — it is never retried, including when the caller marked it `idempotent` (which previously only governed network errors, and still does). And it isn't a connection problem, so it no longer says "Reconnecting…" or dims the remote via `connLost` — that sends the user to check their wifi over a stale token. Rejections get their own badge.

`submitAddUrl` closed the modal either way, which was the same lie one level up. It now stays open on rejection with the reason attached, so the link is still there to retry or correct.

## Snapshot returned a URL for a file that didn't exist

Capture discarded mpv's result and returned `ok: true` with an `image_url` before anything was written. A rejected command produced a URL that would never resolve; a slow write produced one that 404'd until it did.

Capture now requires an explicit success from mpv, then waits — bounded — for a non-empty file. The result type is heterogeneous (IPC returns a reply dict, the Qt runtime a bool, a dropped command `None`), so the predicate counts only an explicit success. A frame that never lands is a **504** with the stub removed, not a 200 pointing at nothing.

`RELAYTV_SNAPSHOT_TIMEOUT_SEC` (default 2s, clamped to 30) exists because the Pi's SD card is slower than the NUC's disk. The point is that the wait is bounded, not that it's generous. `ENV_INVENTORY.md` regenerated with `--write`.

## Testing

Revert proofs, both confirmed against the reverted guard:

| Reverted | Result |
|---|---|
| `post()` back to unconditional `ok = true` | **4 JS tests fail** |
| snapshot back to fire-and-forget | **6 endpoint tests fail** |

The second is worth noting: `test_delayed_frame_still_succeeds` fails with *exactly* the audited symptom — a 200 followed by a 404 on the URL it just handed out.

Coverage added:

- **JS (8)** — 200, 401, 409, 500-with-unparseable-body, network error, idempotent retry succeeding on the second attempt, non-idempotent not retried, and a rejected command not retried despite `idempotent`.
- **Endpoint (10)** — the success predicate across all four result shapes, rejected command, dropped command, frame written synchronously, frame written 150ms late by a real thread, frame that never arrives (asserting the request stays bounded), zero-byte frame treated as missing, idle 409, the GET alias, and env-var fallback/clamping.

Gates: **753 Python tests** (+10), **19 JS tests** (+8), ruff clean, `git diff --check` clean, `node --check` clean.

## Device verification

On the combined branch, both devices:

| Check | LR | Pi |
|---|---|---|
| `POST /snapshot` with nothing playing → 409 with `detail` | pass | pass |

**Still outstanding**: the browser-side half. Confirming Play/Pause, Next, seek, and volume each surface a visible rejection needs a token configured and a browser with a cleared token — neither device currently runs with `RELAYTV_API_TOKEN` set.
