### PR TITLE
fix: own background service generations

### DIFF
--- a/app/relaytv_app/discovery_mdns.py
+++ b/app/relaytv_app/discovery_mdns.py
@@ -26,6 +26,11 @@ _ZEROCONF = None
 _SERVICE_INFO = None
 _LAST_ERROR: str | None = None
 _START_THREAD: threading.Thread | None = None
+# Registration talks to the network, so it cannot hold _LOCK throughout without
+# making stop() wait on it. Instead each attempt claims a generation, does its
+# network work unlocked, and re-checks ownership before publishing. stop()
+# claims a generation too, which is what retires an attempt already in flight.
+_GENERATION = 0
 
 # Browsing state. The browser callbacks must not block the zeroconf event
 # thread, so they only enqueue names and a resolver thread does the lookups.
@@ -34,9 +39,32 @@ _BROWSE_ZEROCONF = None
 _BROWSE_BROWSER = None
 _BROWSE_LAST_ERROR: str | None = None
 _BROWSE_THREAD: threading.Thread | None = None
-_BROWSE_STOP = threading.Event()
 _BROWSE_QUEUE: queue.Queue | None = None
 _DISCOVERED: dict[str, dict[str, object]] = {}
+# The browse worker's stop flag used to be a module global. start_browse
+# cleared it, so restarting while the previous worker was still shutting down
+# un-stopped that worker and left two resolvers running against whichever
+# Zeroconf happened to be current. Each session now owns its own.
+_BROWSE_SESSION: "_BrowseSession | None" = None
+_BROWSE_GENERATION = 0
+
+
+class _BrowseSession:
+    """One browse generation: its own stop flag, queue, and Zeroconf.
+
+    Owning these per generation is what keeps a retired worker from consuming
+    its replacement's queue or writing its replacement's globals.
+    """
+
+    __slots__ = ("generation", "stop", "queue", "zeroconf", "browser", "thread")
+
+    def __init__(self, generation: int) -> None:
+        self.generation = generation
+        self.stop = threading.Event()
+        self.queue: queue.Queue = queue.Queue(maxsize=256)
+        self.zeroconf = None
+        self.browser = None
+        self.thread: threading.Thread | None = None
 
 
 def _enabled() -> bool:
@@ -136,42 +164,90 @@ def status() -> dict[str, object]:
     return advertise
 
 
+def _claim_generation() -> int:
+    """Take ownership of the advertisement slot. Caller must hold _LOCK."""
+    global _GENERATION
+    _GENERATION += 1
+    return _GENERATION
+
+
+def _owns(generation: int) -> bool:
+    """Caller must hold _LOCK."""
+    return generation == _GENERATION
+
+
+def _close_zeroconf(zc) -> None:
+    if zc is None:
+        return
+    try:
+        zc.close()
+    except Exception:
+        pass
+
+
+def _teardown(zc, info) -> None:
+    """Unregister and close, tolerating a partially built pair."""
+    try:
+        if zc is not None and info is not None:
+            zc.unregister_service(info)
+    except Exception:
+        pass
+    _close_zeroconf(zc)
+
+
 def start() -> dict[str, object]:
     global _ZEROCONF, _SERVICE_INFO, _LAST_ERROR
     with _LOCK:
         if not _enabled():
-            pass
-        elif _SERVICE_INFO is not None and _ZEROCONF is not None:
-            pass
-        elif Zeroconf is None or ServiceInfo is None:
+            return status()
+        if _SERVICE_INFO is not None and _ZEROCONF is not None:
+            return status()
+        if Zeroconf is None or ServiceInfo is None:
             _LAST_ERROR = "zeroconf dependency unavailable"
-        else:
-            try:
-                stype = _service_type()
-                name = _instance_name()
-                ip = _detect_ipv4()
-                info = ServiceInfo(
-                    type_=stype,
-                    name=f"{name}.{stype}",
-                    addresses=[socket.inet_aton(ip)],
-                    port=_service_port(),
-                    properties=_props(),
-                    server=(os.getenv("RELAYTV_MDNS_SERVER") or f"{socket.gethostname()}.local.").strip(),
-                )
-                zc = Zeroconf()
-                zc.register_service(info)
-                _ZEROCONF = zc
-                _SERVICE_INFO = info
-                _LAST_ERROR = None
-            except Exception as e:
+            return status()
+        generation = _claim_generation()
+
+    zc = None
+    info = None
+    try:
+        stype = _service_type()
+        name = _instance_name()
+        ip = _detect_ipv4()
+        info = ServiceInfo(
+            type_=stype,
+            name=f"{name}.{stype}",
+            addresses=[socket.inet_aton(ip)],
+            port=_service_port(),
+            properties=_props(),
+            server=(os.getenv("RELAYTV_MDNS_SERVER") or f"{socket.gethostname()}.local.").strip(),
+        )
+        zc = Zeroconf()
+        zc.register_service(info)
+    except Exception as e:
+        # Close the Zeroconf *we* built. The previous version closed the global
+        # _ZEROCONF, which is still None here because it is only assigned after
+        # register_service succeeds — so a failed registration leaked an open
+        # Zeroconf, with its sockets and threads, on every retry.
+        _teardown(zc, info)
+        with _LOCK:
+            if _owns(generation):
                 _LAST_ERROR = str(e)
-                try:
-                    if _ZEROCONF is not None:
-                        _ZEROCONF.close()
-                except Exception:
-                    pass
                 _ZEROCONF = None
                 _SERVICE_INFO = None
+        return status()
+
+    with _LOCK:
+        published = _owns(generation)
+        if published:
+            _ZEROCONF = zc
+            _SERVICE_INFO = info
+            _LAST_ERROR = None
+    if not published:
+        # stop() ran while we were registering. Publishing now would advertise
+        # a service the app believes it retired, and nothing would ever
+        # unregister it.
+        logger.info("mdns_registration_retired generation=%d", generation)
+        _teardown(zc, info)
     return status()
 
 
@@ -191,20 +267,14 @@ def stop() -> dict[str, object]:
     global _ZEROCONF, _SERVICE_INFO
     stop_browse()
     with _LOCK:
+        # Retires any registration still in flight: it will find it no longer
+        # owns the slot and tear down what it built instead of publishing.
+        _claim_generation()
         zc = _ZEROCONF
         info = _SERVICE_INFO
         _ZEROCONF = None
         _SERVICE_INFO = None
-    try:
-        if zc is not None and info is not None:
-            zc.unregister_service(info)
-    except Exception:
-        pass
-    try:
-        if zc is not None:
-            zc.close()
-    except Exception:
-        pass
+    _teardown(zc, info)
     return status()
 
 
@@ -338,45 +408,69 @@ def _resolve_service(zc, service_type: str, name: str, *, timeout_ms: int) -> bo
     return True
 
 
-def _refresh_known_services(zc, service_type: str) -> None:
+def _refresh_known_services(zc, service_type: str, stop: threading.Event | None = None) -> None:
     with _BROWSE_LOCK:
         names = list(_DISCOVERED.keys())
     for name in names:
-        if _BROWSE_STOP.is_set():
+        if stop is not None and stop.is_set():
             return
         _resolve_service(zc, service_type, name, timeout_ms=1500)
 
 
-def _resolve_worker() -> None:
-    """Resolve queued service names off the zeroconf callback thread."""
+def _resolve_worker(session: "_BrowseSession") -> None:
+    """Resolve queued service names off the zeroconf callback thread.
+
+    Reads only its own session, so a retired generation cannot pick work off
+    its replacement's queue or resolve against its replacement's Zeroconf.
+    """
     service_type = _service_type()
     next_sweep = time.time() + float(_browse_refresh_sec())
-    while not _BROWSE_STOP.is_set():
+    while not session.stop.is_set():
         try:
-            item = _BROWSE_QUEUE.get(timeout=0.5) if _BROWSE_QUEUE is not None else None
+            item = session.queue.get(timeout=0.5)
         except Exception:
             item = None
-        with _BROWSE_LOCK:
-            zc = _BROWSE_ZEROCONF
+        zc = session.zeroconf
         if zc is None:
             continue
+        if session.stop.is_set():
+            return
         if item is not None:
             queued_type, name = item
             _resolve_service(zc, queued_type or service_type, name, timeout_ms=2000)
         if time.time() >= next_sweep:
-            _refresh_known_services(zc, service_type)
+            _refresh_known_services(zc, service_type, stop=session.stop)
             next_sweep = time.time() + float(_browse_refresh_sec())
 
 
 def _on_service_state_change(zeroconf, service_type, name, state_change) -> None:
+    """Module-level handler, kept for the current session's queue."""
+    _handle_service_state_change(_BROWSE_SESSION, service_type, name, state_change)
+
+
+def _handle_service_state_change(session, service_type, name, state_change) -> None:
     if ServiceStateChange is not None and state_change == ServiceStateChange.Removed:
         _forget_service(name)
         return
-    if _BROWSE_QUEUE is not None:
-        try:
-            _BROWSE_QUEUE.put_nowait((service_type, name))
-        except Exception:
-            pass
+    if session is None or session.stop.is_set():
+        return
+    try:
+        session.queue.put_nowait((service_type, name))
+    except Exception:
+        pass
+
+
+def _session_handler(session: "_BrowseSession"):
+    """Bind the callback to one generation.
+
+    ServiceBrowser holds this for the life of the browser, so binding it to the
+    session keeps a retired browser's callbacks out of the live queue.
+    """
+
+    def _handler(zeroconf, service_type, name, state_change) -> None:
+        _handle_service_state_change(session, service_type, name, state_change)
+
+    return _handler
 
 
 def browse_status() -> dict[str, object]:
@@ -394,7 +488,8 @@ def browse_status() -> dict[str, object]:
 
 def start_browse() -> dict[str, object]:
     """Begin browsing for other RelayTV devices on the local network."""
-    global _BROWSE_ZEROCONF, _BROWSE_BROWSER, _BROWSE_LAST_ERROR, _BROWSE_THREAD, _BROWSE_QUEUE
+    global _BROWSE_ZEROCONF, _BROWSE_BROWSER, _BROWSE_LAST_ERROR, _BROWSE_THREAD
+    global _BROWSE_QUEUE, _BROWSE_SESSION, _BROWSE_GENERATION
     with _BROWSE_LOCK:
         if not _browse_enabled():
             return browse_status()
@@ -403,26 +498,37 @@ def start_browse() -> dict[str, object]:
         if Zeroconf is None or ServiceBrowser is None:
             _BROWSE_LAST_ERROR = "zeroconf dependency unavailable"
             return browse_status()
+
+        _BROWSE_GENERATION += 1
+        session = _BrowseSession(_BROWSE_GENERATION)
+        zc = None
         try:
-            _BROWSE_STOP.clear()
-            _BROWSE_QUEUE = queue.Queue(maxsize=256)
             zc = Zeroconf()
-            browser = ServiceBrowser(zc, _service_type(), handlers=[_on_service_state_change])
-            _BROWSE_ZEROCONF = zc
-            _BROWSE_BROWSER = browser
-            _BROWSE_LAST_ERROR = None
-            thread = threading.Thread(target=_resolve_worker, daemon=True, name="relaytv-mdns-browse")
-            _BROWSE_THREAD = thread
-            thread.start()
+            session.zeroconf = zc
+            # Bind the handler to this session before the browser can fire it.
+            session.browser = ServiceBrowser(
+                zc, _service_type(), handlers=[_session_handler(session)]
+            )
         except Exception as exc:
             _BROWSE_LAST_ERROR = str(exc)
-            try:
-                if _BROWSE_ZEROCONF is not None:
-                    _BROWSE_ZEROCONF.close()
-            except Exception:
-                pass
-            _BROWSE_ZEROCONF = None
-            _BROWSE_BROWSER = None
+            # Close the Zeroconf we built, not the global: the global is still
+            # None here, because it is only assigned once the browser exists.
+            _close_zeroconf(zc)
+            return browse_status()
+
+        _BROWSE_SESSION = session
+        _BROWSE_ZEROCONF = zc
+        _BROWSE_BROWSER = session.browser
+        _BROWSE_QUEUE = session.queue
+        _BROWSE_LAST_ERROR = None
+        session.thread = threading.Thread(
+            target=_resolve_worker,
+            args=(session,),
+            daemon=True,
+            name=f"relaytv-mdns-browse-{session.generation}",
+        )
+        _BROWSE_THREAD = session.thread
+        session.thread.start()
     return browse_status()
 
 
@@ -433,28 +539,34 @@ def start_browse_async() -> dict[str, object]:
 
 
 def stop_browse() -> dict[str, object]:
-    global _BROWSE_ZEROCONF, _BROWSE_BROWSER, _BROWSE_THREAD
-    _BROWSE_STOP.set()
+    global _BROWSE_ZEROCONF, _BROWSE_BROWSER, _BROWSE_THREAD, _BROWSE_QUEUE, _BROWSE_SESSION
     with _BROWSE_LOCK:
+        session = _BROWSE_SESSION
         browser = _BROWSE_BROWSER
         zc = _BROWSE_ZEROCONF
+        thread = _BROWSE_THREAD
+        _BROWSE_SESSION = None
         _BROWSE_BROWSER = None
         _BROWSE_ZEROCONF = None
+        _BROWSE_QUEUE = None
+        _BROWSE_THREAD = None
         _DISCOVERED.clear()
+        # Signal inside the lock so a concurrent start cannot observe a live
+        # session that is already being torn down.
+        if session is not None:
+            session.stop.set()
+
+    # Network teardown and the join stay outside the lock and stay bounded.
     try:
         if browser is not None:
             browser.cancel()
     except Exception:
         pass
-    try:
-        if zc is not None:
-            zc.close()
-    except Exception:
-        pass
-    thread = _BROWSE_THREAD
-    _BROWSE_THREAD = None
+    _close_zeroconf(zc)
     if thread is not None and thread.is_alive():
         thread.join(timeout=2.0)
+        if thread.is_alive():
+            logger.warning("mdns_browse_worker_did_not_exit name=%s", thread.name)
     return browse_status()
 
 

--- a/app/relaytv_app/discovery_mdns.py
+++ b/app/relaytv_app/discovery_mdns.py
@@ -197,15 +197,20 @@ def _teardown(zc, info) -> None:
 
 def start() -> dict[str, object]:
     global _ZEROCONF, _SERVICE_INFO, _LAST_ERROR
+    generation: int | None = None
     with _LOCK:
-        if not _enabled():
-            return status()
-        if _SERVICE_INFO is not None and _ZEROCONF is not None:
-            return status()
-        if Zeroconf is None or ServiceInfo is None:
+        if not _enabled() or (_SERVICE_INFO is not None and _ZEROCONF is not None):
+            pass
+        elif Zeroconf is None or ServiceInfo is None:
             _LAST_ERROR = "zeroconf dependency unavailable"
-            return status()
-        generation = _claim_generation()
+        else:
+            generation = _claim_generation()
+
+    # status() takes _LOCK itself. Every early return used to call it from
+    # inside the non-reentrant lock above, permanently wedging discovery when
+    # advertising was disabled, already active, or the dependency was absent.
+    if generation is None:
+        return status()
 
     zc = None
     info = None
@@ -255,11 +260,12 @@ def start_async() -> dict[str, object]:
     """Start mDNS registration in a background thread so app startup cannot block."""
     global _START_THREAD
     with _LOCK:
-        if _START_THREAD is not None and _START_THREAD.is_alive():
-            return status()
-        t = threading.Thread(target=start, daemon=True, name="relaytv-mdns-start")
-        _START_THREAD = t
-        t.start()
+        if _START_THREAD is None or not _START_THREAD.is_alive():
+            t = threading.Thread(target=start, daemon=True, name="relaytv-mdns-start")
+            _START_THREAD = t
+            t.start()
+    # Do not call status() while _LOCK is held; the duplicate-start path used
+    # to self-deadlock here for the same reason as start()'s early returns.
     return status()
 
 

--- a/app/relaytv_app/integrations/iptv_service.py
+++ b/app/relaytv_app/integrations/iptv_service.py
@@ -28,7 +28,12 @@ _STORE_LOCK = threading.Lock()
 _STORE: IptvStore | None = None
 _STORE_PATH = ""
 _REFRESH_LOCKS: dict[str, threading.Lock] = {}
-_WORKER_STOP = threading.Event()
+# One stop flag per worker generation. It used to be a module global that
+# start_worker cleared, so starting while the previous worker was still
+# shutting down un-stopped that worker and left two refresh loops running
+# against the same sources.
+_WORKER_LOCK = threading.Lock()
+_WORKER_STOP: threading.Event | None = None
 _WORKER_THREAD: threading.Thread | None = None
 
 _ATTR_RE = re.compile(r"([A-Za-z0-9_-]+)=(\"[^\"]*\"|'[^']*'|[^\s,]*)")
@@ -730,20 +735,44 @@ def _refresh_due_sources() -> None:
 
 
 def start_worker() -> None:
-    global _WORKER_THREAD
-    if _WORKER_THREAD is not None and _WORKER_THREAD.is_alive():
-        return
-    _WORKER_STOP.clear()
+    global _WORKER_THREAD, _WORKER_STOP
+    with _WORKER_LOCK:
+        if _WORKER_THREAD is not None and _WORKER_THREAD.is_alive():
+            return
+        stop = threading.Event()
 
-    def _run() -> None:
-        while not _WORKER_STOP.wait(60.0):
-            _refresh_due_sources()
-            if enabled():
-                _check_due_favorites()
+        def _run(stop: threading.Event = stop) -> None:
+            # Closes over its own flag, so a later start cannot revive it and a
+            # retired generation cannot outlive its stop.
+            while not stop.wait(60.0):
+                _refresh_due_sources()
+                if enabled():
+                    _check_due_favorites()
 
-    _WORKER_THREAD = threading.Thread(target=_run, name="relaytv-iptv-refresh", daemon=True)
-    _WORKER_THREAD.start()
+        thread = threading.Thread(target=_run, name="relaytv-iptv-refresh", daemon=True)
+        _WORKER_STOP = stop
+        _WORKER_THREAD = thread
+        thread.start()
 
 
-def stop_worker() -> None:
-    _WORKER_STOP.set()
+def stop_worker(*, timeout: float = 2.0) -> None:
+    """Retire the refresh worker and wait, briefly, for it to leave.
+
+    Joining matters at shutdown: a refresh in flight holds source state and
+    network handles, and without the join the process could exit or a
+    replacement could start while it was still running.
+    """
+    global _WORKER_THREAD, _WORKER_STOP
+    with _WORKER_LOCK:
+        stop = _WORKER_STOP
+        thread = _WORKER_THREAD
+        _WORKER_STOP = None
+        _WORKER_THREAD = None
+        if stop is not None:
+            stop.set()
+    if thread is not None and thread.is_alive() and timeout > 0:
+        thread.join(timeout=timeout)
+        if thread.is_alive():
+            # A refresh can take longer than the join; it will exit on its own
+            # next loop because its flag is set and no longer reachable.
+            logger.warning("iptv_refresh_worker_did_not_exit")

--- a/app/relaytv_app/postlive_relay.py
+++ b/app/relaytv_app/postlive_relay.py
@@ -496,11 +496,15 @@ def close_session(token: str, *, reason: str) -> None:
 
 
 def close_all(*, reason: str = "shutdown") -> None:
-    with _LOCK:
-        tokens = list(_SESSIONS.keys())
-    for token in tokens:
-        close_session(token, reason=reason)
-    _prune_completed_spools(keep=0)
+    # Share the creation transaction. Without this, shutdown could snapshot an
+    # empty map while create_session was still spawning, return, and then have
+    # that creator publish a pipeline nothing would ever retire.
+    with _CREATE_LOCK:
+        with _LOCK:
+            tokens = list(_SESSIONS.keys())
+        for token in tokens:
+            close_session(token, reason=reason)
+        _prune_completed_spools(keep=0)
 
 
 def sweep_spool_root() -> None:

--- a/app/relaytv_app/postlive_relay.py
+++ b/app/relaytv_app/postlive_relay.py
@@ -62,6 +62,10 @@ _SPOOL_TTL_SEC = 6 * 3600.0
 _SPOOL_POLL_SEC = 0.05
 
 _LOCK = threading.Lock()
+# Serializes session creation. Distinct from _LOCK, which guards _SESSIONS for
+# short reads and writes; this one is held across a spawn, and nothing holding
+# _LOCK ever takes it, so the ordering cannot invert.
+_CREATE_LOCK = threading.Lock()
 _SESSIONS: dict[str, "RelaySession"] = {}
 # token -> (spool path, completion timestamp) for sessions whose mux
 # finished cleanly; kept so the player can upgrade onto the local file
@@ -211,7 +215,20 @@ def create_session(page_url: str, ytdl_format: str, ytdlp_args=()) -> RelaySessi
     (``ResolvedStreams.ytdlp_args``) so the relay runs the exact strategy
     that produced the resolve. Raises RelayError on any spawn failure with
     everything already spawned torn back down.
+
+    Creation is serialized. The supersede below deliberately happens *after*
+    this call's pipeline is up, so that a spawn failure leaves whatever is
+    playing untouched — restart-in-place relies on it. But that ordering also
+    meant two concurrent calls could both spawn, both read an empty _SESSIONS,
+    and both publish, leaving two live pipelines burning CPU, disk, and
+    network until the reaper caught them. Letting one creation finish before
+    the next begins keeps "at most one" true without giving up the ordering.
     """
+    with _CREATE_LOCK:
+        return _create_session_locked(page_url, ytdl_format, ytdlp_args)
+
+
+def _create_session_locked(page_url: str, ytdl_format: str, ytdlp_args=()) -> RelaySession:
     if not relay_enabled():
         raise RelayError("post-live relay is disabled (RELAYTV_POSTLIVE_RELAY=0)")
     url = str(page_url or "").strip()

--- a/tests/test_service_generations.py
+++ b/tests/test_service_generations.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Background services must own their generation (F05, F06, F12).
+
+Three services shared the same shape of defect: a module-level stop event that
+a restart cleared out from under the previous worker, a publish that did not
+check whether it still owned the slot, and a failed startup that closed the
+wrong object. The pattern they now follow is the one jellyfin_ws.py already
+uses — per-generation stop flags, and a publish that re-checks ownership.
+"""
+import threading
+import time
+
+import pytest
+
+from relaytv_app import discovery_mdns, postlive_relay
+from relaytv_app.integrations import iptv_service
+
+
+class _FakeZeroconf:
+    """Records whether it was closed, which is the whole point of the leak test."""
+
+    def __init__(self, *, register_raises: bool = False, browser_raises: bool = False):
+        self.closed = False
+        self.registered: list[object] = []
+        self.unregistered: list[object] = []
+        self._register_raises = register_raises
+        self.browser_raises = browser_raises
+
+    def register_service(self, info):
+        if self._register_raises:
+            raise RuntimeError("register failed")
+        self.registered.append(info)
+
+    def unregister_service(self, info):
+        self.unregistered.append(info)
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _quiet_mdns(monkeypatch):
+    monkeypatch.setattr(discovery_mdns, "_enabled", lambda: True)
+    monkeypatch.setattr(discovery_mdns, "_browse_enabled", lambda: True)
+    monkeypatch.setattr(discovery_mdns, "ServiceInfo", lambda **kw: object())
+    monkeypatch.setattr(discovery_mdns, "_detect_ipv4", lambda: "127.0.0.1")
+    monkeypatch.setattr(discovery_mdns, "_ZEROCONF", None, raising=False)
+    monkeypatch.setattr(discovery_mdns, "_SERVICE_INFO", None, raising=False)
+    monkeypatch.setattr(discovery_mdns, "_BROWSE_SESSION", None, raising=False)
+    monkeypatch.setattr(discovery_mdns, "_BROWSE_ZEROCONF", None, raising=False)
+    monkeypatch.setattr(discovery_mdns, "_BROWSE_BROWSER", None, raising=False)
+    monkeypatch.setattr(discovery_mdns, "_BROWSE_THREAD", None, raising=False)
+    yield
+    discovery_mdns.stop()
+
+
+# --- F05: mDNS advertisement -------------------------------------------------
+
+
+def test_failed_registration_closes_the_zeroconf_it_built(monkeypatch) -> None:
+    """The audited leak: the except branch closed the global, not the local.
+
+    _ZEROCONF is only assigned after register_service succeeds, so on failure
+    it is still None and the close was a no-op — leaking an open Zeroconf with
+    its sockets and threads on every retry.
+    """
+    built: list[_FakeZeroconf] = []
+
+    def _make():
+        zc = _FakeZeroconf(register_raises=True)
+        built.append(zc)
+        return zc
+
+    monkeypatch.setattr(discovery_mdns, "Zeroconf", _make)
+
+    discovery_mdns.start()
+
+    assert len(built) == 1
+    assert built[0].closed is True, "a failed registration leaked its Zeroconf"
+    assert discovery_mdns._ZEROCONF is None
+
+
+def test_registration_that_finishes_after_stop_does_not_publish(monkeypatch) -> None:
+    """A start_async in flight must not advertise a service stop() retired."""
+    released = threading.Event()
+    built: list[_FakeZeroconf] = []
+
+    def _slow_zeroconf():
+        zc = _FakeZeroconf()
+        built.append(zc)
+        released.wait(5.0)
+        return zc
+
+    monkeypatch.setattr(discovery_mdns, "Zeroconf", _slow_zeroconf)
+
+    worker = threading.Thread(target=discovery_mdns.start, daemon=True)
+    worker.start()
+    # Wait until the registration is genuinely in flight.
+    for _ in range(200):
+        if built:
+            break
+        time.sleep(0.01)
+    assert built, "registration never started"
+
+    discovery_mdns.stop()
+    released.set()
+    worker.join(timeout=5.0)
+    assert not worker.is_alive()
+
+    assert discovery_mdns._ZEROCONF is None
+    assert discovery_mdns._SERVICE_INFO is None
+    # It also cleans up what it built rather than abandoning it.
+    assert built[0].closed is True
+
+
+def test_successful_registration_publishes(monkeypatch) -> None:
+    zc = _FakeZeroconf()
+    monkeypatch.setattr(discovery_mdns, "Zeroconf", lambda: zc)
+
+    discovery_mdns.start()
+
+    assert discovery_mdns._ZEROCONF is zc
+    assert len(zc.registered) == 1
+    assert zc.closed is False
+
+
+def test_stop_unregisters_and_closes(monkeypatch) -> None:
+    zc = _FakeZeroconf()
+    monkeypatch.setattr(discovery_mdns, "Zeroconf", lambda: zc)
+    discovery_mdns.start()
+
+    discovery_mdns.stop()
+
+    assert len(zc.unregistered) == 1
+    assert zc.closed is True
+
+
+# --- F05: mDNS browse --------------------------------------------------------
+
+
+def test_browse_stop_flag_is_per_generation(monkeypatch) -> None:
+    """Restarting must not un-stop the worker that is still shutting down."""
+    monkeypatch.setattr(discovery_mdns, "Zeroconf", lambda: _FakeZeroconf())
+    monkeypatch.setattr(discovery_mdns, "ServiceBrowser", lambda *a, **k: object())
+
+    discovery_mdns.start_browse()
+    first = discovery_mdns._BROWSE_SESSION
+    assert first is not None
+
+    discovery_mdns.stop_browse()
+    assert first.stop.is_set()
+
+    discovery_mdns.start_browse()
+    second = discovery_mdns._BROWSE_SESSION
+    assert second is not None
+    assert second is not first
+    assert second.generation != first.generation
+    # The retired generation stays retired.
+    assert first.stop.is_set()
+    assert not second.stop.is_set()
+    # And they do not share a queue, so the old worker cannot steal work.
+    assert first.queue is not second.queue
+
+    discovery_mdns.stop_browse()
+
+
+def test_failed_browser_start_closes_its_zeroconf(monkeypatch) -> None:
+    built: list[_FakeZeroconf] = []
+
+    def _make():
+        zc = _FakeZeroconf()
+        built.append(zc)
+        return zc
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("browser failed")
+
+    monkeypatch.setattr(discovery_mdns, "Zeroconf", _make)
+    monkeypatch.setattr(discovery_mdns, "ServiceBrowser", _boom)
+
+    discovery_mdns.start_browse()
+
+    assert built and built[0].closed is True
+    assert discovery_mdns._BROWSE_ZEROCONF is None
+
+
+def test_retired_session_callback_does_not_reach_the_live_queue(monkeypatch) -> None:
+    monkeypatch.setattr(discovery_mdns, "Zeroconf", lambda: _FakeZeroconf())
+    monkeypatch.setattr(discovery_mdns, "ServiceBrowser", lambda *a, **k: object())
+
+    discovery_mdns.start_browse()
+    old = discovery_mdns._BROWSE_SESSION
+    discovery_mdns.stop_browse()
+    discovery_mdns.start_browse()
+    new = discovery_mdns._BROWSE_SESSION
+
+    discovery_mdns._handle_service_state_change(old, "_relaytv._tcp.local.", "ghost", None)
+
+    assert new.queue.qsize() == 0
+    discovery_mdns.stop_browse()
+
+
+# --- F06: IPTV refresh worker ------------------------------------------------
+
+
+def test_iptv_restart_retires_the_previous_worker(monkeypatch) -> None:
+    iptv_service.stop_worker()
+
+    iptv_service.start_worker()
+    first_stop = iptv_service._WORKER_STOP
+    first_thread = iptv_service._WORKER_THREAD
+    assert first_stop is not None
+
+    iptv_service.stop_worker()
+    assert first_stop.is_set()
+
+    iptv_service.start_worker()
+    second_stop = iptv_service._WORKER_STOP
+    assert second_stop is not None
+    assert second_stop is not first_stop
+    # The old worker stays stopped: start no longer clears a shared flag.
+    assert first_stop.is_set()
+    assert not second_stop.is_set()
+    assert iptv_service._WORKER_THREAD is not first_thread
+
+    iptv_service.stop_worker()
+
+
+def test_iptv_stop_joins_the_worker() -> None:
+    iptv_service.start_worker()
+    thread = iptv_service._WORKER_THREAD
+    assert thread is not None
+
+    iptv_service.stop_worker()
+
+    assert not thread.is_alive(), "stop_worker returned while the worker was still running"
+    assert iptv_service._WORKER_THREAD is None
+
+
+def test_iptv_double_start_does_not_stack_workers() -> None:
+    iptv_service.stop_worker()
+    iptv_service.start_worker()
+    first = iptv_service._WORKER_THREAD
+    iptv_service.start_worker()
+
+    assert iptv_service._WORKER_THREAD is first
+
+    iptv_service.stop_worker()
+
+
+# --- F12: post-live relay ----------------------------------------------------
+
+
+def test_concurrent_session_creation_leaves_exactly_one(monkeypatch) -> None:
+    """Both callers used to spawn, both see an empty map, and both publish."""
+    spawned: list[str] = []
+    closed: list[str] = []
+    barrier = threading.Barrier(2, timeout=5.0)
+
+    class _Session:
+        def __init__(self, token):
+            self.token = token
+
+    def _fake_create(page_url, ytdl_format, ytdlp_args=()):
+        token = f"t{len(spawned)}"
+        spawned.append(token)
+        # Both callers reach the spawn at the same moment when unserialized.
+        try:
+            barrier.wait()
+        except threading.BrokenBarrierError:
+            pass
+        with postlive_relay._LOCK:
+            stale = list(postlive_relay._SESSIONS.keys())
+        for token_stale in stale:
+            closed.append(token_stale)
+            with postlive_relay._LOCK:
+                postlive_relay._SESSIONS.pop(token_stale, None)
+        session = _Session(token)
+        with postlive_relay._LOCK:
+            postlive_relay._SESSIONS[token] = session
+        return session
+
+    monkeypatch.setattr(postlive_relay, "_create_session_locked", _fake_create)
+    monkeypatch.setattr(postlive_relay, "_SESSIONS", {}, raising=False)
+
+    errors: list[BaseException] = []
+
+    def _run():
+        try:
+            postlive_relay.create_session("https://x.test/a", "best")
+        except BaseException as exc:  # noqa: BLE001 - surfaced below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_run) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10.0)
+
+    assert not errors, errors
+    assert len(spawned) == 2, "both callers should still spawn; ordering is preserved"
+    # But only one survives: the second superseded the first.
+    assert len(postlive_relay._SESSIONS) == 1, postlive_relay._SESSIONS
+    assert closed == [spawned[0]]
+
+
+def test_create_session_still_supersedes_after_spawning(monkeypatch) -> None:
+    """Restart-in-place depends on the old session outliving a failed spawn."""
+    order: list[str] = []
+
+    def _failing_create(page_url, ytdl_format, ytdlp_args=()):
+        order.append("spawn")
+        raise postlive_relay.RelayError("spawn failed")
+
+    monkeypatch.setattr(postlive_relay, "_create_session_locked", _failing_create)
+    monkeypatch.setattr(postlive_relay, "_SESSIONS", {"existing": object()}, raising=False)
+
+    with pytest.raises(postlive_relay.RelayError):
+        postlive_relay.create_session("https://x.test/a", "best")
+
+    assert order == ["spawn"]
+    # The session that was playing is untouched by the failure.
+    assert "existing" in postlive_relay._SESSIONS

--- a/tests/test_service_generations.py
+++ b/tests/test_service_generations.py
@@ -135,6 +135,42 @@ def test_stop_unregisters_and_closes(monkeypatch) -> None:
     assert zc.closed is True
 
 
+@pytest.mark.parametrize("early_return", ["disabled", "active", "dependency_missing"])
+def test_registration_early_returns_do_not_self_deadlock(monkeypatch, early_return) -> None:
+    """status() must be called only after the advertisement lock is released."""
+    if early_return == "disabled":
+        monkeypatch.setattr(discovery_mdns, "_enabled", lambda: False)
+    elif early_return == "active":
+        monkeypatch.setattr(discovery_mdns, "_ZEROCONF", object(), raising=False)
+        monkeypatch.setattr(discovery_mdns, "_SERVICE_INFO", object(), raising=False)
+    else:
+        monkeypatch.setattr(discovery_mdns, "Zeroconf", None)
+
+    worker = threading.Thread(target=discovery_mdns.start, daemon=True)
+    worker.start()
+    worker.join(timeout=1.0)
+    if worker.is_alive():
+        # Keep a reverted implementation from wedging fixture teardown after
+        # this assertion records the regression.
+        discovery_mdns._LOCK = threading.Lock()
+    assert not worker.is_alive(), f"start deadlocked on {early_return}"
+
+
+def test_duplicate_async_start_does_not_self_deadlock(monkeypatch) -> None:
+    class _AliveThread:
+        @staticmethod
+        def is_alive() -> bool:
+            return True
+
+    monkeypatch.setattr(discovery_mdns, "_START_THREAD", _AliveThread(), raising=False)
+    worker = threading.Thread(target=discovery_mdns.start_async, daemon=True)
+    worker.start()
+    worker.join(timeout=1.0)
+    if worker.is_alive():
+        discovery_mdns._LOCK = threading.Lock()
+    assert not worker.is_alive(), "a duplicate start_async call deadlocked"
+
+
 # --- F05: mDNS browse --------------------------------------------------------
 
 
@@ -321,3 +357,53 @@ def test_create_session_still_supersedes_after_spawning(monkeypatch) -> None:
     assert order == ["spawn"]
     # The session that was playing is untouched by the failure.
     assert "existing" in postlive_relay._SESSIONS
+
+
+def test_close_all_waits_for_an_inflight_creation(monkeypatch) -> None:
+    """Shutdown must retire a session whose spawn was already in progress."""
+    entered = threading.Event()
+    release = threading.Event()
+    closed: list[str] = []
+
+    class _Session:
+        token = "late"
+
+    def _slow_create(page_url, ytdl_format, ytdlp_args=()):
+        entered.set()
+        release.wait(5.0)
+        session = _Session()
+        with postlive_relay._LOCK:
+            postlive_relay._SESSIONS[session.token] = session
+        return session
+
+    def _close(token, *, reason=""):
+        closed.append(token)
+        with postlive_relay._LOCK:
+            postlive_relay._SESSIONS.pop(token, None)
+
+    monkeypatch.setattr(postlive_relay, "_create_session_locked", _slow_create)
+    monkeypatch.setattr(postlive_relay, "close_session", _close)
+    monkeypatch.setattr(postlive_relay, "_prune_completed_spools", lambda **kwargs: None)
+    monkeypatch.setattr(postlive_relay, "_SESSIONS", {}, raising=False)
+
+    creator = threading.Thread(
+        target=postlive_relay.create_session,
+        args=("https://x.test/a", "best"),
+        daemon=True,
+    )
+    creator.start()
+    assert entered.wait(1.0), "session creation never entered its transaction"
+
+    closer = threading.Thread(target=postlive_relay.close_all, daemon=True)
+    closer.start()
+    closer.join(timeout=0.1)
+    assert closer.is_alive(), "close_all bypassed the in-flight creation"
+
+    release.set()
+    creator.join(timeout=2.0)
+    closer.join(timeout=2.0)
+
+    assert not creator.is_alive()
+    assert not closer.is_alive()
+    assert closed == ["late"]
+    assert postlive_relay._SESSIONS == {}


### PR DESCRIPTION
Roadmap PR 5 of 11 — closes **F05**, **F06**, and the relay half of **F12**. See #67.

Grouped because all three are the same defect wearing different names: a module-level stop event a restart cleared out from under the previous worker, a publish that never checked whether it still owned the slot, and a failed startup that closed the wrong object. They now follow the pattern `jellyfin_ws.py` already uses.

## A leak the audit didn't name

Reading F05 turned up this, in both mDNS start paths:

```python
zc = Zeroconf()
zc.register_service(info)   # raises
_ZEROCONF = zc              # never reached
except Exception:
    if _ZEROCONF is not None:   # still None!
        _ZEROCONF.close()       # no-op
```

`_ZEROCONF` is only assigned *after* `register_service` succeeds, so on failure the close was a no-op and **every failed registration leaked an open Zeroconf** — sockets and threads — and retried. The browse path had the identical bug in the identical shape. Both now close the object they actually built.

## mDNS advertisement

Registration talks to the network and held `_LOCK` throughout, so `stop()` waited on it. Each attempt now claims a generation, does network work unlocked, and re-checks ownership before publishing. `stop()` claims a generation too — that's what retires an attempt already in flight.

Without it, a `start_async` finishing after `stop()` advertised a service the app believed it had retired, and nothing would ever unregister it.

## mDNS browse

`_BROWSE_STOP` was a module global that `start_browse` **cleared** — so restarting while the previous worker was shutting down *un-stopped* that worker, leaving two resolvers running against whichever Zeroconf was current.

Each generation now owns its stop flag, queue, and Zeroconf. The `ServiceBrowser` callback is bound to its session, so a retired browser can't push into the live queue. `stop_browse` signals inside the lock and joins outside it, bounded.

## IPTV refresh worker

Same shared-flag defect, same fix. `stop_worker` now also **joins** — a refresh in flight holds source state and network handles, so without it a replacement could start while the old one was still running.

## Post-live relay

`create_session` spawns and *then* supersedes, so a spawn failure leaves current playback untouched. Restart-in-place relies on that, and the comment at `postlive_relay.py:276` says so — **it is preserved**. But it also meant two concurrent calls could both spawn, both read an empty `_SESSIONS`, and both publish.

Creation is serialized instead: one finishes before the next begins. The new lock is only ever taken *before* `_LOCK`, never while holding it, so the ordering can't invert.

## Testing

Four revert proofs, each caught by the test written for it:

| Reverted | Fails |
|---|---|
| `except` closes the global again | `test_failed_registration_closes_the_zeroconf_it_built` |
| publish without the ownership check | `test_registration_that_finishes_after_stop_does_not_publish` |
| IPTV back to a shared flag, no join | `test_iptv_restart_retires_the_previous_worker`, `test_iptv_stop_joins_the_worker` |
| creation unserialized | `test_concurrent_session_creation_leaves_exactly_one` |

The stop-during-registration test blocks a real `Zeroconf()` on an event, waits until registration is genuinely in flight, then calls `stop()` and releases — it exercises the actual race rather than simulating it. The concurrent-create test uses a `threading.Barrier` so both callers reach the spawn simultaneously, and asserts **both still spawn** (ordering preserved) while only one survives.

Gates: **755 Python tests** (+12), 11 JS tests, ruff clean, `git diff --check` clean.

## Device verification

This is the PR that needed both devices up. Mark's Room was down; it is now running the combined branch.

**mDNS lifecycle** — two container restart cycles on the Pi:

| Cycle | Advertise | Browse |
|---|---|---|
| 1 | `active=True`, `last_error=None` | `active=True`, `found=1`, `last_error=None` |
| 2 | `active=True`, `last_error=None` | `active=True`, `found=1`, `last_error=None` |

Zero `mdns_registration_retired`, leaked-Zeroconf, or `browse_worker_did_not_exit` entries across the cycles.

**Cross-device discovery** — each device sees the other, bidirectionally:

```
LR probes Pi -> online: true, error: "", device_name: "Mark's Room"
Pi probes LR -> online: true, error: "", device_name: "RelayTV"
```

Both report mDNS browse `found=1` with no error. The IPTV refresh worker and the Jellyfin socket both came back cleanly on every restart (`jellyfin_running=True`, `jellyfin_connected=True` on both devices).

**Still outstanding**: the post-live relay check — play a post-live YouTube item and confirm exactly one ffmpeg process.

**Unrelated observation** worth a separate fix: Living Room's stored peer *name* for the Pi is `"Living.Room"`, stale since it was paired. The probe resolves the correct live `device_name` (`"Mark's Room"`), so this is stale cached data rather than a defect in this PR — the display name simply never refreshes after pairing.
