### PR TITLE
fix: bound thumbnail and metadata caches

### DIFF
--- a/app/relaytv_app/resolver.py
+++ b/app/relaytv_app/resolver.py
@@ -7,6 +7,7 @@ import json
 import time
 import urllib.request
 import shutil
+from collections import OrderedDict
 from dataclasses import dataclass
 
 from .config import runtime_config
@@ -1034,9 +1035,52 @@ def youtube_oembed_info(youtube_url: str) -> dict | None:
     return None
 
 
-# Cache for yt-dlp metadata lookups (thumbnails, titles) to avoid repeated calls
-_YTDLP_INFO_CACHE: dict[str, tuple[float, dict]] = {}
+# Cache for yt-dlp metadata lookups (thumbnails, titles) to avoid repeated calls.
+#
+# Was an unlocked dict with a TTL check but no eviction, so it grew for the
+# life of the process — every distinct URL ever looked up kept its full
+# yt-dlp JSON resident. Entries also expired only when read again, so a URL
+# looked up once and never revisited was never released.
+#
+# Concurrent lookups of the same URL each ran their own yt-dlp subprocess,
+# because nothing recorded that one was already in flight.
+_YTDLP_INFO_CACHE: "OrderedDict[str, tuple[float, dict]]" = OrderedDict()
 _YTDLP_INFO_TTL_SEC = int(os.getenv("YTDLP_INFO_TTL_SEC", "21600"))  # 6 hours
+_YTDLP_INFO_CACHE_MAX = max(16, int(os.getenv("YTDLP_INFO_CACHE_MAX") or "256"))
+_YTDLP_INFO_LOCK = threading.Lock()
+# One condition per URL currently being fetched, so a second caller waits for
+# the first rather than spawning a duplicate subprocess.
+_YTDLP_INFO_INFLIGHT: dict[str, threading.Event] = {}
+
+
+def _ytdlp_info_cached(url: str, now: float) -> dict | None:
+    """Return a live cache entry, evicting it if the TTL has passed."""
+    with _YTDLP_INFO_LOCK:
+        entry = _YTDLP_INFO_CACHE.get(url)
+        if entry is None:
+            return None
+        if (now - entry[0]) >= _YTDLP_INFO_TTL_SEC:
+            _YTDLP_INFO_CACHE.pop(url, None)
+            return None
+        _YTDLP_INFO_CACHE.move_to_end(url)
+        return entry[1]
+
+
+def _ytdlp_info_store(url: str, now: float, data: dict) -> None:
+    with _YTDLP_INFO_LOCK:
+        _YTDLP_INFO_CACHE[url] = (now, data)
+        _YTDLP_INFO_CACHE.move_to_end(url)
+        # Drop anything past its TTL first, then the least recently used.
+        for stale in [k for k, (ts, _v) in _YTDLP_INFO_CACHE.items() if (now - ts) >= _YTDLP_INFO_TTL_SEC]:
+            _YTDLP_INFO_CACHE.pop(stale, None)
+        while len(_YTDLP_INFO_CACHE) > _YTDLP_INFO_CACHE_MAX:
+            _YTDLP_INFO_CACHE.popitem(last=False)
+
+
+def reset_ytdlp_info_cache_for_tests() -> None:
+    with _YTDLP_INFO_LOCK:
+        _YTDLP_INFO_CACHE.clear()
+        _YTDLP_INFO_INFLIGHT.clear()
 
 
 def ytdlp_info(url: str) -> dict | None:
@@ -1053,9 +1097,22 @@ def ytdlp_info(url: str) -> dict | None:
         return None
 
     now = time.time()
-    cached = _YTDLP_INFO_CACHE.get(u)
-    if cached and (now - cached[0]) < _YTDLP_INFO_TTL_SEC:
-        return cached[1]
+    cached = _ytdlp_info_cached(u, now)
+    if cached is not None:
+        return cached
+
+    # Coordinate duplicates: whoever claims the URL fetches it, everyone else
+    # waits for that result instead of spawning another yt-dlp.
+    with _YTDLP_INFO_LOCK:
+        pending = _YTDLP_INFO_INFLIGHT.get(u)
+        owner = pending is None
+        if owner:
+            pending = threading.Event()
+            _YTDLP_INFO_INFLIGHT[u] = pending
+    if not owner:
+        # Bounded: a hung lookup must not pin every other caller forever.
+        pending.wait(timeout=25.0)
+        return _ytdlp_info_cached(u, time.time())
 
     try:
         p, _selected_args, _challenged = _run_ytdlp_provider_command(
@@ -1069,10 +1126,14 @@ def ytdlp_info(url: str) -> dict | None:
         data = json.loads((p.stdout or "").strip() or "{}")
         if not isinstance(data, dict) or not data:
             return None
-        _YTDLP_INFO_CACHE[u] = (now, data)
+        _ytdlp_info_store(u, now, data)
         return data
     except Exception:
         return None
+    finally:
+        with _YTDLP_INFO_LOCK:
+            _YTDLP_INFO_INFLIGHT.pop(u, None)
+        pending.set()
 
 
 def resolve_title(url: str) -> str:

--- a/app/relaytv_app/resolver.py
+++ b/app/relaytv_app/resolver.py
@@ -1053,17 +1053,22 @@ _YTDLP_INFO_LOCK = threading.Lock()
 _YTDLP_INFO_INFLIGHT: dict[str, threading.Event] = {}
 
 
+def _ytdlp_info_cached_locked(url: str, now: float) -> dict | None:
+    """Return a live entry while the caller holds ``_YTDLP_INFO_LOCK``."""
+    entry = _YTDLP_INFO_CACHE.get(url)
+    if entry is None:
+        return None
+    if (now - entry[0]) >= _YTDLP_INFO_TTL_SEC:
+        _YTDLP_INFO_CACHE.pop(url, None)
+        return None
+    _YTDLP_INFO_CACHE.move_to_end(url)
+    return entry[1]
+
+
 def _ytdlp_info_cached(url: str, now: float) -> dict | None:
     """Return a live cache entry, evicting it if the TTL has passed."""
     with _YTDLP_INFO_LOCK:
-        entry = _YTDLP_INFO_CACHE.get(url)
-        if entry is None:
-            return None
-        if (now - entry[0]) >= _YTDLP_INFO_TTL_SEC:
-            _YTDLP_INFO_CACHE.pop(url, None)
-            return None
-        _YTDLP_INFO_CACHE.move_to_end(url)
-        return entry[1]
+        return _ytdlp_info_cached_locked(url, now)
 
 
 def _ytdlp_info_store(url: str, now: float, data: dict) -> None:
@@ -1104,6 +1109,12 @@ def ytdlp_info(url: str) -> dict | None:
     # Coordinate duplicates: whoever claims the URL fetches it, everyone else
     # waits for that result instead of spawning another yt-dlp.
     with _YTDLP_INFO_LOCK:
+        # The previous owner may have completed between the optimistic cache
+        # read above and this lock acquisition. Recheck before claiming a new
+        # subprocess or that narrow window launches the same yt-dlp twice.
+        cached = _ytdlp_info_cached_locked(u, time.time())
+        if cached is not None:
+            return cached
         pending = _YTDLP_INFO_INFLIGHT.get(u)
         owner = pending is None
         if owner:

--- a/app/relaytv_app/thumb_cache.py
+++ b/app/relaytv_app/thumb_cache.py
@@ -267,10 +267,14 @@ def _worker() -> None:
                     continue
                 tmp_out = os.path.join(td, "out.jpg")
                 if _normalize_to_jpg(raw_fp, tmp_out):
-                    _commit_file(tmp_out, dst)
+                    committed = _commit_file(tmp_out, dst)
                 else:
                     # Fallback: persist original bytes (may not be jpg but better than dropping).
-                    _commit_file(raw_fp, dst)
+                    committed = _commit_file(raw_fp, dst)
+                if not committed:
+                    # A full/read-only disk is a failed thumbnail attempt too;
+                    # clearing backoff here hammers storage on every status poll.
+                    continue
                 _touch(dst)
                 _prune_thumb_dir()
                 failed = False

--- a/app/relaytv_app/thumb_cache.py
+++ b/app/relaytv_app/thumb_cache.py
@@ -38,12 +38,62 @@ THUMB_RETENTION_SEC = max(0, int(os.getenv("RELAYTV_THUMB_RETENTION_SEC") or str
 THUMB_PRUNE_INTERVAL_SEC = max(0, int(os.getenv("RELAYTV_THUMB_PRUNE_INTERVAL_SEC") or "120"))
 THUMB_SRC_MAP_MAX = max(1, int(os.getenv("RELAYTV_THUMB_SRC_MAP_MAX") or "4096"))
 
-_Q: "queue.Queue[tuple[str, str]]" = queue.Queue()
+# The work queue was unbounded and had no de-duplication, so every /status
+# poll re-enqueued the same ids for any thumbnail that had not landed yet: a
+# history page of items whose provider was down grew the queue without limit
+# and re-requested the same failing URLs forever.
+THUMB_QUEUE_MAX = max(16, int(os.getenv("RELAYTV_THUMB_QUEUE_MAX") or "512"))
+# How long a failed thumbnail is left alone before it may be retried.
+THUMB_FAILURE_BACKOFF_SEC = max(0, int(os.getenv("RELAYTV_THUMB_FAILURE_BACKOFF_SEC") or "900"))
+THUMB_FAILURE_MAP_MAX = max(1, int(os.getenv("RELAYTV_THUMB_FAILURE_MAP_MAX") or "2048"))
+
+_Q: "queue.Queue[tuple[str, str]]" = queue.Queue(maxsize=THUMB_QUEUE_MAX)
 _STARTED = False
 _LOCK = threading.Lock()
 _PRUNE_LOCK = threading.Lock()
 _SRC_BY_ID: dict[str, str] = {}
 _LAST_PRUNE_TS = 0.0
+# Ids queued or being fetched right now, and ids whose last fetch failed.
+_INFLIGHT_LOCK = threading.Lock()
+_INFLIGHT: set[str] = set()
+_FAILED_AT: dict[str, float] = {}
+
+
+def _claim_thumb(tid: str) -> bool:
+    """Return True when this caller should enqueue ``tid``.
+
+    False when it is already queued or in flight, or when its last attempt
+    failed recently enough that retrying would just hammer a dead provider.
+    """
+    now = time.time()
+    with _INFLIGHT_LOCK:
+        if tid in _INFLIGHT:
+            return False
+        failed_at = _FAILED_AT.get(tid)
+        if failed_at is not None and (now - failed_at) < THUMB_FAILURE_BACKOFF_SEC:
+            return False
+        _INFLIGHT.add(tid)
+        return True
+
+
+def _release_thumb(tid: str, *, failed: bool) -> None:
+    now = time.time()
+    with _INFLIGHT_LOCK:
+        _INFLIGHT.discard(tid)
+        if failed:
+            if len(_FAILED_AT) >= THUMB_FAILURE_MAP_MAX:
+                # Drop the oldest failures rather than growing without bound.
+                for stale, _ts in sorted(_FAILED_AT.items(), key=lambda kv: kv[1])[:64]:
+                    _FAILED_AT.pop(stale, None)
+            _FAILED_AT[tid] = now
+        else:
+            _FAILED_AT.pop(tid, None)
+
+
+def reset_thumb_tracking_for_tests() -> None:
+    with _INFLIGHT_LOCK:
+        _INFLIGHT.clear()
+        _FAILED_AT.clear()
 
 def _ensure_dir() -> None:
     try:
@@ -200,16 +250,20 @@ def _worker() -> None:
     _ensure_dir()
     while True:
         url, tid = _Q.get()
+        failed = True
         try:
             dst = local_abs_path(tid)
             if os.path.exists(dst) and os.path.getsize(dst) > 0:
                 _touch(dst)
                 _prune_thumb_dir()
+                failed = False
                 continue
             with tempfile.TemporaryDirectory() as td:
                 raw_fp = os.path.join(td, "in")
                 ok = _download_to(url, raw_fp)
                 if not ok:
+                    # Stays failed: the backoff is what stops a dead provider
+                    # from being re-requested on every status poll.
                     continue
                 tmp_out = os.path.join(td, "out.jpg")
                 if _normalize_to_jpg(raw_fp, tmp_out):
@@ -219,9 +273,11 @@ def _worker() -> None:
                     _commit_file(raw_fp, dst)
                 _touch(dst)
                 _prune_thumb_dir()
+                failed = False
         except Exception:
             pass
         finally:
+            _release_thumb(tid, failed=failed)
             try:
                 _Q.task_done()
             except Exception:
@@ -255,12 +311,17 @@ def attach_local_thumbnail(item: dict) -> dict:
         # Remember source URL for best-effort synchronous materialization fallback.
         _remember_src(tid, thumb.strip())
 
-        # Enqueue generation if missing.
+        # Enqueue generation if missing, once.
         if not (os.path.exists(dst) and os.path.getsize(dst) > 0):
-            try:
-                _Q.put_nowait((thumb.strip(), tid))
-            except Exception:
-                pass
+            if _claim_thumb(tid):
+                try:
+                    _Q.put_nowait((thumb.strip(), tid))
+                except queue.Full:
+                    # Saturated: drop this request rather than grow. The next
+                    # poll re-offers it, so nothing is permanently lost.
+                    _release_thumb(tid, failed=False)
+                except Exception:
+                    _release_thumb(tid, failed=False)
             return item  # don't advertise local until ready
 
         _touch(dst)

--- a/docs/ENV_INVENTORY.md
+++ b/docs/ENV_INVENTORY.md
@@ -316,12 +316,15 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_STATUS_INCLUDE_MPV_LOG` | `routes/__init__.py` | - | static env |
 | `RELAYTV_SUB_LANG` | `config.py`<br>`player.py`<br>`routes/settings.py`<br>`state.py` | `routes/settings.py` | settings bus |
 | `RELAYTV_THUMB_DIR` | `qt_shell_app.py`<br>`thumb_cache.py` | - | child process input |
+| `RELAYTV_THUMB_FAILURE_BACKOFF_SEC` | `thumb_cache.py` | - | static env |
+| `RELAYTV_THUMB_FAILURE_MAP_MAX` | `thumb_cache.py` | - | static env |
 | `RELAYTV_THUMB_JPEG_Q` | `thumb_cache.py` | - | static env |
 | `RELAYTV_THUMB_MAX_BYTES` | `thumb_cache.py` | - | static env |
 | `RELAYTV_THUMB_MAX_FILES` | `thumb_cache.py` | - | static env |
 | `RELAYTV_THUMB_MAX_TOTAL_BYTES` | `thumb_cache.py` | - | static env |
 | `RELAYTV_THUMB_MAX_TOTAL_MB` | `thumb_cache.py` | - | static env |
 | `RELAYTV_THUMB_PRUNE_INTERVAL_SEC` | `thumb_cache.py` | - | static env |
+| `RELAYTV_THUMB_QUEUE_MAX` | `thumb_cache.py` | - | static env |
 | `RELAYTV_THUMB_RETENTION_SEC` | `thumb_cache.py` | - | static env |
 | `RELAYTV_THUMB_SRC_MAP_MAX` | `thumb_cache.py` | - | static env |
 | `RELAYTV_THUMB_WIDTH` | `thumb_cache.py` | - | static env |
@@ -361,6 +364,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `YTDLP_FORMAT_TIKTOK` | `ytdlp_format_policy.py` | - | static env |
 | `YTDLP_FORMAT_TWITCH` | `ytdlp_format_policy.py` | - | static env |
 | `YTDLP_FORMAT_YOUTUBE` | `ytdlp_format_policy.py` | - | static env |
+| `YTDLP_INFO_CACHE_MAX` | `resolver.py` | - | static env |
 | `YTDLP_INFO_TTL_SEC` | `resolver.py` | - | static env |
 | `YTDLP_JS_RUNTIME` | `resolver.py` | - | static env |
 <!-- END GENERATED ENV TABLE -->

--- a/tests/test_media_cache_bounds.py
+++ b/tests/test_media_cache_bounds.py
@@ -108,6 +108,25 @@ def test_a_success_clears_a_previous_failure(thumb_env) -> None:
     assert thumb_cache._claim_thumb(tid) is True
 
 
+def test_a_failed_thumbnail_commit_enters_backoff(thumb_env, monkeypatch) -> None:
+    """Download success is not success when the cache file cannot be published."""
+    url = "https://cdn.test/disk-full.jpg"
+    tid = thumb_cache.thumb_id(url)
+    monkeypatch.setattr(thumb_cache, "_download_to", lambda source, path: True)
+    monkeypatch.setattr(thumb_cache, "_normalize_to_jpg", lambda source, path: False)
+    monkeypatch.setattr(thumb_cache, "_commit_file", lambda source, path: False)
+    monkeypatch.setattr(thumb_cache, "_prune_thumb_dir", lambda *args, **kwargs: None)
+    assert thumb_cache._claim_thumb(tid) is True
+
+    worker = threading.Thread(target=thumb_cache._worker, daemon=True)
+    worker.start()
+    thumb_env.put((url, tid))
+    thumb_env.join()
+
+    assert tid in thumb_cache._FAILED_AT
+    assert thumb_cache._claim_thumb(tid) is False
+
+
 def test_failure_map_is_bounded(thumb_env) -> None:
     for index in range(thumb_cache.THUMB_FAILURE_MAP_MAX + 200):
         thumb_cache._release_thumb(f"tid{index}", failed=True)
@@ -191,6 +210,33 @@ def test_concurrent_lookups_run_one_subprocess(monkeypatch) -> None:
 
     assert len(calls) == 1, f"spawned {len(calls)} subprocesses for one URL"
     assert all(r == {"title": "shared"} for r in results), results
+
+
+def test_cache_is_rechecked_before_claiming_a_new_lookup(monkeypatch) -> None:
+    """An owner can finish between the optimistic read and inflight lock."""
+    url = "https://x.test/completed-in-gap"
+    expected = {"title": "already done"}
+    original_cached = resolver._ytdlp_info_cached
+    first = True
+
+    def _complete_during_first_read(key, now):
+        nonlocal first
+        if first:
+            first = False
+            resolver._ytdlp_info_store(key, now, expected)
+            return None
+        return original_cached(key, now)
+
+    subprocess_calls: list[str] = []
+    monkeypatch.setattr(resolver, "_ytdlp_info_cached", _complete_during_first_read)
+    monkeypatch.setattr(
+        resolver,
+        "_run_ytdlp_provider_command",
+        lambda requested, *args, **kwargs: subprocess_calls.append(requested),
+    )
+
+    assert resolver.ytdlp_info(url) == expected
+    assert subprocess_calls == []
 
 
 def test_a_failed_lookup_releases_its_inflight_slot(monkeypatch) -> None:

--- a/tests/test_media_cache_bounds.py
+++ b/tests/test_media_cache_bounds.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Media caches must be bounded and de-duplicated (F10).
+
+The thumbnail queue was unbounded with no de-duplication, so every /status
+poll re-enqueued ids for anything that had not landed yet: a history page of
+items whose provider was down grew the queue without limit and re-requested
+the same failing URLs forever. The yt-dlp metadata cache was an unlocked dict
+with a TTL check but no eviction, so it grew for the life of the process.
+"""
+import queue
+import threading
+import time
+
+import pytest
+
+from relaytv_app import resolver, thumb_cache
+
+
+@pytest.fixture(autouse=True)
+def _clean_caches():
+    thumb_cache.reset_thumb_tracking_for_tests()
+    resolver.reset_ytdlp_info_cache_for_tests()
+    yield
+    thumb_cache.reset_thumb_tracking_for_tests()
+    resolver.reset_ytdlp_info_cache_for_tests()
+
+
+@pytest.fixture
+def thumb_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(thumb_cache, "THUMB_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(thumb_cache, "start_worker", lambda: None)
+    # Drain into a list instead of running the real worker.
+    drained: "queue.Queue[tuple[str, str]]" = queue.Queue(maxsize=thumb_cache.THUMB_QUEUE_MAX)
+    monkeypatch.setattr(thumb_cache, "_Q", drained)
+    return drained
+
+
+# --- thumbnail de-duplication ------------------------------------------------
+
+
+def test_the_same_thumbnail_is_queued_once(thumb_env) -> None:
+    item = {"thumbnail": "https://cdn.test/a.jpg"}
+
+    for _ in range(10):
+        thumb_cache.attach_local_thumbnail(dict(item))
+
+    assert thumb_env.qsize() == 1
+
+
+def test_distinct_thumbnails_are_all_queued(thumb_env) -> None:
+    for index in range(5):
+        thumb_cache.attach_local_thumbnail({"thumbnail": f"https://cdn.test/{index}.jpg"})
+
+    assert thumb_env.qsize() == 5
+
+
+def test_queue_saturation_drops_rather_than_grows(thumb_env) -> None:
+    for index in range(thumb_cache.THUMB_QUEUE_MAX + 50):
+        thumb_cache.attach_local_thumbnail({"thumbnail": f"https://cdn.test/{index}.jpg"})
+
+    assert thumb_env.qsize() <= thumb_cache.THUMB_QUEUE_MAX
+
+
+def test_a_dropped_request_can_be_offered_again(thumb_env, monkeypatch) -> None:
+    """Saturation must not permanently blacklist an id."""
+    monkeypatch.setattr(thumb_env, "put_nowait", lambda item: (_ for _ in ()).throw(queue.Full()))
+    thumb_cache.attach_local_thumbnail({"thumbnail": "https://cdn.test/x.jpg"})
+
+    # Not left marked in-flight, so a later poll can retry it.
+    tid = thumb_cache.thumb_id("https://cdn.test/x.jpg")
+    assert thumb_cache._claim_thumb(tid) is True
+
+
+# --- failure backoff ---------------------------------------------------------
+
+
+def test_a_failed_thumbnail_is_not_retried_immediately(thumb_env) -> None:
+    url = "https://cdn.test/dead.jpg"
+    tid = thumb_cache.thumb_id(url)
+
+    thumb_cache.attach_local_thumbnail({"thumbnail": url})
+    assert thumb_env.qsize() == 1
+    # The worker reports the fetch failed.
+    thumb_cache._release_thumb(tid, failed=True)
+
+    for _ in range(20):
+        thumb_cache.attach_local_thumbnail({"thumbnail": url})
+
+    assert thumb_env.qsize() == 1, "a failing provider was re-requested on every poll"
+
+
+def test_backoff_expires(thumb_env, monkeypatch) -> None:
+    url = "https://cdn.test/slow.jpg"
+    tid = thumb_cache.thumb_id(url)
+    thumb_cache._release_thumb(tid, failed=True)
+    assert thumb_cache._claim_thumb(tid) is False
+
+    monkeypatch.setattr(thumb_cache, "THUMB_FAILURE_BACKOFF_SEC", 0)
+    assert thumb_cache._claim_thumb(tid) is True
+
+
+def test_a_success_clears_a_previous_failure(thumb_env) -> None:
+    tid = thumb_cache.thumb_id("https://cdn.test/flaky.jpg")
+    thumb_cache._release_thumb(tid, failed=True)
+    assert thumb_cache._claim_thumb(tid) is False
+
+    thumb_cache._release_thumb(tid, failed=False)
+    assert thumb_cache._claim_thumb(tid) is True
+
+
+def test_failure_map_is_bounded(thumb_env) -> None:
+    for index in range(thumb_cache.THUMB_FAILURE_MAP_MAX + 200):
+        thumb_cache._release_thumb(f"tid{index}", failed=True)
+
+    assert len(thumb_cache._FAILED_AT) <= thumb_cache.THUMB_FAILURE_MAP_MAX
+
+
+# --- yt-dlp metadata cache ---------------------------------------------------
+
+
+def test_metadata_cache_evicts_by_size() -> None:
+    now = time.time()
+    for index in range(resolver._YTDLP_INFO_CACHE_MAX + 40):
+        resolver._ytdlp_info_store(f"https://x.test/{index}", now, {"title": str(index)})
+
+    assert len(resolver._YTDLP_INFO_CACHE) <= resolver._YTDLP_INFO_CACHE_MAX
+
+
+def test_metadata_cache_evicts_least_recently_used() -> None:
+    now = time.time()
+    for index in range(resolver._YTDLP_INFO_CACHE_MAX):
+        resolver._ytdlp_info_store(f"https://x.test/{index}", now, {"title": str(index)})
+
+    # Touch the oldest so it is no longer the eviction candidate.
+    assert resolver._ytdlp_info_cached("https://x.test/0", now) is not None
+    resolver._ytdlp_info_store("https://x.test/new", now, {"title": "new"})
+
+    assert resolver._ytdlp_info_cached("https://x.test/0", now) is not None
+    assert resolver._ytdlp_info_cached("https://x.test/1", now) is None
+
+
+def test_metadata_cache_expires_by_ttl() -> None:
+    now = time.time()
+    resolver._ytdlp_info_store("https://x.test/a", now, {"title": "a"})
+
+    assert resolver._ytdlp_info_cached("https://x.test/a", now) is not None
+    stale = now + resolver._YTDLP_INFO_TTL_SEC + 1
+    assert resolver._ytdlp_info_cached("https://x.test/a", stale) is None
+    # And it is gone, not merely reported missing.
+    assert "https://x.test/a" not in resolver._YTDLP_INFO_CACHE
+
+
+def test_expired_entries_are_swept_on_write() -> None:
+    """A URL looked up once and never revisited was never released."""
+    old = time.time() - resolver._YTDLP_INFO_TTL_SEC - 10
+    resolver._ytdlp_info_store("https://x.test/forgotten", old, {"title": "old"})
+    resolver._ytdlp_info_store("https://x.test/fresh", time.time(), {"title": "new"})
+
+    assert "https://x.test/forgotten" not in resolver._YTDLP_INFO_CACHE
+
+
+def test_concurrent_lookups_run_one_subprocess(monkeypatch) -> None:
+    """Duplicates used to each spawn their own yt-dlp."""
+    calls: list[str] = []
+    release = threading.Event()
+
+    class _Proc:
+        returncode = 0
+        stdout = '{"title": "shared"}'
+
+    def _fake_run(url, base_args, extra, timeout):
+        calls.append(url)
+        release.wait(5.0)
+        return _Proc(), (), False
+
+    monkeypatch.setattr(resolver, "_run_ytdlp_provider_command", _fake_run)
+    monkeypatch.setattr(resolver, "build_ytdlp_base_args", lambda: ())
+
+    results: list[object] = []
+
+    def _lookup():
+        results.append(resolver.ytdlp_info("https://x.test/same"))
+
+    threads = [threading.Thread(target=_lookup, daemon=True) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    time.sleep(0.2)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=10.0)
+
+    assert len(calls) == 1, f"spawned {len(calls)} subprocesses for one URL"
+    assert all(r == {"title": "shared"} for r in results), results
+
+
+def test_a_failed_lookup_releases_its_inflight_slot(monkeypatch) -> None:
+    """A failure must not leave later callers waiting on a fetch nobody runs."""
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("yt-dlp exploded")
+
+    monkeypatch.setattr(resolver, "_run_ytdlp_provider_command", _boom)
+    monkeypatch.setattr(resolver, "build_ytdlp_base_args", lambda: ())
+
+    assert resolver.ytdlp_info("https://x.test/boom") is None
+    assert "https://x.test/boom" not in resolver._YTDLP_INFO_INFLIGHT
+    # A second attempt runs rather than blocking on a phantom fetch.
+    assert resolver.ytdlp_info("https://x.test/boom") is None


### PR DESCRIPTION
Roadmap PR 9 of 11 — closes **F10**. See #67.

## Thumbnails

The work queue was **unbounded with no de-duplication**, so every `/status` poll re-enqueued the same ids for anything that hadn't landed yet. A history page of items whose provider was down grew the queue without limit and re-requested the same failing URLs forever.

Now: the queue is capped, ids are claimed before queuing so duplicates are dropped, and a failed fetch starts a backoff before that id may be tried again.

Two details worth noting:

- **Saturation drops the request but does not blacklist the id** — the next poll re-offers it, so nothing is permanently lost. There's a test for that specifically, because the obvious implementation leaks in-flight marks on the full-queue path.
- **The failure map is capped too**, oldest first. Fixing one unbounded structure by adding another would be a poor trade.

## yt-dlp metadata

An unlocked dict with a TTL check but **no eviction** — it grew for the life of the process, every distinct URL keeping its full yt-dlp JSON resident. Entries also expired only when *read again*, so a URL looked up once and never revisited was never released.

Now an `OrderedDict` under a lock with LRU eviction, and writes sweep anything already past its TTL.

**Concurrent lookups of the same URL each ran their own yt-dlp subprocess**, because nothing recorded one was in flight. Callers now coordinate: first fetches, rest wait for that result — with a bounded wait so a hung lookup can't pin them, and the owner releasing its slot in a `finally` so a failure doesn't leave later callers waiting on a fetch nobody is running.

## Testing

| Reverted | Fails |
|---|---|
| thumbnail claim removed | de-duplication + backoff tests |
| cache eviction removed | 3 cache-bound tests |
| in-flight coordination removed | `test_concurrent_lookups_run_one_subprocess` |

The duplicate test asserts on the **number of subprocesses actually spawned** (4 threads → 1 call), not on timing.

Gates: **757 Python tests** (+14), 11 JS tests, ruff clean, `git diff --check` clean. `ENV_INVENTORY.md` regenerated for four new tuning variables (`RELAYTV_THUMB_QUEUE_MAX`, `RELAYTV_THUMB_FAILURE_BACKOFF_SEC`, `RELAYTV_THUMB_FAILURE_MAP_MAX`, `YTDLP_INFO_CACHE_MAX`).

## Device verification

On the combined branch, bounds confirmed live in the running process on both devices:

| Value | LR | Pi |
|---|---|---|
| `thumb_cache._Q.maxsize` | 512 | 512 |
| `resolver._YTDLP_INFO_CACHE_MAX` | 256 | 256 |

**Still outstanding**: the soak — load a 200-item history, confirm memory is stable across an hour and that failing thumbnails stop being re-requested on every status poll.
