### PR TITLE
fix: canonicalize URL host parsing

### DIFF
--- a/app/relaytv_app/public_media.py
+++ b/app/relaytv_app/public_media.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, urlencode, urlunsplit
+
+from . import url_boundary
 
 
 _PRIVATE_ITEM_KEYS = {
@@ -56,26 +58,33 @@ def sanitize_public_url(value: object) -> str:
     raw = str(value or "").strip()
     if not raw:
         return ""
-    try:
-        parsed = urlsplit(raw)
-    except Exception:
+    # Shares its parser with input validation, so a value this cannot represent
+    # can no longer be accepted in the first place. Values already on disk from
+    # before that guard still reach here, and must not raise: a single poisoned
+    # item used to break /queue, /status, /history, and realtime for everyone,
+    # on every request, until someone hand-edited the JSON.
+    parsed = url_boundary.parse_url(raw)
+    if parsed is None:
         return ""
-    if not parsed.scheme or not parsed.netloc:
+    # Preserved from the urlsplit version: a value with no scheme or no
+    # authority is a relative reference or a non-network URL (file:, data:),
+    # and is passed through untouched.
+    if not parsed.scheme or not parsed.raw_netloc:
         return raw
-
-    hostname = parsed.hostname or ""
-    if not hostname:
+    # An authority that parsed but yielded no hostname is malformed. Omit it
+    # rather than echoing it back: the raw form can still carry credentials,
+    # which is the one thing this function exists to remove.
+    if not parsed.hostname:
         return ""
-    netloc = f"[{hostname}]" if ":" in hostname else hostname
-    if parsed.port is not None:
-        netloc = f"{netloc}:{parsed.port}"
 
     query = [
         (key, val)
         for key, val in parse_qsl(parsed.query, keep_blank_values=True)
         if not _is_sensitive_query_key(key)
     ]
-    return urlunsplit((parsed.scheme, netloc, parsed.path, urlencode(query, doseq=True), ""))
+    return urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urlencode(query, doseq=True), "")
+    )
 
 
 def public_media_item(item: object) -> object:

--- a/app/relaytv_app/resolver.py
+++ b/app/relaytv_app/resolver.py
@@ -19,6 +19,7 @@ from fastapi import HTTPException
 from .debug import debug_log, get_logger
 from .thumb_cache import attach_local_thumbnail
 from . import upload_store
+from . import url_boundary
 from . import ytdlp_format_policy
 
 
@@ -218,42 +219,59 @@ def validate_user_url(raw: str) -> str:
     u = normalize_shared_url(extract_first_url(raw or ""))
     if not u:
         raise HTTPException(status_code=400, detail="Missing url")
-    try:
-        p = urlparse(u)
-    except Exception:
+    # One parser for ingestion and serialization. Validating with urlparse and
+    # serializing with urlsplit().port meant a malformed port passed here and
+    # raised later, poisoning every payload that carried the item.
+    parsed = url_boundary.parse_url(u)
+    if parsed is None:
         raise HTTPException(status_code=400, detail="Invalid url")
-    if (p.scheme or "").lower() not in ("http", "https"):
+    if parsed.scheme not in ("http", "https"):
         raise HTTPException(status_code=400, detail="Unsupported URL scheme (http/https only)")
-    if not (p.netloc or "").strip():
+    if not parsed.hostname:
         raise HTTPException(status_code=400, detail="Invalid url host")
     return u
 
+# Provider domains, matched at a dot boundary. Order is significant: the first
+# entry that matches wins, mirroring the if/elif chain this replaced.
+#
+# The YouTube tuple is wider than youtube.com on purpose. The substring test it
+# replaces ("youtu" in host) also matched youtube-nocookie.com and
+# youtubekids.com, and dropping them would be a silent behavior change; only
+# the lookalikes it matched by accident are gone.
+_PROVIDER_DOMAINS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("youtube", ("youtube.com", "youtu.be", "youtube-nocookie.com", "youtubekids.com")),
+    ("rumble", ("rumble.com",)),
+    ("twitch", ("twitch.tv",)),
+    ("tiktok", ("tiktok.com",)),
+    ("bitchute", ("bitchute.com",)),
+    ("odysee", ("odysee.com", "lbry.tv")),
+    ("vimeo", ("vimeo.com",)),
+)
+
+_YOUTUBE_DOMAINS = ("youtube.com", "youtu.be", "youtube-nocookie.com")
+
+
+def url_hostname(u: object) -> str:
+    """Return the lowercased hostname, or "" when the URL is malformed."""
+    parsed = url_boundary.parse_url(u)
+    return parsed.hostname if parsed is not None else ""
+
+
 def is_youtube_url(u: str) -> bool:
-    try:
-        p = urlparse(u)
-        host = (p.netloc or "").lower()
-        return (
-            host.endswith("youtube.com")
-            or host.endswith("www.youtube.com")
-            or host.endswith("m.youtube.com")
-            or host.endswith("youtu.be")
-            or "youtube.com" in host
-        )
-    except Exception:
-        return False
+    return url_boundary.host_matches_any(url_hostname(u), _YOUTUBE_DOMAINS)
 
 
 def youtube_id_from_url(u: str) -> str | None:
     """Extract a YouTube video id from common URL shapes."""
     try:
         p = urlparse(u)
-        host = (p.netloc or "").lower()
+        host = url_hostname(u)
 
-        if host.endswith("youtu.be"):
+        if url_boundary.host_matches(host, "youtu.be"):
             vid = p.path.strip("/").split("/")[0]
             return vid or None
 
-        if "youtube.com" in host:
+        if url_boundary.host_matches_any(host, ("youtube.com", "youtube-nocookie.com")):
             q = parse_qs(p.query)
             if "v" in q and q["v"]:
                 return q["v"][0]
@@ -275,27 +293,20 @@ def youtube_id_from_url(u: str) -> str | None:
 
 
 def provider_from_url(u: str) -> str:
-    """Very small provider classifier (used only for UI niceness)."""
+    """Classify a URL's provider.
+
+    Described as "UI niceness" when it was a substring match, but the result
+    also selects resolver strategy and transport fallbacks, so a lookalike
+    domain could steer a URL into the wrong provider's handling.
+    """
     if upload_store.is_upload_url(u):
         return "upload"
-    try:
-        host = (urlparse(u).netloc or "").lower()
-    except Exception:
-        host = ""
-    if "youtu" in host:
-        return "youtube"
-    if host.endswith("rumble.com") or "rumble.com" in host:
-        return "rumble"
-    if host.endswith("twitch.tv") or "twitch.tv" in host:
-        return "twitch"
-    if host.endswith("tiktok.com") or "tiktok.com" in host:
-        return "tiktok"
-    if host.endswith("bitchute.com") or "bitchute.com" in host:
-        return "bitchute"
-    if host.endswith("odysee.com") or "odysee.com" in host or host.endswith("lbry.tv") or "lbry.tv" in host:
-        return "odysee"
-    if host.endswith("vimeo.com") or "vimeo.com" in host:
-        return "vimeo"
+    host = url_hostname(u)
+    if not host:
+        return "other"
+    for provider, domains in _PROVIDER_DOMAINS:
+        if url_boundary.host_matches_any(host, domains):
+            return provider
     return "other"
 
 

--- a/app/relaytv_app/url_boundary.py
+++ b/app/relaytv_app/url_boundary.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""One parser for the hostname/port boundary.
+
+Three places asked the same question about a URL and answered it three ways:
+input validation (``resolver.validate_user_url``), public serialization
+(``public_media.sanitize_public_url``), and provider classification
+(``resolver.provider_from_url``). Two defects lived in the gap.
+
+The first is that ``urlsplit`` does not validate a port. It accepts
+``http://host:99999/a`` and ``http://host:abc/a`` happily; it is the ``.port``
+accessor that raises ``ValueError``. Validation never touched ``.port``, so
+those URLs were accepted at ingestion and blew up later in serialization —
+turning one poisoned queue item into a permanent failure of ``/queue``,
+``/status``, ``/history``, and every realtime snapshot, which survived a
+restart because the value was on disk.
+
+The second is that provider classification matched hosts by substring, so
+``evil-youtu.com`` classified as YouTube and ``rumble.com.evil.net`` as Rumble.
+``str.endswith`` alone is not enough either: ``"evilrumble.com".endswith(
+"rumble.com")`` is True. Matching needs an explicit dot boundary.
+
+Parsing here never raises. Callers decide what a malformed URL means: input
+validation rejects it, serialization omits it, classification calls it
+``other``.
+"""
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+
+@dataclass(frozen=True)
+class ParsedUrl:
+    """The parts of a URL the app actually makes decisions on."""
+
+    scheme: str
+    hostname: str
+    port: int | None
+    # The netloc exactly as it appeared. Distinguishes "no authority at all"
+    # (a relative reference, or file:///path) from "an authority that has no
+    # usable hostname" (http://:80/a) — different inputs that callers treat
+    # differently, and which a rebuilt netloc collapses together.
+    raw_netloc: str
+    path: str
+    query: str
+    fragment: str
+    username: str
+    password: str
+
+    @property
+    def netloc(self) -> str:
+        """Rebuild the netloc from validated parts, dropping credentials.
+
+        IPv6 literals are re-bracketed; ``hostname`` strips the brackets that
+        make the address parseable.
+        """
+        if not self.hostname:
+            return ""
+        host = f"[{self.hostname}]" if ":" in self.hostname else self.hostname
+        if self.port is not None:
+            return f"{host}:{self.port}"
+        return host
+
+
+def parse_url(value: object) -> ParsedUrl | None:
+    """Parse a URL into canonical parts, or ``None`` when it is malformed.
+
+    ``None`` means the value cannot be reasoned about: an unparseable netloc,
+    or a port that is not an integer in 0-65535. It does *not* mean the URL is
+    relative — a relative reference parses fine with an empty scheme and host,
+    which is how upload paths like ``/media/uploads/...`` stay usable.
+    """
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parts = urlsplit(raw)
+    except Exception:
+        return None
+    try:
+        # The accessor that validates. Both of these raise ValueError:
+        # a non-numeric port, and one outside 0-65535.
+        port = parts.port
+        hostname = parts.hostname or ""
+        username = parts.username or ""
+        password = parts.password or ""
+    except ValueError:
+        return None
+    return ParsedUrl(
+        scheme=(parts.scheme or "").lower(),
+        hostname=hostname.lower().rstrip("."),
+        port=port,
+        raw_netloc=parts.netloc or "",
+        path=parts.path or "",
+        query=parts.query or "",
+        fragment=parts.fragment or "",
+        username=username,
+        password=password,
+    )
+
+
+def host_matches(host: str, domain: str) -> bool:
+    """Return True when ``host`` is ``domain`` or a subdomain of it.
+
+    The dot boundary is the whole point: a bare ``endswith`` matches
+    ``evilrumble.com`` against ``rumble.com``, and a substring test matches
+    ``rumble.com.evil.net``.
+    """
+    left = str(host or "").strip().lower().rstrip(".")
+    right = str(domain or "").strip().lower().rstrip(".")
+    if not left or not right:
+        return False
+    return left == right or left.endswith("." + right)
+
+
+def host_matches_any(host: str, domains: tuple[str, ...]) -> bool:
+    """Return True when ``host`` matches any of ``domains`` at a dot boundary."""
+    return any(host_matches(host, domain) for domain in domains)

--- a/tests/test_url_boundary.py
+++ b/tests/test_url_boundary.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""One parser for the hostname/port boundary (F03, F14).
+
+Input validation and public serialization used different parsers, and provider
+classification used substrings. Two defects lived in the gap: a malformed port
+was accepted at ingestion and raised at serialization, and lookalike domains
+classified as real providers.
+"""
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from relaytv_app import public_media, state, url_boundary
+from relaytv_app.main import create_app
+from relaytv_app.resolver import (
+    is_youtube_url,
+    provider_from_url,
+    validate_user_url,
+    youtube_id_from_url,
+)
+
+
+# --- the parser --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://host:99999/a",   # port out of range
+        "http://host:abc/a",     # port not an integer
+        "http://host:-1/a",
+        "http://[::1/a",         # unterminated IPv6 literal
+    ],
+)
+def test_malformed_urls_do_not_parse(url: str) -> None:
+    assert url_boundary.parse_url(url) is None
+
+
+def test_parser_never_raises_on_hostile_input() -> None:
+    for value in ("", None, 0, [], "http://" + "a" * 5000, "::::", "http://:::80/a"):
+        url_boundary.parse_url(value)  # must not raise
+
+
+def test_relative_and_ipv6_urls_parse() -> None:
+    relative = url_boundary.parse_url("/media/uploads/u_1/a.mp4")
+    assert relative is not None
+    assert relative.scheme == "" and relative.hostname == ""
+
+    ipv6 = url_boundary.parse_url("http://[::1]:8080/a")
+    assert ipv6 is not None
+    assert ipv6.hostname == "::1"
+    assert ipv6.port == 8080
+    # Re-bracketed when rebuilt, or the URL stops being parseable.
+    assert ipv6.netloc == "[::1]:8080"
+
+
+@pytest.mark.parametrize(
+    "host,domain,expected",
+    [
+        ("youtube.com", "youtube.com", True),
+        ("www.youtube.com", "youtube.com", True),
+        ("m.youtube.com", "youtube.com", True),
+        ("YouTube.COM", "youtube.com", True),
+        ("youtube.com.", "youtube.com", True),
+        # The two shapes the old matcher got wrong.
+        ("youtube.com.phish.co", "youtube.com", False),
+        ("evil-youtube.com", "youtube.com", False),
+        # endswith alone is not enough: this has no dot boundary.
+        ("evilrumble.com", "rumble.com", False),
+        ("", "youtube.com", False),
+        ("youtube.com", "", False),
+    ],
+)
+def test_host_matches_requires_a_dot_boundary(host, domain, expected) -> None:
+    assert url_boundary.host_matches(host, domain) is expected
+
+
+# --- F03: ingestion rejects what serialization cannot represent ---------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["http://host:99999/a", "http://host:abc/a", "http://[::1/a", "http://:80/a", "http://user@:9/a"],
+)
+def test_malformed_urls_are_rejected_at_ingestion(url: str) -> None:
+    with pytest.raises(HTTPException) as excinfo:
+        validate_user_url(url)
+    assert excinfo.value.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://youtu.be/dQw4w9WgXcQ",
+        "https://host.test:8443/a",
+        "http://[::1]:8080/a",
+        "http://192.168.1.5:8787/x",
+    ],
+)
+def test_valid_urls_still_pass_ingestion(url: str) -> None:
+    assert validate_user_url(url) == url
+
+
+def test_serialization_never_raises_on_a_poisoned_value() -> None:
+    """The migration case: bad values are already on disk from before the guard."""
+    for url in ("http://host:99999/a", "http://host:abc/a", "http://[::1/a"):
+        assert public_media.sanitize_public_url(url) == ""
+
+
+def test_serialization_behavior_is_otherwise_unchanged() -> None:
+    # Credentials and signing parameters still stripped.
+    assert (
+        public_media.sanitize_public_url("https://u:p@host.test/a?token=T&x=1")
+        == "https://host.test/a?x=1"
+    )
+    # Ports, IPv6, and non-network URLs preserved exactly as before.
+    assert public_media.sanitize_public_url("https://host.test:8443/a") == "https://host.test:8443/a"
+    assert public_media.sanitize_public_url("http://[::1]:8080/a") == "http://[::1]:8080/a"
+    assert public_media.sanitize_public_url("/media/uploads/u_1/a.mp4") == "/media/uploads/u_1/a.mp4"
+    assert public_media.sanitize_public_url("//cdn.test/p.jpg") == "//cdn.test/p.jpg"
+    assert public_media.sanitize_public_url("file:///data/x.mp4") == "file:///data/x.mp4"
+    # An authority with no hostname is omitted, not echoed: the raw form can
+    # still carry the credentials this function exists to remove.
+    assert public_media.sanitize_public_url("http://user@:9/a") == ""
+
+
+def test_poisoned_queue_item_does_not_break_public_payloads(monkeypatch) -> None:
+    """One bad item used to fail /queue, /status, /history for every client."""
+    poisoned = {"url": "http://host:99999/a", "title": "poisoned", "provider": "other"}
+    healthy = {"url": "https://youtu.be/abc123", "title": "fine", "provider": "youtube"}
+
+    monkeypatch.setattr(state, "QUEUE", [poisoned, healthy], raising=False)
+    monkeypatch.setattr(state, "NOW_PLAYING", dict(poisoned), raising=False)
+    monkeypatch.setattr(state, "HISTORY", [dict(poisoned)], raising=False)
+
+    client = TestClient(create_app(testing=True))
+    for path in ("/queue", "/status", "/history"):
+        response = client.get(path)
+        assert response.status_code == 200, f"{path} failed on a poisoned item"
+        # The healthy item is still served alongside it.
+        assert "host:99999" not in response.text
+
+
+# --- F14: provider classification --------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://evil-youtu.com/x",
+        "https://youtube.com.phish.co/v",
+        "https://rumble.com.evil.net/x",
+        "https://evilrumble.com/x",
+        "https://nottwitch.tv.attacker.io/x",
+        "https://tiktok.com.evil.test/x",
+        "https://vimeo.com.evil.test/x",
+        "https://lbry.tv.evil.test/x",
+    ],
+)
+def test_lookalike_domains_are_not_real_providers(url: str) -> None:
+    assert provider_from_url(url) == "other"
+    assert is_youtube_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url,provider",
+    [
+        ("https://www.youtube.com/watch?v=a", "youtube"),
+        ("https://youtu.be/a", "youtube"),
+        ("https://m.youtube.com/watch?v=a", "youtube"),
+        ("https://music.youtube.com/watch?v=a", "youtube"),
+        # Matched by the substring test this replaces; kept deliberately.
+        ("https://www.youtube-nocookie.com/embed/a", "youtube"),
+        ("https://www.youtubekids.com/watch?v=a", "youtube"),
+        ("https://rumble.com/v1.html", "rumble"),
+        ("https://www.twitch.tv/x", "twitch"),
+        ("https://vm.tiktok.com/x", "tiktok"),
+        ("https://www.bitchute.com/video/x", "bitchute"),
+        ("https://odysee.com/@a/b", "odysee"),
+        ("https://lbry.tv/@a/b", "odysee"),
+        ("https://vimeo.com/123", "vimeo"),
+        ("https://player.vimeo.com/video/123", "vimeo"),
+        ("https://example.com/a.mp4", "other"),
+        ("http://host:99999/a", "other"),
+    ],
+)
+def test_real_provider_classification_is_unchanged(url: str, provider: str) -> None:
+    assert provider_from_url(url) == provider
+
+
+@pytest.mark.parametrize(
+    "url,video_id",
+    [
+        ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://m.youtube.com/shorts/abc123", "abc123"),
+        ("https://www.youtube.com/embed/abc123", "abc123"),
+        ("https://www.youtube.com/live/abc123", "abc123"),
+        # A lookalike must not yield an id an attacker chose.
+        ("https://youtube.com.phish.co/watch?v=evil", None),
+        ("https://evil-youtu.be/watch?v=evil", None),
+    ],
+)
+def test_youtube_id_extraction_respects_the_boundary(url: str, video_id) -> None:
+    assert youtube_id_from_url(url) == video_id


### PR DESCRIPTION
Roadmap PR 3 of 11 — closes **F03** and **F14**. See #67 for the audit.

Input validation, public serialization, and provider classification each asked the same question about a URL and answered it differently. Two defects lived in the gap.

## `urlsplit` does not validate a port

It accepts `http://host:99999/a` and `http://host:abc/a` happily — it's the `.port` *accessor* that raises `ValueError`. Validation never touched `.port`:

```python
>>> validate_user_url("http://host:99999/a")     # accepted
'http://host:99999/a'
>>> sanitize_public_url("http://host:99999/a")   # raises
ValueError: Port out of range 0-65535
```

So one poisoned queue item permanently broke `/queue`, `/status`, `/history`, and every realtime snapshot — for every client, on every request — and survived a restart, because the value was on disk.

## Substring provider matching

`evil-youtu.com` classified as YouTube; `rumble.com.evil.net` as Rumble. `endswith` alone wouldn't have fixed it either — `"evilrumble.com".endswith("rumble.com")` is `True`. Matching needs an explicit dot boundary.

This isn't only cosmetic despite the old docstring saying "UI niceness": the result selects resolver strategy and transport fallbacks, so a lookalike could steer a URL into the wrong provider's handling.

## The fix

`url_boundary.py` parses once for all three callers and never raises. Each decides what malformed means: **ingestion rejects**, **serialization omits**, **classification returns `other`**.

### One correction I had to make mid-change

Rebuilding the netloc from validated parts collapses two cases that must stay distinct:

- *No authority at all* — a relative reference, `file:///data/x.mp4` — must pass through **untouched**.
- *An authority with no usable hostname* — `http://user@:9/a` — must **not**, because echoing the raw value leaks the credentials this function exists to remove.

My first version returned the raw string for both. `ParsedUrl` now carries the original netloc so serialization is byte-for-byte unchanged from the `urlsplit` version, except the two inputs that used to raise.

### Deliberately wider than it looks

The YouTube tuple includes `youtube-nocookie.com` and `youtubekids.com`. The substring test (`"youtu" in host`) matched those too, and dropping them would be a silent behavior change. Only the lookalikes it matched *by accident* are gone.

## Scope note

The CDN-hostname heuristics in `player.py` (`tiktokcdn`, `byteoversea`, `muscdn`) still use substrings. They run on already-resolved stream URLs rather than user input, and are substring matches by design. Consolidating those is the separate `ARCHITECTURE.md` follow-up, not this PR.

## Testing

Three revert proofs, all confirmed to fail against the reverted guard:

| Reverted | Result |
|---|---|
| serialization → raw `urlsplit` | **2 fail**, with the actual `ValueError: Port out of range` |
| provider matching → substrings | **8 fail** |
| validation → netloc-only | **5 fail** |

The migration case is covered directly: `test_poisoned_queue_item_does_not_break_public_payloads` plants a malformed URL in the queue, now-playing, and history — as if written by an older build — and asserts `/queue`, `/status`, and `/history` all still return 200. It fails against the reverted code with the real exception, so it isn't self-consistent.

Gates: **802 Python tests** (+59), 11 JS tests, ruff clean, `git diff --check` clean.

## Device verification

On the combined branch, both devices:

| Check | LR | Pi |
|---|---|---|
| `POST /enqueue` with `http://host:99999/a` → 400 `{"detail":"Invalid url"}` | pass | pass |
| `/status`, `/queue`, `/history` serialize without raising | 200 | 200 |
| YouTube resolve + playback (title, thumbnail, position advancing) | pass | pass |

**Still outstanding, and this is the PR that most needs it**: only YouTube was exercised. Rumble, Twitch, Odysee, an IPTV channel, and an upload each still need one play. Classification is pinned by tests for all of them, but resolution is what actually matters and only the devices show that.
