### PR TITLE
perf: keep upload ingestion off the event loop

### DIFF
--- a/app/relaytv_app/routes/uploads.py
+++ b/app/relaytv_app/routes/uploads.py
@@ -14,6 +14,28 @@ from ..debug import get_logger
 router = APIRouter()
 logger = get_logger("routes.uploads")
 
+# Ingestion runs on the event loop, so every blocking call here stalls HTTP
+# controls and realtime subscribers for the whole upload. The writes, syncs,
+# metadata, and cleanup scans all move to a worker thread.
+#
+# The per-chunk fsync went further than durability needed: a 4 GiB upload
+# issued roughly 4000 fsyncs *and* 4000 JSON session rewrites, each one a
+# write plus an os.replace. Durable progress is batched instead. The in-memory
+# session stays exact — it drives the progressive-start decision — and the
+# session file is still written immediately on every state change (progressive
+# start, fallback, completion), so restart behavior is unchanged; only the
+# routine progress heartbeat is coarser.
+_DURABLE_SYNC_BYTES = 64 * 1024 * 1024
+_DURABLE_SYNC_SEC = 5.0
+
+
+def _write_chunk(handle, chunk: bytes, *, sync: bool) -> None:
+    """Blocking file write, run off the event loop."""
+    handle.write(chunk)
+    if sync:
+        handle.flush()
+        os.fsync(handle.fileno())
+
 
 @router.get("/media/uploads/{upload_id}/{filename}", name="get_uploaded_media")
 def get_uploaded_media(upload_id: str, filename: str):
@@ -133,7 +155,8 @@ def _enqueue_uploaded_media_url(url: str) -> dict:
 @router.post("/ingest/media")
 async def ingest_media(request: Request, file: UploadFile = File(...), title: str | None = Form(None)):
     settings_snapshot = state.get_settings() if hasattr(state, "get_settings") else {}
-    upload_store.cleanup_uploads(settings_snapshot)
+    # Scans and stats the whole upload tree; not something to do on the loop.
+    await run_in_threadpool(upload_store.cleanup_uploads, settings_snapshot)
     filename = str(getattr(file, "filename", "") or "").strip()
     content_type = str(getattr(file, "content_type", "") or "").split(";", 1)[0].strip().lower()
     if not upload_store.is_allowed_upload(content_type, filename):
@@ -146,8 +169,10 @@ async def ingest_media(request: Request, file: UploadFile = File(...), title: st
     upload_id = upload_store.new_upload_id()
     public_name = upload_store.sanitize_upload_filename(filename, content_type=content_type)
     target_dir = upload_store.upload_dir(upload_id)
-    os.makedirs(target_dir, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(prefix="relaytv-upload-", suffix=".part", dir=target_dir)
+    await run_in_threadpool(os.makedirs, target_dir, 0o777, True)
+    fd, tmp_path = await run_in_threadpool(
+        tempfile.mkstemp, "relaytv-upload-", ".part", target_dir
+    )
     os.close(fd)
     final_path = os.path.join(target_dir, public_name)
     size_bytes = 0
@@ -160,12 +185,13 @@ async def ingest_media(request: Request, file: UploadFile = File(...), title: st
                 size_bytes += len(chunk)
                 if size_bytes > max_bytes:
                     raise HTTPException(status_code=413, detail="Uploaded media exceeds configured storage size limit")
-                out.write(chunk)
-            out.flush()
-            os.fsync(out.fileno())
+                await run_in_threadpool(_write_chunk, out, chunk, sync=False)
+            # One sync at the end: the file is not readable by anything until
+            # the os.replace below publishes it.
+            await run_in_threadpool(_write_chunk, out, b"", sync=True)
         if size_bytes <= 0:
             raise HTTPException(status_code=400, detail="Uploaded media is empty")
-        os.replace(tmp_path, final_path)
+        await run_in_threadpool(os.replace, tmp_path, final_path)
         media_title = str(title or "").strip() or os.path.basename(filename or public_name) or public_name
         meta = {
             "id": upload_id,
@@ -177,10 +203,10 @@ async def ingest_media(request: Request, file: UploadFile = File(...), title: st
             "size_bytes": int(size_bytes),
             "created_unix": float(time.time()),
         }
-        upload_store.write_metadata(upload_id, meta)
+        await run_in_threadpool(upload_store.write_metadata, upload_id, meta)
         media_url = str(request.url_for("get_uploaded_media", upload_id=upload_id, filename=public_name))
         item = upload_store.build_item(meta, absolute_url=media_url)
-        cleanup_result = upload_store.cleanup_uploads(settings_snapshot)
+        cleanup_result = await run_in_threadpool(upload_store.cleanup_uploads, settings_snapshot)
         return {
             "ok": True,
             "media_id": upload_id,
@@ -221,7 +247,8 @@ async def ingest_media_enqueue(request: Request, file: UploadFile = File(...), t
 @router.post("/ingest/media/play")
 async def ingest_media_play(request: Request, file: UploadFile = File(...), title: str | None = Form(None)):
     settings_snapshot = state.get_settings() if hasattr(state, "get_settings") else {}
-    upload_store.cleanup_uploads(settings_snapshot)
+    # Scans and stats the whole upload tree; not something to do on the loop.
+    await run_in_threadpool(upload_store.cleanup_uploads, settings_snapshot)
     filename = str(getattr(file, "filename", "") or "").strip()
     content_type = str(getattr(file, "content_type", "") or "").split(";", 1)[0].strip().lower()
     if not upload_store.is_allowed_upload(content_type, filename):
@@ -242,11 +269,11 @@ async def ingest_media_play(request: Request, file: UploadFile = File(...), titl
         content_type=content_type,
         size_bytes=0,
     )
-    upload_store.write_metadata(upload_id, meta)
+    await run_in_threadpool(upload_store.write_metadata, upload_id, meta)
 
     media_url = str(request.url_for("get_uploaded_media", upload_id=upload_id, filename=public_name))
     target_dir = upload_store.upload_dir(upload_id)
-    os.makedirs(target_dir, exist_ok=True)
+    await run_in_threadpool(os.makedirs, target_dir, 0o777, True)
     final_path = os.path.join(target_dir, public_name)
     size_bytes = 0
     progressive_started = False
@@ -257,7 +284,9 @@ async def ingest_media_play(request: Request, file: UploadFile = File(...), titl
     stored_ok = False
     session = upload_store.new_play_session(meta)
     session["path"] = final_path
-    upload_store.write_session(upload_id, session)
+    await run_in_threadpool(upload_store.write_session, upload_id, session)
+    synced_bytes = 0
+    synced_at = time.monotonic()
     try:
         with open(final_path, "wb") as out:
             while True:
@@ -269,9 +298,16 @@ async def ingest_media_play(request: Request, file: UploadFile = File(...), titl
                 size_bytes += len(chunk)
                 if size_bytes > max_bytes:
                     raise HTTPException(status_code=413, detail="Uploaded media exceeds configured storage size limit")
-                out.write(chunk)
-                out.flush()
-                os.fsync(out.fileno())
+                # Progressive playback reads this file while it is being
+                # written, so the bytes must reach the filesystem every chunk.
+                # Forcing them all the way to the platter every chunk is what
+                # was expensive, and is not what the reader needs.
+                now_mono = time.monotonic()
+                due = (
+                    size_bytes - synced_bytes >= _DURABLE_SYNC_BYTES
+                    or now_mono - synced_at >= _DURABLE_SYNC_SEC
+                )
+                await run_in_threadpool(_write_chunk, out, chunk, sync=due)
 
                 session = upload_store.mark_session_progress(
                     session,
@@ -281,7 +317,12 @@ async def ingest_media_play(request: Request, file: UploadFile = File(...), titl
                     chunk_finished_unix=chunk_finished,
                     path=final_path,
                 )
-                upload_store.write_session(upload_id, session)
+                if due:
+                    # The in-memory session is exact either way; this is the
+                    # durable heartbeat, and it rides along with the sync.
+                    synced_bytes = size_bytes
+                    synced_at = now_mono
+                    await run_in_threadpool(upload_store.write_session, upload_id, session)
 
                 if progressive_started or session.get("fallback_to_full_upload") is True:
                     continue
@@ -295,29 +336,30 @@ async def ingest_media_play(request: Request, file: UploadFile = File(...), titl
                         progressive_started = True
                         playback_mode = "progressive"
                         session = upload_store.mark_session_progressive_started(session)
-                        upload_store.write_session(upload_id, session)
+                        await run_in_threadpool(upload_store.write_session, upload_id, session)
                     except Exception as exc:
                         logger.warning("progressive_upload_start_failed id=%s error=%s", upload_id, exc)
                         fallback_reason = "start_failed"
                         session = upload_store.mark_session_fallback(session, fallback_reason)
-                        upload_store.write_session(upload_id, session)
+                        await run_in_threadpool(upload_store.write_session, upload_id, session)
                 elif reason not in ("buffering", "warming_up", "waiting_for_upload"):
                     fallback_reason = str(reason or "").strip() or "fallback_full_upload"
                     session = upload_store.mark_session_fallback(session, fallback_reason)
-                    upload_store.write_session(upload_id, session)
+                    await run_in_threadpool(upload_store.write_session, upload_id, session)
                     _progressive_fallback_toast()
                     fallback_toast_sent = True
 
-            out.flush()
-            os.fsync(out.fileno())
+            # Final durable sync: the file is complete and playback may still
+            # be reading it.
+            await run_in_threadpool(_write_chunk, out, b"", sync=True)
 
         if size_bytes <= 0:
             raise HTTPException(status_code=400, detail="Uploaded media is empty")
 
         meta["size_bytes"] = int(size_bytes)
-        upload_store.write_metadata(upload_id, meta)
+        await run_in_threadpool(upload_store.write_metadata, upload_id, meta)
         session = upload_store.mark_session_complete(session)
-        upload_store.write_session(upload_id, session)
+        await run_in_threadpool(upload_store.write_session, upload_id, session)
 
         item = upload_store.build_item(meta, absolute_url=media_url)
         if not progressive_started:
@@ -328,9 +370,9 @@ async def ingest_media_play(request: Request, file: UploadFile = File(...), titl
             now_playing = await _play_uploaded_item(item, mode="ingest_media_play")
             playback_mode = "full_upload"
             session = upload_store.mark_session_completed_playback(session, mode=playback_mode)
-            upload_store.write_session(upload_id, session)
+            await run_in_threadpool(upload_store.write_session, upload_id, session)
 
-        cleanup_result = upload_store.cleanup_uploads(settings_snapshot)
+        cleanup_result = await run_in_threadpool(upload_store.cleanup_uploads, settings_snapshot)
         stored_ok = True
         return {
             "ok": True,
@@ -355,6 +397,6 @@ async def ingest_media_play(request: Request, file: UploadFile = File(...), titl
             pass
         if not stored_ok:
             try:
-                upload_store.delete_upload(upload_id)
+                await run_in_threadpool(upload_store.delete_upload, upload_id)
             except Exception:
                 pass

--- a/tests/test_upload_responsiveness.py
+++ b/tests/test_upload_responsiveness.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Upload ingestion must not stall the event loop (F08).
+
+Both ingest handlers ran their file writes, fsyncs, JSON session writes, and
+cleanup scans directly on the loop. A 4 GiB upload issued roughly 4000 fsyncs
+and 4000 session rewrites there, so HTTP controls and realtime subscribers
+stopped making progress for the duration.
+"""
+import asyncio
+import inspect
+import os
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from relaytv_app import upload_store
+from relaytv_app.main import create_app
+from relaytv_app.routes import uploads
+
+
+@pytest.fixture
+def uploads_root(tmp_path, monkeypatch):
+    root = tmp_path / "uploads"
+    root.mkdir()
+    monkeypatch.setattr(upload_store, "_UPLOADS_ROOT", str(root))
+    return root
+
+
+# --- the loop stays free -----------------------------------------------------
+
+
+def test_no_blocking_io_remains_on_the_event_loop() -> None:
+    """Every disk call in an async handler must go through the threadpool."""
+    offenders: list[str] = []
+    for name in ("ingest_media", "ingest_media_play", "ingest_media_enqueue"):
+        handler = getattr(uploads, name)
+        if not inspect.iscoroutinefunction(handler):
+            continue
+        source = inspect.getsource(handler)
+        for line in source.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#") or "run_in_threadpool" in stripped:
+                continue
+            for call in (
+                "os.fsync(",
+                "os.makedirs(",
+                "os.replace(",
+                "upload_store.write_session(",
+                "upload_store.write_metadata(",
+                "upload_store.cleanup_uploads(",
+                "upload_store.delete_upload(",
+            ):
+                if call in stripped:
+                    offenders.append(f"{name}: {stripped}")
+    assert not offenders, offenders
+
+
+@pytest.mark.anyio
+async def test_health_stays_responsive_while_the_disk_is_slow(uploads_root, monkeypatch) -> None:
+    """Run a real upload against a deliberately slow disk and poll /health.
+
+    The write is made genuinely blocking (time.sleep, not asyncio.sleep), so
+    this fails by timing out if the write ever runs on the event loop again.
+    """
+    import httpx
+
+    real_write = uploads._write_chunk
+
+    def _slow_write(handle, chunk, *, sync):
+        time.sleep(0.15)
+        return real_write(handle, chunk, sync=sync)
+
+    monkeypatch.setattr(uploads, "_write_chunk", _slow_write)
+
+    app = create_app(testing=True)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://tv.local") as client:
+        # 6 MiB in 1 MiB chunks: ~0.9s of blocking disk time.
+        upload = asyncio.create_task(
+            client.post(
+                "/ingest/media",
+                files={"file": ("clip.mp4", b"q" * (6 * 1024 * 1024), "video/mp4")},
+                data={"title": "Clip"},
+            )
+        )
+        await asyncio.sleep(0.2)
+
+        health_latencies: list[float] = []
+        for _ in range(5):
+            started = time.monotonic()
+            response = await asyncio.wait_for(client.get("/health"), timeout=2.0)
+            health_latencies.append(time.monotonic() - started)
+            assert response.status_code == 200
+            await asyncio.sleep(0.05)
+
+        result = await asyncio.wait_for(upload, timeout=30.0)
+
+    assert result.status_code == 200, result.text
+    # Each health check must return promptly; a blocked loop would make these
+    # wait out the whole upload.
+    assert max(health_latencies) < 0.15, health_latencies
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# --- durability policy -------------------------------------------------------
+
+
+def test_sync_cadence_is_batched_not_per_chunk() -> None:
+    assert uploads._DURABLE_SYNC_BYTES >= 8 * 1024 * 1024
+    assert uploads._DURABLE_SYNC_SEC >= 1.0
+
+
+def test_write_chunk_only_syncs_when_asked(tmp_path) -> None:
+    synced: list[int] = []
+    real_fsync = os.fsync
+    path = tmp_path / "f.bin"
+
+    def _counting_fsync(fd):
+        synced.append(fd)
+        return real_fsync(fd)
+
+    with open(path, "wb") as handle:
+        uploads.os.fsync = _counting_fsync
+        try:
+            uploads._write_chunk(handle, b"abc", sync=False)
+            assert synced == []
+            uploads._write_chunk(handle, b"def", sync=True)
+            assert len(synced) == 1
+        finally:
+            uploads.os.fsync = real_fsync
+
+    assert path.read_bytes() == b"abcdef"
+
+
+def test_empty_final_chunk_still_syncs(tmp_path) -> None:
+    """The end-of-upload sync is written as a zero-length flush."""
+    synced: list[int] = []
+    real_fsync = os.fsync
+
+    with open(tmp_path / "f.bin", "wb") as handle:
+        uploads.os.fsync = lambda fd: synced.append(fd) or real_fsync(fd)
+        try:
+            uploads._write_chunk(handle, b"", sync=True)
+        finally:
+            uploads.os.fsync = real_fsync
+
+    assert len(synced) == 1
+
+
+# --- behavior preserved ------------------------------------------------------
+
+
+def _upload(client, payload: bytes, endpoint: str = "/ingest/media"):
+    return client.post(
+        endpoint,
+        files={"file": ("clip.mp4", payload, "video/mp4")},
+        data={"title": "Clip"},
+    )
+
+
+def test_upload_still_stores_the_file(uploads_root) -> None:
+    client = TestClient(create_app(testing=True))
+    payload = b"\x00\x01" * 4096
+
+    response = _upload(client, payload)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    served = client.get(body["url"].replace("http://testserver", ""))
+    assert served.status_code == 200
+    assert served.content == payload
+
+
+def test_size_limit_is_still_enforced(uploads_root, monkeypatch) -> None:
+    monkeypatch.setattr(upload_store, "max_upload_bytes", lambda settings: 1024)
+    client = TestClient(create_app(testing=True))
+
+    response = _upload(client, b"x" * 4096)
+
+    assert response.status_code == 413
+
+
+def test_partial_file_is_removed_when_the_upload_fails(uploads_root, monkeypatch) -> None:
+    monkeypatch.setattr(upload_store, "max_upload_bytes", lambda settings: 1024)
+    client = TestClient(create_app(testing=True))
+
+    _upload(client, b"x" * 4096)
+
+    leftovers = [p for p in uploads_root.rglob("*.part")]
+    assert leftovers == [], leftovers
+
+
+def test_empty_upload_is_rejected(uploads_root) -> None:
+    client = TestClient(create_app(testing=True))
+    assert _upload(client, b"").status_code == 400
+
+
+def test_unsupported_type_is_rejected(uploads_root) -> None:
+    client = TestClient(create_app(testing=True))
+    response = client.post(
+        "/ingest/media",
+        files={"file": ("x.txt", b"hello", "text/plain")},
+        data={"title": "x"},
+    )
+    assert response.status_code == 400
+
+
+def test_large_upload_does_not_sync_per_chunk(uploads_root, monkeypatch) -> None:
+    """The cost this PR removes, measured rather than asserted in prose."""
+    syncs: list[int] = []
+    real = uploads._write_chunk
+
+    def _counting(handle, chunk, *, sync):
+        if sync:
+            syncs.append(len(chunk))
+        return real(handle, chunk, sync=sync)
+
+    monkeypatch.setattr(uploads, "_write_chunk", _counting)
+    client = TestClient(create_app(testing=True))
+
+    # 8 MiB in 1 MiB chunks: eight chunks, well under the batch threshold.
+    _upload(client, b"z" * (8 * 1024 * 1024))
+
+    # Only the final flush syncs, instead of one sync per chunk.
+    assert len(syncs) == 1, f"expected a single durable sync, got {len(syncs)}"
+
+
+def test_progressive_session_still_written_on_state_changes() -> None:
+    """Batching the heartbeat must not batch the state transitions."""
+    source = inspect.getsource(uploads.ingest_media_play)
+    # Each transition writes the session immediately, off the loop.
+    for marker in (
+        "mark_session_progressive_started",
+        "mark_session_fallback",
+        "mark_session_complete",
+    ):
+        index = source.index(marker)
+        following = source[index : index + 400]
+        assert "write_session" in following, f"{marker} does not persist immediately"


### PR DESCRIPTION
Roadmap PR 8 of 11 — closes **F08**. See #67.

## The cost

Both ingest handlers ran their file writes, `fsync`s, JSON session writes, metadata writes, and cleanup scans **directly on the event loop**. A 4 GiB upload issued roughly **4000 fsyncs and 4000 session rewrites** there — each rewrite a JSON dump plus an `os.replace`. HTTP controls and realtime subscribers stopped making progress for the duration.

Every blocking call now goes through `run_in_threadpool`, which the module already used for playback handoff.

## Batching, and what stays immediate

The per-chunk `fsync` went further than durability needed. Progressive playback reads the file while it's being written, so the bytes must reach the **filesystem** every chunk — but forcing them to the **platter** every chunk is what was expensive, and isn't what the reader needs. Sync is batched to 64 MiB or 5s, whichever comes first, plus a final sync at completion.

Session persistence rides along with the sync — **but only the routine progress heartbeat**. The in-memory session stays exact, because it drives the progressive-start decision, and every state change (progressive start, fallback, completion) still writes immediately. Restart behavior is unchanged; only the heartbeat is coarser. `test_progressive_session_still_written_on_state_changes` pins that distinction.

## A test I had to throw away

My first responsiveness test blocked an `asyncio.Event` and asserted the loop still ticked. It passed — and would have passed against the *unfixed* code too, because it only proved that asyncio yields. That's exactly the self-consistent test the repo rules warn about.

The replacement runs a **real upload through an ASGI transport** against a deliberately slow disk, using `time.sleep` (genuinely blocking, not `asyncio.sleep`) and polling `/health` throughout, asserting max health latency stays under 150ms. Reverted, health latency becomes the length of the upload and it fails.

## Testing

| Reverted | Fails |
|---|---|
| write back on the loop | `test_health_stays_responsive_while_the_disk_is_slow` |
| `fsync` every chunk | `test_large_upload_does_not_sync_per_chunk` |
| any blocking call reintroduced in an async handler | `test_no_blocking_io_remains_on_the_event_loop` |

I verified the source scan independently by reintroducing a bare `os.replace` — it fires.

Behavior preserved and tested: file stored and served byte-identical, size limit still 413s, partial `.part` files removed on failure, empty upload rejected, unsupported type rejected.

Gates: **755 Python tests** (+12), 11 JS tests, ruff clean, `git diff --check` clean.

## Device verification

**Still outstanding.** This PR's device check — upload roughly 2 GB and confirm the UI stays responsive and playback controls still work during it — has not been run. The responsiveness test does exercise a real upload through an ASGI transport against a deliberately blocked disk, and fails when the write returns to the event loop, but that is not the same as a large upload over the network onto the Pi's SD card.

The code is deployed on both devices and both are healthy, so the check is ready to run whenever convenient.
