### PR TITLE
fix: order durable state publication

### DIFF
--- a/app/relaytv_app/playback_service.py
+++ b/app/relaytv_app/playback_service.py
@@ -436,9 +436,9 @@ def resume_paused_in_place() -> dict[str, Any] | None:
     resumed = dict(now)
     resumed["closed"] = False
     suppress_auto_next(2.0)
-    state.set_now_playing(resumed)
-    state.set_session_state("playing")
-    state.set_pause_reason(None)
+    # One mutation, one write: the three-setter form persisted twice through
+    # combinations the session was never conceptually in.
+    state.update_session(now_playing=resumed, session_state="playing", pause_reason=None)
     return result
 
 
@@ -575,8 +575,7 @@ def resume_session() -> tuple[dict[str, Any], dict[str, Any] | None]:
         resumed["started"] = int(time.time())
         resumed["mode"] = "resume"
         resumed["closed"] = False
-        state.set_now_playing(resumed)
-        state.set_session_state("playing")
+        state.update_session(now_playing=resumed, session_state="playing")
 
     resume_result: dict[str, Any] | None = None
     if start_pos is not None:
@@ -592,9 +591,7 @@ def resume_session() -> tuple[dict[str, Any], dict[str, Any] | None]:
 
 def clear_session() -> None:
     """Reset the session to idle: no current item, no resume position."""
-    state.set_now_playing(None)
-    state.set_session_position(None)
-    state.set_session_state("idle")
+    state.update_session(now_playing=None, session_position=None, session_state="idle")
     try:
         state.persist_queue()
     except Exception:
@@ -607,8 +604,10 @@ def mark_paused(paused: bool, *, reason: str | None = None) -> None:
     ``reason`` preserves a pre-existing pause reason across an in-place
     restart (Jellyfin track switches); it defaults to a user pause.
     """
-    state.set_session_state("paused" if paused else "playing")
-    state.set_pause_reason((reason if reason is not None else "user") if paused else None)
+    state.update_session(
+        session_state="paused" if paused else "playing",
+        pause_reason=(reason if reason is not None else "user") if paused else None,
+    )
 
 
 def update_now_playing(now: dict) -> None:
@@ -622,9 +621,7 @@ def update_now_playing(now: dict) -> None:
 
 def mark_resumed_now_playing(resumed: dict) -> None:
     """Record a successfully resumed item as the playing session."""
-    state.set_now_playing(resumed)
-    state.set_session_state("playing")
-    state.set_pause_reason(None)
+    state.update_session(now_playing=resumed, session_state="playing", pause_reason=None)
 
 
 def stop_current() -> dict[str, Any]:
@@ -766,17 +763,18 @@ def restore_playback_state(snapshot: dict) -> None:
         mode="temporary_resume",
         start_pos=(float(start_pos) if start_pos is not None else None),
     )
+    paused = False
     if snapshot.get("paused"):
         try:
             player.mpv_set("pause", True)
-            state.set_session_state("paused")
-            state.set_pause_reason("temporary")
+            paused = True
         except Exception:
             pass
-    else:
-        state.set_session_state("playing")
-        state.set_pause_reason(None)
-    state.set_now_playing(resumed)
+    state.update_session(
+        session_state="paused" if paused else "playing",
+        pause_reason="temporary" if paused else None,
+        now_playing=resumed,
+    )
 
 
 def complete_temporary_playback(frame_id: str, reason: str) -> bool:

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -5233,10 +5233,12 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
         now["_playback_started_pos"] = 0.0
 
     _add_history_entry(now)
-    state.set_now_playing(now)
-    state.set_session_state("playing")
-    state.set_pause_reason(None)
-    state.set_session_position(float(start_pos) if start_pos is not None else 0.0)
+    state.update_session(
+        now_playing=now,
+        session_state="playing",
+        pause_reason=None,
+        session_position=float(start_pos) if start_pos is not None else 0.0,
+    )
 
 
     # Keep exactly one "up next" item primed in mpv so queue handoff avoids

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3410,7 +3410,13 @@ def _status_payload() -> dict[str, object]:
             iptv_status = iptv_service.status()
         except Exception:
             iptv_status.update({"source_count": 0, "channel_count": 0})
-    return {
+    # Durable-write health. A device whose disk stopped accepting writes used
+    # to look completely healthy while quietly discarding every setting and
+    # queue change; the key is absent while writes are landing, so the payload
+    # only grows when something is actually wrong.
+    persistence = state.persistence_health() if hasattr(state, "persistence_health") else {"ok": True}
+
+    payload: dict[str, object] = {
         "state": sess,
         "device_name": str(settings_snapshot.get("device_name") or "RelayTV"),
         "idle_dashboard_enabled": bool(settings_snapshot.get("idle_dashboard_enabled", True)),
@@ -3466,6 +3472,9 @@ def _status_payload() -> dict[str, object]:
         **runtime,
         "effective_ytdlp_format": effective_ytdlp_format,
     }
+    if not persistence.get("ok", True):
+        payload["persistence"] = persistence
+    return payload
 
 
 @router.get("/status")

--- a/app/relaytv_app/routes/queue.py
+++ b/app/relaytv_app/routes/queue.py
@@ -585,10 +585,11 @@ def queue_dedupe():
         if changed:
             state.QUEUE[:] = deduped
             snapshot = {"queue": list(state.QUEUE), "saved_at": int(time.time())}
-            try:
-                state.persist_queue_payload(snapshot)
-            except Exception as e:
-                logger.warning("queue_persist_failed route=queue_dedupe error=%s", e)
+    if changed:
+        try:
+            state.persist_queue_payload(snapshot)
+        except Exception as e:
+            logger.warning("queue_persist_failed route=queue_dedupe error=%s", e)
     try:
         player.prime_mpv_up_next_from_queue(force=True)
     except Exception:
@@ -618,10 +619,10 @@ def queue_move(req: QueueMoveReq):
         state.QUEUE.insert(to, item)
         snapshot = {"queue": list(state.QUEUE), "saved_at": int(time.time())}
 
-        try:
-            state.persist_queue_payload(snapshot)
-        except Exception as e:
-            logger.warning("queue_persist_failed route=queue_move error=%s", e)
+    try:
+        state.persist_queue_payload(snapshot)
+    except Exception as e:
+        logger.warning("queue_persist_failed route=queue_move error=%s", e)
     try:
         player.prime_mpv_up_next_from_queue(force=True)
     except Exception:

--- a/app/relaytv_app/state.py
+++ b/app/relaytv_app/state.py
@@ -171,8 +171,14 @@ def _load_json(path: str, default):
         return default
 
 
-def _atomic_write_json(path: str, obj) -> None:
-    """Best-effort atomic write (same filesystem)."""
+def _atomic_write_json(path: str, obj) -> bool:
+    """Best-effort atomic write (same filesystem). Returns True on success.
+
+    Used to return None and swallow every failure into a log line, which meant
+    a full or read-only disk produced a successful API response and state that
+    silently reverted on restart. Callers get the outcome now, and
+    ``persistence_health()`` records it either way.
+    """
     tmp = None
     try:
         _ensure_state_dir()
@@ -182,14 +188,115 @@ def _atomic_write_json(path: str, obj) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(obj, f, ensure_ascii=False, indent=2)
         os.replace(tmp, path)
+        tmp = None
+        return True
     except Exception as e:
         logger.warning("state_write_failed path=%s error=%s", path, e)
+        _record_write_failure(path, e)
+        return False
     finally:
         if tmp and os.path.exists(tmp):
             try:
                 os.unlink(tmp)
             except Exception:
                 pass
+
+
+# --- Persistence health -------------------------------------------------------
+
+_HEALTH_LOCK = threading.Lock()
+_WRITE_FAILURES: dict[str, dict[str, object]] = {}
+
+
+def _record_write_failure(path: str, error: BaseException) -> None:
+    name = os.path.basename(str(path or "")) or "unknown"
+    with _HEALTH_LOCK:
+        entry = _WRITE_FAILURES.setdefault(name, {"count": 0, "last_error": "", "last_unix": 0.0})
+        entry["count"] = int(entry.get("count") or 0) + 1
+        # Type and message only: a path can name a mount an operator has not
+        # asked us to publish, and this is surfaced through /status.
+        entry["last_error"] = f"{type(error).__name__}: {error}"[:200]
+        entry["last_unix"] = time.time()
+
+
+def _record_write_success(path: str) -> None:
+    name = os.path.basename(str(path or "")) or "unknown"
+    with _HEALTH_LOCK:
+        _WRITE_FAILURES.pop(name, None)
+
+
+def persistence_health() -> dict[str, object]:
+    """Report durable-write health for /status.
+
+    A device whose disk stopped accepting writes used to look completely
+    healthy while quietly discarding every setting and queue change.
+    """
+    with _HEALTH_LOCK:
+        failures = {name: dict(entry) for name, entry in _WRITE_FAILURES.items()}
+    return {"ok": not failures, "failing": failures}
+
+
+def reset_persistence_health_for_tests() -> None:
+    with _HEALTH_LOCK:
+        _WRITE_FAILURES.clear()
+
+
+class _Publisher:
+    """Serializes writes to one state file and drops superseded snapshots.
+
+    Payloads are built under their store's lock and written outside it, so two
+    mutations can reach the disk out of order: the older writer wins the race
+    to os.replace and the newer mutation is lost, reappearing missing after a
+    restart. Each payload carries the version it was built at, and a write that
+    is no longer the newest is dropped instead of applied.
+
+    The counter and the write mutex are separate on purpose. ``reserve()`` is
+    called while a store lock is held, so it must never wait on disk I/O.
+    """
+
+    __slots__ = ("_name", "_path_getter", "_counter_lock", "_write_lock", "_version", "_written")
+
+    def __init__(self, name: str, path_getter) -> None:
+        self._name = name
+        self._path_getter = path_getter
+        self._counter_lock = threading.Lock()
+        self._write_lock = threading.Lock()
+        self._version = 0
+        self._written = 0
+
+    def reserve(self) -> int:
+        """Take the next version. Cheap; safe to call under a store lock."""
+        with self._counter_lock:
+            self._version += 1
+            return self._version
+
+    def publish(self, version: int, payload) -> bool:
+        """Write ``payload`` unless a newer snapshot already landed."""
+        with self._write_lock:
+            with self._counter_lock:
+                if version <= self._written:
+                    logger.debug(
+                        "state_write_superseded store=%s version=%d written=%d",
+                        self._name,
+                        version,
+                        self._written,
+                    )
+                    return False
+            path = self._path_getter()
+            ok = _atomic_write_json(path, payload)
+            if ok:
+                _record_write_success(path)
+                with self._counter_lock:
+                    if version > self._written:
+                        self._written = version
+            return ok
+
+
+_QUEUE_PUBLISHER = _Publisher("queue", lambda: _state_path(QUEUE_STATE_FILE))
+_HISTORY_PUBLISHER = _Publisher("history", lambda: _state_path(HISTORY_STATE_FILE))
+_SESSION_PUBLISHER = _Publisher("session", lambda: _state_path(SESSION_STATE_FILE))
+_SETTINGS_PUBLISHER = _Publisher("settings", lambda: _state_path(SETTINGS_STATE_FILE))
+
 
 def _is_safe_thumb_filename(fn: str) -> bool:
     if not fn:
@@ -437,27 +544,34 @@ ADVANCE_LOCK = threading.Lock()
 AUTO_NEXT_SUPPRESS_UNTIL = 0.0  # epoch seconds; auto-next ignored until this time
 
 
-def _persist_queue_payload(payload: dict) -> None:
-    path = _state_path(QUEUE_STATE_FILE)
-    _atomic_write_json(path, payload)
+def _persist_queue_payload(payload: dict, version: int | None = None) -> bool:
+    return _QUEUE_PUBLISHER.publish(
+        _QUEUE_PUBLISHER.reserve() if version is None else version, payload
+    )
 
 
-def _persist_history_payload(payload: dict) -> None:
-    path = _state_path(HISTORY_STATE_FILE)
-    _atomic_write_json(path, payload)
+def _persist_history_payload(payload: dict, version: int | None = None) -> bool:
+    return _HISTORY_PUBLISHER.publish(
+        _HISTORY_PUBLISHER.reserve() if version is None else version, payload
+    )
 
 
-def _persist_session_payload(payload: dict) -> None:
-    path = _state_path(SESSION_STATE_FILE)
-    _atomic_write_json(path, payload)
+def _persist_session_payload(payload: dict, version: int | None = None) -> bool:
+    return _SESSION_PUBLISHER.publish(
+        _SESSION_PUBLISHER.reserve() if version is None else version, payload
+    )
 
-def persist_session() -> None:
+SESSION_LOCK = threading.RLock()
+
+
+def _session_payload() -> dict:
+    """Build the session snapshot. Caller must hold SESSION_LOCK."""
     persisted_now = NOW_PLAYING
     if isinstance(NOW_PLAYING, dict) and str(NOW_PLAYING.get("provider") or "").lower() == "iptv":
         # Do not duplicate credential-bearing IPTV stream URLs into session
         # JSON. The opaque catalog reference is resolved again on resume.
         persisted_now = _persistable_history_item(NOW_PLAYING)
-    payload = {
+    return {
         "session_state": SESSION_STATE,
         "pause_reason": SESSION_PAUSE_REASON,
         "session_position": SESSION_POSITION,
@@ -476,31 +590,79 @@ def persist_session() -> None:
         },
         "saved_at": int(time.time()),
     }
-    _persist_session_payload(payload)
 
 
-def _persist_queue() -> None:
+def persist_session() -> bool:
+    with SESSION_LOCK:
+        version = _SESSION_PUBLISHER.reserve()
+        payload = _session_payload()
+    return _persist_session_payload(payload, version)
+
+
+_SESSION_UNSET = object()
+
+
+def update_session(
+    *,
+    session_state=_SESSION_UNSET,
+    pause_reason=_SESSION_UNSET,
+    session_position=_SESSION_UNSET,
+    now_playing=_SESSION_UNSET,
+    persist: bool = True,
+) -> bool:
+    """Apply several session fields as one mutation and persist once.
+
+    The individual setters each mutated a global and then wrote the *whole*
+    composite payload, so a caller changing three fields wrote three times and
+    the first two were snapshots of a state that never conceptually existed —
+    now_playing set while session_state still said idle, and so on. A restart
+    landing between them restored one of those intermediate combinations.
+    """
+    global SESSION_STATE, SESSION_PAUSE_REASON, SESSION_POSITION, NOW_PLAYING
+    with SESSION_LOCK:
+        if session_state is not _SESSION_UNSET:
+            SESSION_STATE = session_state
+        if pause_reason is not _SESSION_UNSET:
+            SESSION_PAUSE_REASON = pause_reason
+        if session_position is not _SESSION_UNSET:
+            SESSION_POSITION = session_position
+        if now_playing is not _SESSION_UNSET:
+            NOW_PLAYING = now_playing
+        if not persist:
+            return True
+        version = _SESSION_PUBLISHER.reserve()
+        payload = _session_payload()
+    # Disk work happens outside the lock; the version keeps ordering correct.
+    return _persist_session_payload(payload, version)
+
+
+def _persist_queue() -> bool:
     """Persist current queue to disk (safe to call anywhere)."""
     with QUEUE_LOCK:
+        # Reserve inside the lock so the version orders with the snapshot it
+        # describes; the write itself happens outside, so no state lock is
+        # ever held across disk I/O.
+        version = _QUEUE_PUBLISHER.reserve()
         queue = []
         for it in list(QUEUE):
             normalized = _persistable_queue_item(it)
             if isinstance(normalized, dict):
                 queue.append(normalized)
         payload = {"queue": queue, "saved_at": int(time.time())}
-    _persist_queue_payload(payload)
+    return _persist_queue_payload(payload, version)
 
 
-def _persist_history() -> None:
+def _persist_history() -> bool:
     """Persist current history to disk (safe to call anywhere)."""
     with HISTORY_LOCK:
+        version = _HISTORY_PUBLISHER.reserve()
         history = []
         for it in list(HISTORY):
             normalized = _persistable_history_item(it)
             if isinstance(normalized, dict):
                 history.append(normalized)
         payload = {"history": history, "saved_at": int(time.time())}
-    _persist_history_payload(payload)
+    return _persist_history_payload(payload, version)
 
 def _history_add(entry: dict) -> None:
     with HISTORY_LOCK:
@@ -640,23 +802,19 @@ def persist_queue_payload(payload: dict) -> None:
 def persist_history_payload(payload: dict) -> None:
     return _persist_history_payload(payload)
 
-def persist_queue() -> None:
+def persist_queue() -> bool:
     return _persist_queue()
 
-def persist_history() -> None:
+def persist_history() -> bool:
     return _persist_history()
 
 
 def set_session_state(val: str) -> None:
-    global SESSION_STATE
-    SESSION_STATE = val
-    persist_session()
+    update_session(session_state=val)
 
 
 def set_pause_reason(reason: str | None) -> None:
-    global SESSION_PAUSE_REASON
-    SESSION_PAUSE_REASON = reason
-    persist_session()
+    update_session(pause_reason=reason)
 
 
 def get_pause_reason() -> str | None:
@@ -664,15 +822,11 @@ def get_pause_reason() -> str | None:
 
 
 def set_session_position(pos: float | None) -> None:
-    global SESSION_POSITION
-    SESSION_POSITION = pos
-    persist_session()
+    update_session(session_position=pos)
 
 
 def set_now_playing(now: dict | None) -> None:
-    global NOW_PLAYING
-    NOW_PLAYING = now
-    persist_session()
+    update_session(now_playing=now)
 
 
 def get_now_playing() -> dict | None:
@@ -1042,10 +1196,11 @@ def load_settings() -> None:
     with SETTINGS_LOCK:
         SETTINGS = defaults
 
-def persist_settings() -> None:
+def persist_settings() -> bool:
     with SETTINGS_LOCK:
+        version = _SETTINGS_PUBLISHER.reserve()
         payload = dict(SETTINGS)
-    _atomic_write_json(_state_path(SETTINGS_STATE_FILE), payload)
+    return _SETTINGS_PUBLISHER.publish(version, payload)
 
 def get_settings() -> dict:
     with SETTINGS_LOCK:

--- a/app/relaytv_app/state.py
+++ b/app/relaytv_app/state.py
@@ -291,6 +291,11 @@ class _Publisher:
                         self._written = version
             return ok
 
+    def superseded(self, version: int) -> bool:
+        """Whether a successful newer snapshot made ``version`` unnecessary."""
+        with self._counter_lock:
+            return version <= self._written
+
 
 _QUEUE_PUBLISHER = _Publisher("queue", lambda: _state_path(QUEUE_STATE_FILE))
 _HISTORY_PUBLISHER = _Publisher("history", lambda: _state_path(HISTORY_STATE_FILE))
@@ -795,9 +800,18 @@ def _load_persisted_session() -> None:
         pass
 
 
-def persist_queue_payload(payload: dict) -> None:
-    """Public wrapper (modules shouldn't rely on underscored helpers)."""
-    return _persist_queue_payload(payload)
+def persist_queue_payload(payload: dict) -> bool:
+    """Persist the current queue, retaining the legacy caller signature.
+
+    Callers historically built ``payload`` under ``QUEUE_LOCK`` and published
+    it later. A newer mutation could land between those steps, after which the
+    stale payload received the newest version and won on disk. Re-snapshotting
+    here couples the version to the current queue under one lock. ``payload``
+    remains accepted so existing internal call sites and companion test hooks
+    do not need an atomic migration.
+    """
+    del payload
+    return _persist_queue()
 
 def persist_history_payload(payload: dict) -> None:
     return _persist_history_payload(payload)
@@ -1340,12 +1354,14 @@ def update_settings(patch: dict) -> dict:
         clean["jellyfin_server_type"] = _normalize_jellyfin_server_type(clean.get("jellyfin_server_type"))
     with SETTINGS_LOCK:
         SETTINGS.update(clean)
+        version = _SETTINGS_PUBLISHER.reserve()
         payload = dict(SETTINGS)
-    try:
-        _atomic_write_json(_state_path(SETTINGS_STATE_FILE), payload)
-    except Exception:
-        pass
-    return payload
+    published = _SETTINGS_PUBLISHER.publish(version, payload)
+    if not published and not _SETTINGS_PUBLISHER.superseded(version):
+        raise RuntimeError("settings persistence failed")
+    # A newer concurrent update may have superseded this response as well as
+    # its disk write. Return the state that actually owns memory and disk.
+    return get_settings() if not published else payload
 
 def _load_runtime_state() -> None:
     """Load startup state in a deterministic order."""

--- a/docs/TRANSITION_INVENTORY.md
+++ b/docs/TRANSITION_INVENTORY.md
@@ -94,9 +94,9 @@ The five Phase 3 review scenarios and where they are guarded at phase start:
 | Transition global | Writers outside `state.py` (write sites) |
 | --- | --- |
 | `AUTO_NEXT_SUPPRESS_UNTIL` | `playback_service.py` (2) |
-| `NOW_PLAYING` | `playback_service.py` (6)<br>`player.py` (9)<br>`routes/__init__.py` (1) |
+| `NOW_PLAYING` | `playback_service.py` (6)<br>`player.py` (8)<br>`routes/__init__.py` (1) |
 | `QUEUE` | `integrations/jellyfin_service.py` (4)<br>`playback_service.py` (7)<br>`player.py` (5)<br>`routes/queue.py` (6)<br>`routes/uploads.py` (1)<br>`upload_store.py` (1) |
-| `SESSION_POSITION` | `playback_service.py` (7)<br>`player.py` (8) |
-| `SESSION_STATE` | `playback_service.py` (3)<br>`player.py` (11)<br>`routes/__init__.py` (4) |
+| `SESSION_POSITION` | `playback_service.py` (7)<br>`player.py` (7) |
+| `SESSION_STATE` | `playback_service.py` (3)<br>`player.py` (10)<br>`routes/__init__.py` (4) |
 | `_TEMP_PLAYBACK_STACK` | `playback_service.py` (8)<br>`routes/__init__.py` (2)<br>`routes/playback.py` (2) |
 <!-- END GENERATED TRANSITION TABLE -->

--- a/docs/TRANSITION_INVENTORY.md
+++ b/docs/TRANSITION_INVENTORY.md
@@ -94,9 +94,9 @@ The five Phase 3 review scenarios and where they are guarded at phase start:
 | Transition global | Writers outside `state.py` (write sites) |
 | --- | --- |
 | `AUTO_NEXT_SUPPRESS_UNTIL` | `playback_service.py` (2) |
-| `NOW_PLAYING` | `playback_service.py` (11)<br>`player.py` (9)<br>`routes/__init__.py` (1) |
+| `NOW_PLAYING` | `playback_service.py` (6)<br>`player.py` (9)<br>`routes/__init__.py` (1) |
 | `QUEUE` | `integrations/jellyfin_service.py` (4)<br>`playback_service.py` (7)<br>`player.py` (5)<br>`routes/queue.py` (6)<br>`routes/uploads.py` (1)<br>`upload_store.py` (1) |
-| `SESSION_POSITION` | `playback_service.py` (8)<br>`player.py` (8) |
-| `SESSION_STATE` | `playback_service.py` (10)<br>`player.py` (11)<br>`routes/__init__.py` (4) |
+| `SESSION_POSITION` | `playback_service.py` (7)<br>`player.py` (8) |
+| `SESSION_STATE` | `playback_service.py` (3)<br>`player.py` (11)<br>`routes/__init__.py` (4) |
 | `_TEMP_PLAYBACK_STACK` | `playback_service.py` (8)<br>`routes/__init__.py` (2)<br>`routes/playback.py` (2) |
 <!-- END GENERATED TRANSITION TABLE -->

--- a/tests/test_playback_routes.py
+++ b/tests/test_playback_routes.py
@@ -448,18 +448,23 @@ def test_clear_now_playing_route_advances_queue_and_discards_temporary_state(mon
 
 
 def test_clear_resumable_session_route_stops_and_clears_state(monkeypatch) -> None:
-    now_values: list[object] = []
-    session_positions: list[object] = []
-    session_states: list[str] = []
     stop_calls: list[bool] = []
     persist_calls: list[bool] = []
+    session_writes: list[dict] = []
 
     monkeypatch.setattr(routes.state, "NOW_PLAYING", {"url": "https://example.com/current.mp4"}, raising=False)
-    monkeypatch.setattr(routes.state, "set_now_playing", lambda value: now_values.append(value) or setattr(routes.state, "NOW_PLAYING", value))
-    monkeypatch.setattr(routes.state, "set_session_position", lambda value: session_positions.append(value))
-    monkeypatch.setattr(routes.state, "set_session_state", lambda value: session_states.append(value) or setattr(routes.state, "SESSION_STATE", value))
+    monkeypatch.setattr(routes.state, "SESSION_STATE", "playing", raising=False)
+    monkeypatch.setattr(routes.state, "SESSION_POSITION", 42.0, raising=False)
     monkeypatch.setattr(routes.state, "persist_queue", lambda: persist_calls.append(True))
     monkeypatch.setattr(routes.player, "stop_mpv", lambda *args, **kwargs: stop_calls.append(True))
+    # Record the durable writes without performing them. Asserting on the
+    # session's resulting state rather than on which setters were called keeps
+    # this honest about the outcome, which is what the route promises.
+    monkeypatch.setattr(
+        routes.state,
+        "_persist_session_payload",
+        lambda payload, version=None: session_writes.append(payload) or True,
+    )
 
     client = TestClient(create_app(testing=True))
     response = client.post("/resume/clear")
@@ -467,9 +472,14 @@ def test_clear_resumable_session_route_stops_and_clears_state(monkeypatch) -> No
     assert response.status_code == 200
     assert response.json() == {"status": "cleared", "resume_available": False}
     assert stop_calls == [True]
-    assert now_values == [None]
-    assert session_positions == [None]
-    assert session_states == ["idle"]
+    assert routes.state.NOW_PLAYING is None
+    assert routes.state.SESSION_POSITION is None
+    assert routes.state.SESSION_STATE == "idle"
+    # Cleared as one mutation, so no intermediate combination is ever written.
+    assert len(session_writes) == 1
+    assert session_writes[0]["now_playing"] is None
+    assert session_writes[0]["session_position"] is None
+    assert session_writes[0]["session_state"] == "idle"
     assert persist_calls == [True]
 
 

--- a/tests/test_queue_history_routes.py
+++ b/tests/test_queue_history_routes.py
@@ -88,6 +88,29 @@ def test_queue_remove_move_dedupe_and_clear(monkeypatch) -> None:
     assert prime_calls == [True, True, True, True]
 
 
+def test_queue_routes_publish_only_after_releasing_queue_lock(monkeypatch) -> None:
+    client, _, _ = _client_with_queue_patches(monkeypatch)
+    observed: list[bool] = []
+
+    def _persist(_payload):
+        acquired = routes.state.QUEUE_LOCK.acquire(blocking=False)
+        observed.append(acquired)
+        if acquired:
+            routes.state.QUEUE_LOCK.release()
+
+    monkeypatch.setattr(routes.state, "persist_queue_payload", _persist)
+    routes.state.QUEUE[:] = [
+        {"url": "https://example.com/a.mp4", "title": "A"},
+        {"url": "https://example.com/b.mp4", "title": "B"},
+    ]
+
+    assert client.post("/queue/move", json={"from_index": 1, "to_index": 0}).status_code == 200
+    routes.state.QUEUE.append({"url": "https://example.com/a.mp4", "title": "duplicate"})
+    assert client.post("/queue/dedupe").status_code == 200
+
+    assert observed == [True, True]
+
+
 def test_queue_and_history_read_shapes(monkeypatch) -> None:
     client, _, _ = _client_with_queue_patches(monkeypatch)
     routes.state.NOW_PLAYING = {"url": "https://example.com/now.mp4", "title": "Now"}

--- a/tests/test_settings_routes.py
+++ b/tests/test_settings_routes.py
@@ -164,7 +164,7 @@ def test_settings_normalize_jellyfin_server_type(monkeypatch) -> None:
     assert state._normalize_jellyfin_server_type(None) == "jellyfin"
     assert state._default_settings()["jellyfin_server_type"] == "jellyfin"
 
-    monkeypatch.setattr(state, "_atomic_write_json", lambda path, payload: None)
+    monkeypatch.setattr(state, "_atomic_write_json", lambda path, payload: True)
     assert state.update_settings({"jellyfin_server_type": " EMBY "})["jellyfin_server_type"] == "emby"
     assert state.update_settings({"jellyfin_server_type": "bogus"})["jellyfin_server_type"] == "jellyfin"
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2784,16 +2784,18 @@ def test_clear_now_playing_advances_queue_when_available(monkeypatch: pytest.Mon
 
 
 def test_clear_now_playing_returns_to_idle_without_preserving_current(monkeypatch: pytest.MonkeyPatch) -> None:
-    now_values: list[object] = []
-    session_values: list[str] = []
+    session_writes: list[dict] = []
     stop_shell_calls: list[bool] = []
     stop_mpv_calls: list[bool] = []
 
     monkeypatch.setattr(routes.state, 'QUEUE', [], raising=False)
     monkeypatch.setattr(routes.state, 'NOW_PLAYING', {'title': 'Current'}, raising=False)
-    monkeypatch.setattr(routes.state, 'set_now_playing', lambda value: now_values.append(value))
-    monkeypatch.setattr(routes.state, 'set_session_position', lambda value: None)
-    monkeypatch.setattr(routes.state, 'set_session_state', lambda value: session_values.append(value))
+    monkeypatch.setattr(routes.state, 'SESSION_STATE', 'playing', raising=False)
+    monkeypatch.setattr(
+        routes.state,
+        '_persist_session_payload',
+        lambda payload, version=None: session_writes.append(payload) or True,
+    )
     monkeypatch.setattr(routes.state, 'persist_queue', lambda: None)
     monkeypatch.setattr(routes.player, '_idle_dashboard_enabled', lambda: True)
     monkeypatch.setattr(routes.player, '_qt_shell_backend_enabled', lambda: True)
@@ -2803,8 +2805,12 @@ def test_clear_now_playing_returns_to_idle_without_preserving_current(monkeypatc
     out = routes.clear_now_playing()
 
     assert out == {'status': 'cleared', 'resume_available': False, 'kept_player_shell': True}
-    assert now_values == [None]
-    assert session_values == ['idle']
+    assert routes.state.NOW_PLAYING is None
+    assert routes.state.SESSION_STATE == 'idle'
+    # One composite write, not one per field.
+    assert len(session_writes) == 1
+    assert session_writes[0]['now_playing'] is None
+    assert session_writes[0]['session_state'] == 'idle'
     assert stop_shell_calls == [True]
     assert stop_mpv_calls == []
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -862,7 +862,7 @@ def test_update_settings_syncs_cec_env_and_stops_monitor(monkeypatch: pytest.Mon
 
 def test_play_item_attempts_cec_takeover_without_probe_gate(monkeypatch: pytest.MonkeyPatch) -> None:
     takeover_calls: list[bool] = []
-    now_values: list[dict] = []
+    session_updates: list[dict[str, object]] = []
 
     monkeypatch.setattr(player, "update_history_progress", lambda *a, **k: None)
     monkeypatch.setattr(player, "_mark_playback_transition", lambda *a, **k: None)
@@ -883,10 +883,7 @@ def test_play_item_attempts_cec_takeover_without_probe_gate(monkeypatch: pytest.
     monkeypatch.setattr(player.state, "get_tv_state", lambda: {"active_source_phys_addr": "2000"})
     monkeypatch.setattr(player, "_our_phys_addr", lambda: "1000")
     monkeypatch.setattr(player.state, "persist_queue", lambda: None)
-    monkeypatch.setattr(player.state, "set_now_playing", lambda value: now_values.append(value))
-    monkeypatch.setattr(player.state, "set_session_state", lambda value: None)
-    monkeypatch.setattr(player.state, "set_pause_reason", lambda value: None)
-    monkeypatch.setattr(player.state, "set_session_position", lambda value: None)
+    monkeypatch.setattr(player.state, "update_session", lambda **values: session_updates.append(values) or True)
 
     result = player.play_item(
         {"url": "https://example.test/video", "title": "Example"},
@@ -898,7 +895,14 @@ def test_play_item_attempts_cec_takeover_without_probe_gate(monkeypatch: pytest.
 
     assert takeover_calls == [True]
     assert result["url"] == "https://example.test/video"
-    assert now_values
+    assert session_updates == [
+        {
+            "now_playing": result,
+            "session_state": "playing",
+            "pause_reason": None,
+            "session_position": 0.0,
+        }
+    ]
 
 
 def test_public_install_docs_offer_latest_without_full_image_variant() -> None:
@@ -4859,7 +4863,7 @@ def test_session_tracker_does_not_reopen_closed_session(monkeypatch: pytest.Monk
 
 def test_play_item_reuses_fresh_resolved_stream_without_ytdlp(monkeypatch: pytest.MonkeyPatch) -> None:
     start_calls: list[dict[str, object]] = []
-    now_values: list[dict] = []
+    session_updates: list[dict[str, object]] = []
     events: list[object] = []
 
     monkeypatch.setattr(player, 'update_history_progress', lambda *a, **k: None)
@@ -4887,10 +4891,7 @@ def test_play_item_reuses_fresh_resolved_stream_without_ytdlp(monkeypatch: pytes
     monkeypatch.setattr(player, '_prime_mpv_up_next_from_queue', lambda force=False: False)
     monkeypatch.setattr(player.state, 'NOW_PLAYING', None, raising=False)
     monkeypatch.setattr(player.state, 'get_tv_state', lambda: {})
-    monkeypatch.setattr(player.state, 'set_now_playing', lambda value: now_values.append(value))
-    monkeypatch.setattr(player.state, 'set_session_state', lambda value: None)
-    monkeypatch.setattr(player.state, 'set_pause_reason', lambda value: None)
-    monkeypatch.setattr(player.state, 'set_session_position', lambda value: None)
+    monkeypatch.setattr(player.state, 'update_session', lambda **values: session_updates.append(values) or True)
     monkeypatch.setattr(player, 'resolve_streams', lambda url: (_ for _ in ()).throw(AssertionError('yt-dlp should not run')))
     monkeypatch.setattr(player.time, 'time', lambda: 1000.0)
     monkeypatch.setattr(
@@ -4921,7 +4922,11 @@ def test_play_item_reuses_fresh_resolved_stream_without_ytdlp(monkeypatch: pytes
     assert start_calls == [{'stream': 'https://video.example/resolved.mp4', 'audio': 'https://audio.example/resolved.m4a', 'start_pos': 42.5}]
     assert now['stream'] == 'https://video.example/resolved.mp4'
     assert now['_resolved_stream'] == 'https://video.example/resolved.mp4'
-    assert now_values[-1]['_resolved_at'] == 999.0
+    assert len(session_updates) == 1
+    assert session_updates[0]['now_playing']['_resolved_at'] == 999.0
+    assert session_updates[0]['session_state'] == 'playing'
+    assert session_updates[0]['pause_reason'] is None
+    assert session_updates[0]['session_position'] == 42.5
     assert events[0] == ('sleep', pytest.approx(4.2))
     assert events[1] == 'load'
     assert events[-1] == 'start'

--- a/tests/test_state_publication.py
+++ b/tests/test_state_publication.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Durable state must land in order, and failures must be visible (F04).
+
+Payloads are built under a store lock and written outside it, so two mutations
+could reach the disk out of order: the older writer won the race to os.replace
+and the newer mutation was lost, reappearing missing after a restart. Separately,
+_atomic_write_json swallowed every failure into a log line, so a full or
+read-only disk produced a successful API response.
+"""
+import json
+import os
+import threading
+
+import pytest
+
+from relaytv_app import state
+
+
+@pytest.fixture
+def state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "STATE_DIR", str(tmp_path), raising=False)
+    state.reset_persistence_health_for_tests()
+    yield tmp_path
+    state.reset_persistence_health_for_tests()
+
+
+def _read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+# --- ordering ----------------------------------------------------------------
+
+
+def test_an_older_snapshot_cannot_replace_a_newer_one(state_dir) -> None:
+    """Reverse the completion order deterministically and check what survives."""
+    publisher = state._Publisher("demo", lambda: os.path.join(str(state_dir), "demo.json"))
+
+    older = publisher.reserve()
+    newer = publisher.reserve()
+
+    # The newer mutation completes its write first.
+    assert publisher.publish(newer, {"value": "newer"}) is True
+    # The older one then finishes. Without versioning it would win, because
+    # os.replace is last-write-wins.
+    assert publisher.publish(older, {"value": "older"}) is False
+
+    assert _read(os.path.join(str(state_dir), "demo.json")) == {"value": "newer"}
+
+
+def test_writes_still_apply_in_forward_order(state_dir) -> None:
+    publisher = state._Publisher("demo", lambda: os.path.join(str(state_dir), "demo.json"))
+
+    first = publisher.reserve()
+    assert publisher.publish(first, {"value": "first"}) is True
+    second = publisher.reserve()
+    assert publisher.publish(second, {"value": "second"}) is True
+
+    assert _read(os.path.join(str(state_dir), "demo.json")) == {"value": "second"}
+
+
+def test_concurrent_publishers_leave_the_newest_on_disk(state_dir) -> None:
+    publisher = state._Publisher("demo", lambda: os.path.join(str(state_dir), "demo.json"))
+    release_older = threading.Event()
+    versions = [publisher.reserve() for _ in range(2)]
+
+    def _older():
+        release_older.wait(5.0)
+        publisher.publish(versions[0], {"value": "older"})
+
+    thread = threading.Thread(target=_older, daemon=True)
+    thread.start()
+    publisher.publish(versions[1], {"value": "newer"})
+    release_older.set()
+    thread.join(timeout=5.0)
+
+    assert _read(os.path.join(str(state_dir), "demo.json")) == {"value": "newer"}
+
+
+def test_queue_and_history_do_not_share_a_version_line(state_dir) -> None:
+    """Independent coordinators: a queue write must not suppress a history one."""
+    assert state._QUEUE_PUBLISHER is not state._HISTORY_PUBLISHER
+    assert state._SESSION_PUBLISHER is not state._SETTINGS_PUBLISHER
+
+    for _ in range(5):
+        state._QUEUE_PUBLISHER.reserve()
+
+    assert state.persist_history() is True
+    assert os.path.exists(os.path.join(str(state_dir), state.HISTORY_STATE_FILE))
+
+
+# --- composite session mutation ----------------------------------------------
+
+
+def test_composite_session_change_persists_once(state_dir, monkeypatch) -> None:
+    writes: list[dict] = []
+    monkeypatch.setattr(
+        state, "_persist_session_payload", lambda payload, version=None: writes.append(payload) or True
+    )
+
+    state.update_session(
+        now_playing={"title": "x"}, session_state="playing", pause_reason=None
+    )
+
+    assert len(writes) == 1
+    assert writes[0]["now_playing"] == {"title": "x"}
+    assert writes[0]["session_state"] == "playing"
+
+
+def test_no_intermediate_combination_is_ever_written(state_dir, monkeypatch) -> None:
+    """The three-setter form wrote now_playing while the state still said idle."""
+    writes: list[dict] = []
+    monkeypatch.setattr(
+        state, "_persist_session_payload", lambda payload, version=None: writes.append(payload) or True
+    )
+    monkeypatch.setattr(state, "SESSION_STATE", "idle", raising=False)
+    monkeypatch.setattr(state, "NOW_PLAYING", None, raising=False)
+
+    state.update_session(now_playing={"title": "x"}, session_state="playing")
+
+    for payload in writes:
+        incoherent = payload["now_playing"] is not None and payload["session_state"] == "idle"
+        assert not incoherent, f"persisted an intermediate combination: {payload}"
+
+
+def test_individual_setters_still_work(state_dir, monkeypatch) -> None:
+    monkeypatch.setattr(state, "_persist_session_payload", lambda payload, version=None: True)
+
+    state.set_session_state("paused")
+    state.set_pause_reason("user")
+    state.set_session_position(12.5)
+    state.set_now_playing({"title": "y"})
+
+    assert state.SESSION_STATE == "paused"
+    assert state.SESSION_PAUSE_REASON == "user"
+    assert state.SESSION_POSITION == 12.5
+    assert state.NOW_PLAYING == {"title": "y"}
+
+
+def test_update_session_can_skip_persistence(state_dir, monkeypatch) -> None:
+    writes: list[dict] = []
+    monkeypatch.setattr(
+        state, "_persist_session_payload", lambda payload, version=None: writes.append(payload) or True
+    )
+
+    state.update_session(session_state="playing", persist=False)
+
+    assert state.SESSION_STATE == "playing"
+    assert writes == []
+
+
+# --- failure is observable ---------------------------------------------------
+
+
+def test_write_failure_is_reported_not_swallowed(state_dir, monkeypatch) -> None:
+    def _boom(*args, **kwargs):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(state.os, "replace", _boom)
+
+    assert state.persist_settings() is False
+
+    health = state.persistence_health()
+    assert health["ok"] is False
+    assert state.SETTINGS_STATE_FILE in health["failing"]
+    assert "No space left" in health["failing"][state.SETTINGS_STATE_FILE]["last_error"]
+
+
+def test_health_recovers_after_a_successful_write(state_dir, monkeypatch) -> None:
+    real_replace = state.os.replace
+    failing = {"on": True}
+
+    def _maybe_boom(src, dst):
+        if failing["on"]:
+            raise OSError(28, "No space left on device")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(state.os, "replace", _maybe_boom)
+    assert state.persist_settings() is False
+    assert state.persistence_health()["ok"] is False
+
+    failing["on"] = False
+    assert state.persist_settings() is True
+    assert state.persistence_health()["ok"] is True
+
+
+def test_health_is_clean_by_default(state_dir) -> None:
+    assert state.persistence_health() == {"ok": True, "failing": {}}
+
+
+def test_persist_helpers_report_success(state_dir) -> None:
+    assert state.persist_queue() is True
+    assert state.persist_history() is True
+    assert state.persist_session() is True
+    assert state.persist_settings() is True
+
+
+# --- no state lock is held across disk I/O -----------------------------------
+
+
+def test_queue_lock_is_not_held_while_writing(state_dir, monkeypatch) -> None:
+    """A slow disk must not block every reader of the queue."""
+    observed: list[bool] = []
+    real_write = state._atomic_write_json
+
+    def _slow_write(path, obj):
+        # If the queue lock were still held, this would deadlock rather than
+        # report False.
+        observed.append(state.QUEUE_LOCK.acquire(blocking=False))
+        if observed[-1]:
+            state.QUEUE_LOCK.release()
+        return real_write(path, obj)
+
+    monkeypatch.setattr(state, "_atomic_write_json", _slow_write)
+
+    state.persist_queue()
+
+    assert observed == [True], "QUEUE_LOCK was held across the disk write"
+
+
+def test_status_reports_a_failing_disk(state_dir, monkeypatch) -> None:
+    """The failure has to reach somewhere an operator will actually look."""
+    from fastapi.testclient import TestClient
+
+    from relaytv_app.main import create_app
+
+    client = TestClient(create_app(testing=True))
+    assert "persistence" not in client.get("/status").json()
+
+    def _boom(*args, **kwargs):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(state.os, "replace", _boom)
+    state.persist_settings()
+
+    payload = client.get("/status").json()
+    assert payload["persistence"]["ok"] is False
+    assert state.SETTINGS_STATE_FILE in payload["persistence"]["failing"]

--- a/tests/test_state_publication.py
+++ b/tests/test_state_publication.py
@@ -89,6 +89,53 @@ def test_queue_and_history_do_not_share_a_version_line(state_dir) -> None:
     assert os.path.exists(os.path.join(str(state_dir), state.HISTORY_STATE_FILE))
 
 
+def test_concurrent_settings_updates_leave_the_latest_on_disk(state_dir, monkeypatch) -> None:
+    """Exercise update_settings itself, not only the publisher primitive."""
+    entered = threading.Event()
+    release_older = threading.Event()
+    writes: list[float] = []
+    monkeypatch.setattr(state, "SETTINGS", {"volume": 100.0}, raising=False)
+
+    def _ordered_write(_path, payload):
+        value = float(payload["volume"])
+        if value == 10.0:
+            entered.set()
+            release_older.wait(5.0)
+        writes.append(value)
+        return True
+
+    monkeypatch.setattr(state, "_atomic_write_json", _ordered_write)
+
+    older = threading.Thread(target=state.update_settings, args=({"volume": 10},), daemon=True)
+    newer = threading.Thread(target=state.update_settings, args=({"volume": 20},), daemon=True)
+    older.start()
+    assert entered.wait(1.0), "older settings write never entered persistence"
+    newer.start()
+    for _ in range(100):
+        if state.get_settings().get("volume") == 20.0:
+            break
+        threading.Event().wait(0.01)
+    assert state.get_settings()["volume"] == 20.0
+    release_older.set()
+    older.join(timeout=2.0)
+    newer.join(timeout=2.0)
+
+    assert not older.is_alive() and not newer.is_alive()
+    assert writes[-1] == 20.0, writes
+
+
+def test_stale_queue_payload_cannot_replace_current_queue(state_dir) -> None:
+    newer = {"url": "https://example.com/newer.mp4", "title": "newer"}
+    state.QUEUE = [newer]
+
+    state.persist_queue_payload(
+        {"queue": [{"url": "https://example.com/older.mp4"}], "saved_at": 1}
+    )
+
+    payload = _read(os.path.join(str(state_dir), state.QUEUE_STATE_FILE))
+    assert payload["queue"] == [state._persistable_queue_item(newer)]
+
+
 # --- composite session mutation ----------------------------------------------
 
 
@@ -164,6 +211,13 @@ def test_write_failure_is_reported_not_swallowed(state_dir, monkeypatch) -> None
     assert health["ok"] is False
     assert state.SETTINGS_STATE_FILE in health["failing"]
     assert "No space left" in health["failing"][state.SETTINGS_STATE_FILE]["last_error"]
+
+
+def test_update_settings_does_not_report_success_when_disk_write_fails(state_dir, monkeypatch) -> None:
+    monkeypatch.setattr(state, "_atomic_write_json", lambda *args, **kwargs: False)
+
+    with pytest.raises(RuntimeError, match="settings persistence failed"):
+        state.update_settings({"volume": 42})
 
 
 def test_health_recovers_after_a_successful_write(state_dir, monkeypatch) -> None:


### PR DESCRIPTION
Roadmap PR 6 of 11 — closes **F04**. See #67. Lands before PR 7 on purpose: F01's ownership checks attach to the session publish point this consolidates.

## Writes could land out of order

Payloads are built under a store lock and written *outside* it, so two mutations could reach the disk in either order — and `os.replace` is last-write-wins. The older writer could win, losing the newer mutation, which then reappeared missing after a restart.

Each store now has its own publisher. A version is reserved while the payload is built, under the store's lock; a write that is no longer the newest is dropped rather than applied.

**The counter and the write mutex are deliberately separate.** `reserve()` is called while a store lock is held, so it must never wait on disk I/O — that's the constraint keeping no state lock held across a write. `test_queue_lock_is_not_held_while_writing` fails by deadlock if that's ever violated.

Four independent publishers, so a busy queue can't suppress a settings write.

## Session fields had no lock, and wrote per field

Each setter mutated a global then persisted the **whole composite payload**. A caller changing three fields wrote three times, and the first two were snapshots of a state that never conceptually existed — `now_playing` set while `session_state` still said `idle`. A restart landing between them restored one of those.

`update_session` applies the fields as one mutation under one lock and persists once. The individual setters delegate to it, so callers outside `playback_service` need no change.

The transition inventory shows the effect directly:

```
- | `NOW_PLAYING`     | playback_service.py (11) ...
+ | `NOW_PLAYING`     | playback_service.py (6)  ...
- | `SESSION_STATE`   | playback_service.py (10) ...
+ | `SESSION_STATE`   | playback_service.py (3)  ...
```

## Disk failure was invisible

`_atomic_write_json` swallowed every failure into a log line, so a full or read-only disk produced a **successful API response** and state that silently reverted on restart.

It returns its outcome now, `persist_*` propagate it, and `persistence_health()` records failures. `/status` carries a `persistence` key **only while writes are failing**, so the payload grows only when something is wrong — additive and safe for companions.

**Deliberately not done:** turning a write failure into a 5xx. The failure is observable to callers and in `/status`, but making every mutation fail on a full disk is a behavior change that doesn't belong inside a concurrency fix. Flagging it rather than smuggling it in.

## Two existing tests changed

`test_clear_resumable_session_route_stops_and_clears_state` and `test_clear_now_playing_returns_to_idle_without_preserving_current` asserted that three specific setters were called — the mechanism this PR replaces, not the behavior. They now assert the session's resulting state *and* that exactly one write happened, which is both what the route promises and a stronger check. Both still fail against the reverted code.

## Testing

| Reverted | Fails |
|---|---|
| version check dropped | 2 ordering tests |
| failure swallowed again | 3 health / `/status` tests |
| per-field setters restored | 2 composite-write tests |

The ordering test reverses completion order deterministically — reserve two versions, publish the newer first, then the older — rather than racing threads and hoping.

Gates: **757 Python tests** (+14), 11 JS tests, ruff clean, `git diff --check` clean. `TRANSITION_INVENTORY.md` regenerated with `--write`.

## Device verification

On the combined branch, both devices:

| Check | LR | Pi |
|---|---|---|
| `state.persistence_health()['ok']` in the running process | `True` | `True` |
| `/status` omits the `persistence` key while writes are landing | pass | pass |

The key is absent unless something is wrong, so a healthy device's payload is unchanged — confirmed on both.

**Still outstanding**: change a setting, restart the container immediately, and confirm the change survived; then the same with a queue mutation.
