### PR TITLE
fix: contain upload identifiers

### DIFF
--- a/app/relaytv_app/upload_store.py
+++ b/app/relaytv_app/upload_store.py
@@ -79,8 +79,50 @@ def uploads_root() -> str:
     return _UPLOADS_ROOT
 
 
+# Upload ids are generated, never supplied: new_upload_id() has produced
+# "u_" + 20 hex characters since the first commit, so this is the whole format
+# that has ever existed on disk and enforcing it orphans nothing.
+_UPLOAD_ID_RE = re.compile(r"^u_[0-9a-f]{20}$")
+
+
+def is_valid_upload_id(upload_id: object) -> bool:
+    """Return True when ``upload_id`` has the generated shape."""
+    return bool(_UPLOAD_ID_RE.match(str(upload_id or "").strip()))
+
+
+def _is_contained(path: str, root: str) -> bool:
+    """Return True when ``path`` resolves inside ``root``."""
+    try:
+        return os.path.commonpath([os.path.abspath(root), os.path.abspath(path)]) == os.path.abspath(root)
+    except (ValueError, OSError):
+        # Different drives, or a path that cannot be resolved at all.
+        return False
+
+
 def upload_dir(upload_id: str) -> str:
-    return os.path.join(uploads_root(), str(upload_id or "").strip())
+    """Return the directory holding an upload, or "" when the id is not one.
+
+    This is the containment boundary for the whole store: metadata, session,
+    media, and deletion paths are all derived from it. An id reaches here from
+    a URL, where upload_ref_from_url used to decode %2F *after* splitting the
+    path, so "..%2F..%2Fdata" arrived as a single component that unquoted into
+    "../../data" and escaped the root. Only the filename was ever basename'd.
+
+    "" rather than a raised exception, because every caller already treats a
+    missing upload as expired (410) and a raise would turn a hostile URL into
+    a 500. Derived paths must propagate the "" instead of joining onto it:
+    os.path.join("", "meta.json") is a *relative* path, which would read from
+    the working directory.
+    """
+    ident = str(upload_id or "").strip()
+    if not is_valid_upload_id(ident):
+        return ""
+    path = os.path.join(uploads_root(), ident)
+    # Belt and braces. The format check already makes traversal impossible;
+    # this keeps that true if the format is ever widened.
+    if not _is_contained(path, uploads_root()):
+        return ""
+    return path
 
 
 def upload_public_path(upload_id: str, filename: str) -> str:
@@ -107,7 +149,11 @@ def upload_ref_from_url(url: object) -> tuple[str, str] | None:
     if len(parts) != 2:
         return None
     upload_id, filename = parts
-    if not upload_id or not filename:
+    if not filename:
+        return None
+    # unquote runs after the split, so an encoded separator survives inside a
+    # single component: "..%2F..%2Fdata" decodes to "../../data" here.
+    if not is_valid_upload_id(upload_id):
         return None
     return upload_id, os.path.basename(filename)
 
@@ -162,11 +208,13 @@ def new_upload_id() -> str:
 
 
 def metadata_path(upload_id: str) -> str:
-    return os.path.join(upload_dir(upload_id), "meta.json")
+    base = upload_dir(upload_id)
+    return os.path.join(base, "meta.json") if base else ""
 
 
 def session_path(upload_id: str) -> str:
-    return os.path.join(upload_dir(upload_id), "session.json")
+    base = upload_dir(upload_id)
+    return os.path.join(base, "session.json") if base else ""
 
 
 def load_metadata(upload_id: str) -> dict | None:
@@ -416,7 +464,10 @@ def stored_file_path(meta: dict) -> str | None:
     stored_name = os.path.basename(str(meta.get("stored_name") or "").strip())
     if not upload_id or not stored_name:
         return None
-    return os.path.join(upload_dir(upload_id), stored_name)
+    base = upload_dir(upload_id)
+    if not base:
+        return None
+    return os.path.join(base, stored_name)
 
 
 def media_exists(upload_id: str) -> bool:
@@ -524,6 +575,12 @@ def list_upload_metadata() -> list[dict]:
 
 def delete_upload(upload_id: str) -> None:
     path = upload_dir(upload_id)
+    if not path:
+        # Never hand an unvalidated id to rmtree. Reached today only with
+        # server-generated ids and ids read back from meta.json, but the
+        # operation is recursive deletion and the guard costs nothing.
+        logger.warning("upload_delete_rejected id=%r", str(upload_id)[:64])
+        return
     try:
         shutil.rmtree(path)
     except FileNotFoundError:

--- a/tests/test_upload_containment.py
+++ b/tests/test_upload_containment.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Upload ids must stay inside the upload root (F13).
+
+upload_ref_from_url decoded percent-escapes *after* splitting the URL path, so
+an encoded separator survived inside a single component: "..%2F..%2Fdata"
+arrived as one part and unquoted into "../../data". Only the filename was ever
+basename'd, so the id went straight into os.path.join with the upload root.
+"""
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from relaytv_app import upload_store
+from relaytv_app.main import create_app
+
+
+@pytest.fixture
+def uploads_root(tmp_path, monkeypatch):
+    root = tmp_path / "uploads"
+    root.mkdir()
+    monkeypatch.setattr(upload_store, "_UPLOADS_ROOT", str(root))
+    return root
+
+
+# --- the id format -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "upload_id",
+    [
+        "../../data",
+        "../../etc",
+        "..",
+        "/etc",
+        "u_short",
+        "u_" + "a" * 19,          # one too few
+        "u_" + "a" * 21,          # one too many
+        "u_" + "g" * 20,          # not hex
+        "U_" + "a" * 20,          # wrong case
+        "u_" + "a" * 20 + "/x",   # separator smuggled in
+        "",
+        None,
+    ],
+)
+def test_invalid_ids_are_rejected(upload_id) -> None:
+    assert upload_store.is_valid_upload_id(upload_id) is False
+    assert upload_store.upload_dir(upload_id) == ""
+
+
+def test_generated_ids_are_valid() -> None:
+    for _ in range(25):
+        assert upload_store.is_valid_upload_id(upload_store.new_upload_id()) is True
+
+
+# --- derived paths must propagate the rejection ------------------------------
+
+
+@pytest.mark.parametrize("upload_id", ["../../data", "u_short", ""])
+def test_derived_paths_are_empty_not_relative(upload_id, uploads_root) -> None:
+    """os.path.join("", "meta.json") is a *relative* path.
+
+    Returning "" from upload_dir without handling it downstream would read
+    ./meta.json out of the working directory instead of the upload store.
+    """
+    assert upload_store.metadata_path(upload_id) == ""
+    assert upload_store.session_path(upload_id) == ""
+    assert upload_store.stored_file_path({"id": upload_id, "stored_name": "a.mp4"}) is None
+
+
+def test_valid_id_still_resolves_every_path(uploads_root) -> None:
+    upload_id = upload_store.new_upload_id()
+    expected = os.path.join(str(uploads_root), upload_id)
+
+    assert upload_store.upload_dir(upload_id) == expected
+    assert upload_store.metadata_path(upload_id) == os.path.join(expected, "meta.json")
+    assert upload_store.session_path(upload_id) == os.path.join(expected, "session.json")
+    assert upload_store.stored_file_path(
+        {"id": upload_id, "stored_name": "clip.mp4"}
+    ) == os.path.join(expected, "clip.mp4")
+
+
+# --- the URL boundary --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://tv.local/media/uploads/..%2F..%2Fdata/x.mp4",
+        "http://tv.local/media/uploads/../../etc/passwd.mp4",
+        "http://tv.local/media/uploads/..%2f..%2fdata/x.mp4",
+        "http://tv.local/media/uploads/%2e%2e%2F%2e%2e/x.mp4",
+        "http://tv.local/media/uploads/u_short/x.mp4",
+    ],
+)
+def test_encoded_traversal_does_not_survive_url_parsing(url: str) -> None:
+    assert upload_store.upload_ref_from_url(url) is None
+
+
+def test_valid_upload_url_still_resolves() -> None:
+    upload_id = upload_store.new_upload_id()
+    ref = upload_store.upload_ref_from_url(f"http://tv.local/media/uploads/{upload_id}/clip.mp4")
+    assert ref == (upload_id, "clip.mp4")
+
+
+# --- the escape, against a real filesystem -----------------------------------
+
+
+def test_traversal_cannot_read_a_file_outside_the_root(uploads_root, tmp_path) -> None:
+    """The audited escape, with a matching file actually in place.
+
+    /data is the parent of /data/uploads on a device, so "../../data" reached a
+    real directory holding settings.json, history.json, and peers.json.
+    """
+    outside = tmp_path / "secret"
+    outside.mkdir()
+    (outside / "meta.json").write_text('{"id": "secret", "stored_name": "loot.bin"}')
+
+    escape = f"..{os.sep}..{os.sep}{outside.name}"
+    assert upload_store.load_metadata(escape) is None
+    assert upload_store.metadata_path(escape) == ""
+
+
+def test_delete_upload_never_rmtrees_an_unvalidated_path(uploads_root, tmp_path) -> None:
+    """delete_upload is recursive deletion; it must not act on a bad id."""
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "settings.json").write_text("{}")
+
+    upload_store.delete_upload(f"..{os.sep}..{os.sep}{victim.name}")
+
+    assert victim.exists()
+    assert (victim / "settings.json").exists()
+
+
+def test_delete_upload_still_removes_a_real_upload(uploads_root) -> None:
+    upload_id = upload_store.new_upload_id()
+    target = uploads_root / upload_id
+    target.mkdir()
+    (target / "clip.mp4").write_bytes(b"data")
+
+    upload_store.delete_upload(upload_id)
+
+    assert not target.exists()
+
+
+# --- the route ---------------------------------------------------------------
+
+
+def test_media_route_rejects_a_traversal_id(uploads_root, tmp_path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "meta.json").write_text('{"id":"x","stored_name":"a.mp4","public_name":"a.mp4"}')
+
+    client = TestClient(create_app(testing=True))
+    response = client.get("/media/uploads/..%2F..%2Foutside/a.mp4")
+
+    assert response.status_code in (404, 410, 400)
+
+
+def test_media_route_still_serves_a_real_upload(uploads_root) -> None:
+    upload_id = upload_store.new_upload_id()
+    target = uploads_root / upload_id
+    target.mkdir()
+    (target / "clip.mp4").write_bytes(b"movie-bytes")
+    upload_store.write_metadata(
+        upload_id,
+        {
+            "id": upload_id,
+            "filename": "clip.mp4",
+            "public_name": "clip.mp4",
+            "stored_name": "clip.mp4",
+            "mime_type": "video/mp4",
+        },
+    )
+
+    client = TestClient(create_app(testing=True))
+    response = client.get(f"/media/uploads/{upload_id}/clip.mp4")
+
+    assert response.status_code == 200
+    assert response.content == b"movie-bytes"


### PR DESCRIPTION
Roadmap PR 4 of 11 — closes **F13**. See #67 for the audit.

## The escape

`upload_ref_from_url` decoded percent-escapes *after* splitting the URL path, so an encoded separator survived inside a single component:

```python
>>> upload_ref_from_url("http://tv/media/uploads/..%2F..%2Fdata/x.mp4")
('../../data', 'x.mp4')
>>> metadata_path("../../data")
'/data/uploads/../../data/meta.json'
```

Only the *filename* was ever `basename`'d. On a device `/data` is the parent of `/data/uploads`, so that path reaches the directory holding `settings.json`, `history.json`, and `peers.json`.

## The fix

`upload_dir` becomes the containment boundary for the whole store — metadata, session, media, and deletion paths all derive from it — and enforces the generated id format.

`new_upload_id` has produced `u_` + 20 hex characters **since the first commit** (`23e742d`), so that's the entire format that has ever existed on disk. Enforcing it orphans nothing. A `commonpath` check backs it up so widening the format later can't quietly reopen this.

### The part that needed care

It returns `""` rather than raising — every caller already treats a missing upload as expired (410), and a raise would turn a hostile URL into a 500.

But that required handling at each *derived* path, not just the boundary: **`os.path.join("", "meta.json")` is a relative path.** Propagating the `""` naively would have read `./meta.json` out of the working directory — trading one wrong file for another. There's a test pinning exactly that.

`delete_upload` also refuses an unvalidated id. It's reached today only with server-generated ids and ids read back from `meta.json`, so this is defence in depth rather than a live path — but the operation is `shutil.rmtree` and the guard costs nothing.

## Testing

**Revert proof:** removing the validation fails **20 tests**, including the real-filesystem escape and the rmtree guard.

28 tests added:

- Id format across 12 near-misses (one char short, one long, wrong case, non-hex, separator smuggled in, `None`), and 25 generated ids round-tripping.
- Derived paths returning `""` rather than a relative path.
- Five encoded-traversal URL shapes including `%2f` lowercase and `%2e%2e`.
- `test_traversal_cannot_read_a_file_outside_the_root` — the audited escape against a **real filesystem**, with a matching `meta.json` actually placed outside the root, since the finding only bites when a file is there.
- `delete_upload` leaving a victim directory intact, and still removing a genuine upload.
- Route-level: traversal rejected, real upload still served with its bytes.

Gates: **771 Python tests** (+28), 11 JS tests, ruff clean, `git diff --check` clean.

## Device verification

On the combined branch:

| Check | LR | Pi |
|---|---|---|
| `GET /media/uploads/..%2F..%2Fdata/x.mp4` → 404, no filesystem access outside the root | pass | pass |
| `is_valid_upload_id('../../etc')` is `False` in the running process | pass | pass |

**Still outstanding**: upload a file and play it, and confirm an existing pre-upgrade upload still plays from history. The id format is unchanged since the first commit so this should be a no-op, but it is worth confirming against real `meta.json` files rather than trusting the git archaeology.
