### PR TITLE
feat: configure shared Jellyfin cast identity

### DIFF
--- a/.github/roadmaps/jellyfin-shared-cast-target.md
+++ b/.github/roadmaps/jellyfin-shared-cast-target.md
@@ -1,6 +1,6 @@
 # Jellyfin Shared Cast Target Roadmap
 
-Status: in progress (M2 complete)
+Status: in progress (M3 complete)
 
 Branch: `fix/jellyfin-shared-cast-target`
 
@@ -181,7 +181,7 @@ Planned commit: `fix: separate Jellyfin cast and catalog credentials`
 
 ### M3 — Make shared-target state observable
 
-Status: pending
+Status: complete
 
 Deliverables:
 
@@ -303,7 +303,7 @@ Update this table in the commit that completes each milestone.
 | M0 Design | complete | roadmap commit | document review; `git diff --check` |
 | M1 Settings | complete | this commit | 253 focused tests; full suite; Ruff; diff check |
 | M2 Credential split | complete | this commit | 149 focused tests; full suite; Ruff; diff check |
-| M3 Observability | pending | — | — |
+| M3 Observability | complete | this commit | 328 focused tests; full suite; Ruff; diff check |
 | M4 Multi-user verification | pending | — | — |
 | M5 Operator docs | pending | — | — |
 | Round 2 Caller attribution | deferred | separate branch/PR | retained above |

--- a/.github/roadmaps/jellyfin-shared-cast-target.md
+++ b/.github/roadmaps/jellyfin-shared-cast-target.md
@@ -1,6 +1,6 @@
 # Jellyfin Shared Cast Target Roadmap
 
-Status: planned
+Status: in progress (M1 complete)
 
 Branch: `fix/jellyfin-shared-cast-target`
 
@@ -130,7 +130,7 @@ Commit: `docs: plan Jellyfin shared cast target`
 
 ### M1 — Add API-key Settings lifecycle
 
-Status: pending
+Status: complete
 
 Deliverables:
 
@@ -301,7 +301,7 @@ Update this table in the commit that completes each milestone.
 | Milestone | Status | Commit | Tests / evidence |
 | --- | --- | --- | --- |
 | M0 Design | complete | roadmap commit | document review; `git diff --check` |
-| M1 Settings | pending | — | — |
+| M1 Settings | complete | this commit | 253 focused tests; full suite; Ruff; diff check |
 | M2 Credential split | pending | — | — |
 | M3 Observability | pending | — | — |
 | M4 Multi-user verification | pending | — | — |

--- a/.github/roadmaps/jellyfin-shared-cast-target.md
+++ b/.github/roadmaps/jellyfin-shared-cast-target.md
@@ -1,0 +1,309 @@
+# Jellyfin Shared Cast Target Roadmap
+
+Status: planned
+
+Branch: `fix/jellyfin-shared-cast-target`
+
+Primary implementation area: `app/relaytv_app/integrations/` and the Settings
+modal
+
+This is an engineering implementation ledger, not an operator runbook. Update
+it in the same commit that completes each milestone. The final operator-facing
+behavior belongs in `docs/JELLYFIN_OPERATIONS.md`.
+
+## Outcome
+
+Let an operator configure a Jellyfin server API key in RelayTV Settings so the
+RelayTV receiver registers as a shared, userless cast target instead of a
+session belonging only to RelayTV's catalog login.
+
+The on-device Jellyfin catalog remains user-scoped: username/password
+authentication supplies catalog preferences, permissions, resume positions,
+and media URLs when it is configured. The API key owns the receiver control
+plane. A later round will address caller-specific catalog resolution and watch
+history for commands cast by other users.
+
+## Server Constraint
+
+Jellyfin treats an API key as an administrator credential without a user
+identity. Its userless session is visible as a shared device only to users
+whose Jellyfin policy allows shared-device control. RelayTV cannot override a
+server policy that disables shared-device control for a user.
+
+The Settings copy and operations documentation must therefore say "all users
+allowed to control shared devices," not unconditionally "all users."
+
+Upstream references:
+
+- [API keys authenticate with the administrator role](https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Api/Auth/CustomAuthenticationHandler.cs)
+- [Jellyfin filters controllable sessions by shared-device and remote-control policy](https://github.com/jellyfin/jellyfin/blob/master/Emby.Server.Implementations/Session/SessionManager.cs)
+- [Play commands include the controlling user ID](https://github.com/jellyfin/jellyfin/blob/master/MediaBrowser.Model/Session/PlayRequest.cs)
+
+## Current-State Findings
+
+1. `jellyfin_api_key` already exists in persisted settings, startup runtime
+   configuration, receiver state, and environment inventory.
+2. The Settings request model and both browser save paths omit the API key.
+   Settings reads redact the value but do not return a configured-state flag.
+3. Live Settings apply requires username/password and passes `api_key=""` to
+   `jellyfin_receiver.connect()`.
+4. The receiver has one request token, preferring the authenticated user token
+   over the API key. Registration, websocket identity, playback reporting,
+   catalog requests, metadata, and media URLs consequently share one identity.
+5. Adding only the Settings field would not fix cast-target scope: a successful
+   username/password authentication would still replace the API key as the
+   websocket and registration credential.
+
+## Credential Model
+
+Every network operation must capture its credential together with the current
+configuration generation. No operation may read mutable token state after it
+starts.
+
+| Purpose | Preferred credential | Fallback | Notes |
+| --- | --- | --- | --- |
+| Cast websocket | server API key | login-session token | API key creates the shared/userless target |
+| Capability registration/readback | server API key | login-session token | Must match the websocket identity |
+| Playing/progress/stopped reports | server API key | login-session token | Must keep the receiver session userless when shared mode is active |
+| Server detection | server API key | login-session token | Either credential is sufficient; use the control identity for consistency |
+| Catalog browse and search | login-session token | server API key | Preserve the configured catalog user's permissions and preferences |
+| Metadata, playback info, images, media URLs | login-session token | server API key | Preserve user-scoped resume and media policy where possible |
+
+Proposed immutable context fields:
+
+- `control_token`: `_API_KEY or _ACCESS_TOKEN`
+- `catalog_token`: `_ACCESS_TOKEN or _API_KEY`
+- existing configuration generation, server identity, device identity, and
+  catalog user ID
+
+Avoid a generic `active_token()` after this split. Call sites should name the
+identity they require.
+
+## Settings Contract
+
+Add a password-style `Server API key` field to the Jellyfin/Emby Settings
+group, with copy similar to:
+
+> Makes RelayTV a shared Jellyfin cast target for users allowed to control
+> shared devices. Create and rotate this administrator-level key in Jellyfin.
+
+Secret behavior must match the existing password contract:
+
+- `GET /settings` returns `jellyfin_api_key: ""` and
+  `jellyfin_api_key_configured: true|false`.
+- An omitted API-key property preserves the stored value.
+- A non-empty value replaces it.
+- The explicit clear control submits an empty value and removes it.
+- The key is never returned by Settings/status endpoints and never logged.
+- Both the Jellyfin-only Apply button and the modal-wide Apply button implement
+  identical preserve/replace/clear behavior.
+
+Readiness becomes two related states:
+
+- shared cast target: server URL plus API key;
+- legacy user-scoped target/catalog: server URL plus username/password.
+
+When both credential types exist, RelayTV should start the shared cast target
+with the API key immediately and authenticate the catalog user independently.
+An API-key-only configuration may run the cast target without requiring a
+username or password. Catalog behavior in that mode uses the preferred user ID
+when supplied and otherwise remains limited to what the server returns without
+a selected user profile.
+
+## Milestones and Commit Boundaries
+
+Each milestone ends with its focused tests passing, this ledger updated, and a
+separate Conventional Commit. Do not combine milestones merely because their
+working changes are adjacent.
+
+### M0 — Record the design and acceptance contract
+
+Status: complete
+
+Deliverables:
+
+- Create the dedicated fix branch.
+- Record credential roles, Jellyfin permission constraints, milestone
+  boundaries, verification, and the caller-specific follow-up.
+
+Commit: `docs: plan Jellyfin shared cast target`
+
+### M1 — Add API-key Settings lifecycle
+
+Status: pending
+
+Deliverables:
+
+- Add `jellyfin_api_key` to the Settings request model.
+- Add redacted configured-state output.
+- Add the modal field, configured-state hint, and explicit clear control.
+- Update both browser save paths.
+- Mirror changes to `RELAYTV_JELLYFIN_API_KEY` through `runtime_config`.
+- Include the API key in the live Jellyfin configuration transaction.
+- Allow API-key-only enablement without username/password validation.
+
+Exit tests:
+
+- Settings GET redaction/configured-state coverage.
+- Preserve, replace, and clear coverage at route and browser-payload seams.
+- API-key-only live apply and both Apply-button paths.
+- Existing username/password behavior remains green.
+
+Planned commit: `fix: configure Jellyfin cast API key in settings`
+
+### M2 — Separate control and catalog credentials
+
+Status: pending
+
+Deliverables:
+
+- Replace the single request-context token with explicit control and catalog
+  tokens captured under `_LOCK` with the configuration generation.
+- Route websocket identity, registration, readback, detection, and playback
+  reports through the control credential.
+- Route catalog, metadata, playback-info, image, and media URL work through the
+  catalog credential.
+- Replace or narrow ambiguous `active_token()`/`access_token()` helpers.
+- Preserve generation checks for authentication, registration, retries, and
+  late network results.
+
+Exit tests:
+
+- With both credentials configured, websocket and registration always use the
+  API key, including after user authentication completes.
+- Catalog and metadata use the login-session token when available.
+- API-key fallback works when no login session exists.
+- Playback reports do not relabel a shared target as the catalog user.
+- Token rotation/reconfiguration retires the old socket and rejects stale
+  network publications.
+
+Planned commit: `fix: separate Jellyfin cast and catalog credentials`
+
+### M3 — Make shared-target state observable
+
+Status: pending
+
+Deliverables:
+
+- Publish only non-secret status describing credential source and scope, for
+  example `control_auth_source` and `cast_target_scope`.
+- Distinguish cast readiness from catalog authentication in Settings status.
+- Ensure failed catalog login cannot take down a healthy API-key cast target.
+- Keep legacy login-only mode identified as user-scoped.
+
+Exit tests:
+
+- Status contains no credential values or token fingerprints.
+- API-key cast readiness survives catalog authentication failure.
+- Clear/replace transitions report the correct scope and socket state.
+
+Planned commit: `fix: report Jellyfin cast target scope`
+
+### M4 — Verify multi-user behavior and lifecycle safety
+
+Status: pending
+
+Deliverables:
+
+- Add regression coverage for rapid enable/disable, server switch, key
+  rotation, and login completion while the shared socket is running.
+- Verify one live heartbeat generation, one control socket, and one stable
+  device ID after configuration churn.
+- Perform live Jellyfin acceptance with at least two users:
+  - the RelayTV catalog user;
+  - a different non-admin user allowed to control shared devices.
+- Record the expected negative case for a user whose shared-device control is
+  disabled.
+
+Live acceptance:
+
+1. Both permitted users see the same RelayTV device in Jellyfin Cast.
+2. The second user can send Play, PlayPause, Seek, volume, and Stop.
+3. Renaming RelayTV changes only the display name, not the device ID.
+4. Catalog browsing still reflects the configured RelayTV catalog user.
+5. No duplicate progress posts, orphan sockets, or stale-generation writes
+   occur during reconnect/key-rotation cycles.
+
+Planned commit: `test: cover shared Jellyfin cast lifecycle`
+
+### M5 — Complete operator documentation
+
+Status: pending
+
+Deliverables:
+
+- Update `docs/JELLYFIN_OPERATIONS.md` with setup, secret handling, shared
+  device permission requirements, status interpretation, fallback behavior,
+  rotation, and troubleshooting.
+- Regenerate machine-checked inventories only if their public surfaces change.
+- Decide whether this user-visible fix warrants a release highlight; do not
+  edit `CHANGELOG.md`.
+- Mark this roadmap complete with final test and live-verification evidence.
+
+Planned commit: `docs: document shared Jellyfin cast targets`
+
+## Round 2 — Caller-Specific Playback Attribution
+
+Status: deferred, retained in roadmap
+
+The first round makes the device visible and controllable across permitted
+users. It does not promise that a cast from another user updates that user's
+resume position, played state, favorites, or personalized media policy.
+
+Jellyfin sends `ControllingUserId` with Play and Playstate commands. A follow-up
+should evaluate carrying that ID through a command-scoped context while the
+receiver's socket and reporting identity remain API-key/userless.
+
+Questions to resolve before implementation:
+
+1. Which catalog and playback-info endpoints safely accept an API key plus the
+   controlling user ID without bypassing that user's library restrictions?
+2. Does Jellyfin expose a supported way to attribute playback reports from a
+   shared/userless receiver session to the controlling user?
+3. If attribution requires session mutation, can users switch controllers
+   during playback without corrupting watch history or shared visibility?
+4. How should RelayTV behave when `ControllingUserId` is absent, stale, or
+   changes between playlist commands?
+5. What are the equivalent semantics on Emby, whose compatibility must not be
+   assumed from Jellyfin behavior?
+
+Proposed follow-up milestones:
+
+- C1: preserve and validate `ControllingUserId` at websocket ingress;
+- C2: add command-scoped user-aware metadata/playback-info resolution;
+- C3: prototype and verify watch-state attribution against supported Jellyfin
+  APIs;
+- C4: cover controller handoff, missing-user fallback, permission denial, and
+  Emby compatibility;
+- C5: document the exact attribution guarantees and limitations.
+
+This round should use its own branch and PR after the shared-target work is
+stable. Do not make M1–M5 depend on unresolved attribution behavior.
+
+## Required Quality Gates
+
+Run before every implementation milestone commit:
+
+```text
+ruff check app tests
+PYTHONPATH=app pytest -q
+git diff --check
+```
+
+Run focused Jellyfin and Settings tests during development before the full
+suite. If an intentional public inventory changes, regenerate it with the
+matching test's `--write` mode instead of hand-editing the generated section.
+
+## Completion Record
+
+Update this table in the commit that completes each milestone.
+
+| Milestone | Status | Commit | Tests / evidence |
+| --- | --- | --- | --- |
+| M0 Design | complete | roadmap commit | document review; `git diff --check` |
+| M1 Settings | pending | — | — |
+| M2 Credential split | pending | — | — |
+| M3 Observability | pending | — | — |
+| M4 Multi-user verification | pending | — | — |
+| M5 Operator docs | pending | — | — |
+| Round 2 Caller attribution | deferred | separate branch/PR | retained above |

--- a/.github/roadmaps/jellyfin-shared-cast-target.md
+++ b/.github/roadmaps/jellyfin-shared-cast-target.md
@@ -1,6 +1,6 @@
 # Jellyfin Shared Cast Target Roadmap
 
-Status: in progress (M3 complete)
+Status: in progress (M4 automated verification complete; live acceptance pending)
 
 Branch: `fix/jellyfin-shared-cast-target`
 
@@ -201,7 +201,7 @@ Planned commit: `fix: report Jellyfin cast target scope`
 
 ### M4 — Verify multi-user behavior and lifecycle safety
 
-Status: pending
+Status: automated verification complete; live acceptance pending
 
 Deliverables:
 
@@ -304,6 +304,6 @@ Update this table in the commit that completes each milestone.
 | M1 Settings | complete | this commit | 253 focused tests; full suite; Ruff; diff check |
 | M2 Credential split | complete | this commit | 149 focused tests; full suite; Ruff; diff check |
 | M3 Observability | complete | this commit | 328 focused tests; full suite; Ruff; diff check |
-| M4 Multi-user verification | pending | — | — |
+| M4 Multi-user verification | partial | this commit | 65 focused tests; full suite; live two-user acceptance pending |
 | M5 Operator docs | pending | — | — |
 | Round 2 Caller attribution | deferred | separate branch/PR | retained above |

--- a/.github/roadmaps/jellyfin-shared-cast-target.md
+++ b/.github/roadmaps/jellyfin-shared-cast-target.md
@@ -247,6 +247,23 @@ the generated fix note is the appropriate release treatment.
 
 Planned commit: `docs: document shared Jellyfin cast targets`
 
+### M6 — Correct shared-session presentation
+
+Status: implementation complete; live menu refresh pending
+
+Deliverables:
+
+- Identify the websocket handshake with the configured device name so an API
+  key session does not fall back to the Jellyfin server name and opaque device
+  ID.
+- Keep the API key only in the socket URL; the identity header must not repeat
+  or expose the credential.
+- Document Jellyfin Web's presentation constraint: a userless shared session
+  has no user subtitle, and the API-key name supplies its client suffix.
+- Add regression coverage for the handshake identity and secret boundary.
+
+Planned commit: `fix: identify shared Jellyfin cast sessions`
+
 ## Round 2 — Caller-Specific Playback Attribution
 
 Status: deferred, retained in roadmap
@@ -311,4 +328,5 @@ Update this table in the commit that completes each milestone.
 | M3 Observability | complete | this commit | 328 focused tests; full suite; Ruff; diff check |
 | M4 Multi-user verification | partial | this commit | 65 focused tests; full suite; live two-user acceptance pending |
 | M5 Operator docs | complete | this commit | operations setup, permissions, rotation, status, and limitation documented |
+| M6 Session presentation | complete | this commit | websocket identity and token-isolation regression coverage; live menu refresh pending |
 | Round 2 Caller attribution | deferred | separate branch/PR | retained above |

--- a/.github/roadmaps/jellyfin-shared-cast-target.md
+++ b/.github/roadmaps/jellyfin-shared-cast-target.md
@@ -1,6 +1,6 @@
 # Jellyfin Shared Cast Target Roadmap
 
-Status: in progress (M1 complete)
+Status: in progress (M2 complete)
 
 Branch: `fix/jellyfin-shared-cast-target`
 
@@ -153,7 +153,7 @@ Planned commit: `fix: configure Jellyfin cast API key in settings`
 
 ### M2 — Separate control and catalog credentials
 
-Status: pending
+Status: complete
 
 Deliverables:
 
@@ -302,7 +302,7 @@ Update this table in the commit that completes each milestone.
 | --- | --- | --- | --- |
 | M0 Design | complete | roadmap commit | document review; `git diff --check` |
 | M1 Settings | complete | this commit | 253 focused tests; full suite; Ruff; diff check |
-| M2 Credential split | pending | — | — |
+| M2 Credential split | complete | this commit | 149 focused tests; full suite; Ruff; diff check |
 | M3 Observability | pending | — | — |
 | M4 Multi-user verification | pending | — | — |
 | M5 Operator docs | pending | — | — |

--- a/.github/roadmaps/jellyfin-shared-cast-target.md
+++ b/.github/roadmaps/jellyfin-shared-cast-target.md
@@ -1,6 +1,6 @@
 # Jellyfin Shared Cast Target Roadmap
 
-Status: in progress (M4 automated verification complete; live acceptance pending)
+Status: implementation complete; live two-user acceptance pending
 
 Branch: `fix/jellyfin-shared-cast-target`
 
@@ -228,7 +228,7 @@ Planned commit: `test: cover shared Jellyfin cast lifecycle`
 
 ### M5 — Complete operator documentation
 
-Status: pending
+Status: complete
 
 Deliverables:
 
@@ -238,7 +238,12 @@ Deliverables:
 - Regenerate machine-checked inventories only if their public surfaces change.
 - Decide whether this user-visible fix warrants a release highlight; do not
   edit `CHANGELOG.md`.
-- Mark this roadmap complete with final test and live-verification evidence.
+- Mark implementation complete and record any live-verification evidence or
+  remaining external acceptance dependency.
+
+Release-highlight decision: no new highlight file. This is a corrective
+extension of the Jellyfin cast-target feature already highlighted in 0.9.0;
+the generated fix note is the appropriate release treatment.
 
 Planned commit: `docs: document shared Jellyfin cast targets`
 
@@ -305,5 +310,5 @@ Update this table in the commit that completes each milestone.
 | M2 Credential split | complete | this commit | 149 focused tests; full suite; Ruff; diff check |
 | M3 Observability | complete | this commit | 328 focused tests; full suite; Ruff; diff check |
 | M4 Multi-user verification | partial | this commit | 65 focused tests; full suite; live two-user acceptance pending |
-| M5 Operator docs | pending | — | — |
+| M5 Operator docs | complete | this commit | operations setup, permissions, rotation, status, and limitation documented |
 | Round 2 Caller attribution | deferred | separate branch/PR | retained above |

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -55,7 +55,8 @@ class _RequestContext:
     client_version: str
     username: str
     password: str
-    token: str
+    control_token: str
+    catalog_token: str
     catalog_user_id: str
     authenticated: bool
     connected: bool
@@ -699,7 +700,8 @@ def _request_context() -> _RequestContext:
             client_version=str(_STATUS.get("client_version") or "1.0"),
             username=str(_AUTH_USERNAME or ""),
             password=str(_AUTH_PASSWORD or ""),
-            token=str(_ACCESS_TOKEN or _API_KEY or ""),
+            control_token=str(_API_KEY or _ACCESS_TOKEN or ""),
+            catalog_token=str(_ACCESS_TOKEN or _API_KEY or ""),
             catalog_user_id=catalog_user_id,
             authenticated=bool(_STATUS.get("authenticated")),
             connected=bool(_STATUS.get("connected")),
@@ -956,16 +958,16 @@ def api_key() -> str:
         return str(_API_KEY or "")
 
 
-def _active_token() -> str:
+def control_token() -> str:
+    """Return the credential that owns the receiver's shared control plane."""
     with _LOCK:
-        if _ACCESS_TOKEN:
-            return str(_ACCESS_TOKEN)
-        return str(_API_KEY or "")
+        return str(_API_KEY or _ACCESS_TOKEN or "")
 
 
-def active_token() -> str:
-    """Public accessor used by route helpers."""
-    return _active_token()
+def catalog_token() -> str:
+    """Return the credential used for user-scoped catalog and media work."""
+    with _LOCK:
+        return str(_ACCESS_TOKEN or _API_KEY or "")
 
 
 def session_token() -> str:
@@ -1026,7 +1028,7 @@ def get_item_metadata(item_id: str, *, token_override: str = "", server_url_over
     base = str(server_url_override or context.server_url or "").strip().rstrip("/")
     if not iid or not base:
         return {}
-    token = str(token_override or context.token or "").strip()
+    token = str(token_override or context.catalog_token or "").strip()
     user_id = context.catalog_user_id
     token_key = hashlib.sha1(token.encode("utf-8", "ignore")).hexdigest()[:12] if token else "-"
     cache_key = f"meta:{base}:{user_id}:{iid}:{token_key}"
@@ -1462,7 +1464,7 @@ def _extract_total_count(payload: object, default_count: int = 0) -> int:
 
 def _catalog_base_token_user() -> tuple[str, str, str]:
     context = _request_context()
-    return context.server_url, context.token, context.catalog_user_id
+    return context.server_url, context.catalog_token, context.catalog_user_id
 
 
 def get_item_detail(item_id: str, *, refresh: bool = False) -> dict[str, object]:
@@ -2634,8 +2636,8 @@ def _context_url(context: _RequestContext, path: str) -> str:
 
 
 def _context_headers(context: _RequestContext) -> dict[str, str]:
-    """Authentication headers derived entirely from one request context."""
-    token = context.token.strip()
+    """Control-plane authentication captured in one request context."""
+    token = context.control_token.strip()
     out: dict[str, str] = {}
     if token:
         out["X-Emby-Token"] = token
@@ -3073,7 +3075,7 @@ def _ensure_registration(now_ts: float | None = None) -> None:
         return
     if not context.server_url:
         return
-    if not context.token:
+    if not context.control_token:
         return
 
     now_val = float(now_ts if now_ts is not None else time.time())

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -55,6 +55,7 @@ class _RequestContext:
     client_version: str
     username: str
     password: str
+    auth_mode: str
     control_token: str
     catalog_token: str
     catalog_user_id: str
@@ -81,6 +82,7 @@ _STATUS: dict[str, object] = {
     "last_detect_ok": None,
     "last_detect_error": None,
     "api_key_configured": False,
+    "auth_mode": "user_login",
     "connected": False,
     "last_heartbeat_ts": None,
     "last_command": None,
@@ -130,6 +132,7 @@ _STATUS: dict[str, object] = {
 }
 
 _API_KEY: str = ""
+_AUTH_MODE: str = "user_login"
 _AUTH_USERNAME: str = ""
 _AUTH_PASSWORD: str = ""
 _ACCESS_TOKEN: str = ""
@@ -325,18 +328,27 @@ def derive_device_id() -> str:
 def _read_config() -> dict[str, object]:
     configured_name = ""
     configured_server_type = ""
+    configured_auth_mode = ""
     try:
         from .. import state as _state
 
         s = _state.get_settings() if hasattr(_state, "get_settings") else {}
         configured_name = str((s or {}).get("device_name") or "").strip()
         configured_server_type = str((s or {}).get("jellyfin_server_type") or "").strip().lower()
+        configured_auth_mode = str((s or {}).get("jellyfin_auth_mode") or "").strip().lower()
     except Exception:
         configured_name = ""
         configured_server_type = ""
+        configured_auth_mode = ""
     server_type = configured_server_type or (runtime_config.snapshot().raw("RELAYTV_JELLYFIN_SERVER_TYPE") or "").strip().lower()
     if server_type not in ("jellyfin", "emby"):
         server_type = "jellyfin"
+    if configured_auth_mode not in ("shared_api_key", "user_login"):
+        configured_auth_mode = (
+            "shared_api_key"
+            if str(runtime_config.snapshot().raw("RELAYTV_JELLYFIN_API_KEY") or "").strip()
+            else "user_login"
+        )
     device_name = (
         configured_name
         or (runtime_config.snapshot().raw("RELAYTV_DEVICE_NAME") or "").strip()
@@ -354,6 +366,7 @@ def _read_config() -> dict[str, object]:
         "client_version": (os.getenv("RELAYTV_JELLYFIN_CLIENT_VERSION") or "1.0").strip() or "1.0",
         "heartbeat_sec": max(2, int(float(os.getenv("RELAYTV_JELLYFIN_HEARTBEAT_SEC") or "5"))),
         "server_type": server_type,
+        "auth_mode": configured_auth_mode,
     }
 
 
@@ -387,7 +400,7 @@ def start() -> None:
 
 def _start_locked() -> None:
     """Initialize Jellyfin receiver runtime state (network wiring added later)."""
-    global _API_KEY, _AUTH_USERNAME, _AUTH_PASSWORD, _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
+    global _API_KEY, _AUTH_MODE, _AUTH_USERNAME, _AUTH_PASSWORD, _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
     cfg = _read_config()
     global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS, _LAST_STOPPED_SIGNATURE, _LAST_STOPPED_TS
     with _LOCK:
@@ -399,6 +412,8 @@ def _start_locked() -> None:
         _STATUS["client_version"] = str(cfg["client_version"])
         _STATUS["heartbeat_sec"] = int(cfg["heartbeat_sec"])
         _STATUS["server_type"] = str(cfg["server_type"])
+        _AUTH_MODE = str(cfg["auth_mode"])
+        _STATUS["auth_mode"] = _AUTH_MODE
         _API_KEY = (runtime_config.snapshot().raw("RELAYTV_JELLYFIN_API_KEY") or "").strip()
         _AUTH_USERNAME = (runtime_config.snapshot().raw("RELAYTV_JELLYFIN_USERNAME") or "").strip()
         _AUTH_PASSWORD = (runtime_config.snapshot().raw("RELAYTV_JELLYFIN_PASSWORD") or "").strip()
@@ -491,18 +506,19 @@ def mark_heartbeat() -> None:
 def _status_with_sync_health(raw: dict[str, object]) -> dict[str, object]:
     out = dict(raw)
     now_ts = int(time.time())
-    if bool(out.get("api_key_configured")):
+    auth_mode = str(out.get("auth_mode") or "user_login")
+    if auth_mode == "shared_api_key" and bool(out.get("api_key_configured")):
         out["control_auth_source"] = "api_key"
         out["cast_target_scope"] = "shared"
-    elif bool(out.get("authenticated")):
+    elif auth_mode == "user_login" and bool(out.get("authenticated")):
         out["control_auth_source"] = "user_session"
         out["cast_target_scope"] = "user_scoped"
     else:
         out["control_auth_source"] = "none"
         out["cast_target_scope"] = "unavailable"
-    if bool(out.get("authenticated")):
+    if auth_mode == "user_login" and bool(out.get("authenticated")):
         out["catalog_auth_source"] = "user_session"
-    elif bool(out.get("api_key_configured")):
+    elif auth_mode == "shared_api_key" and bool(out.get("api_key_configured")):
         out["catalog_auth_source"] = "api_key"
     else:
         out["catalog_auth_source"] = "none"
@@ -559,16 +575,21 @@ def _status_with_sync_health(raw: dict[str, object]) -> dict[str, object]:
         out["sync_health"] = "error"
         out["sync_health_reason"] = "register_failed"
         return out
-    if bool(out.get("auth_user_configured")) and bool(out.get("last_auth_ok")) is False:
+    if auth_mode == "user_login" and bool(out.get("auth_user_configured")) and bool(out.get("last_auth_ok")) is False:
         out["sync_health"] = "error"
         out["sync_health_reason"] = "auth_failed"
         return out
 
-    if auth_ts == 0 and bool(out.get("auth_user_configured")):
+    if auth_mode == "user_login" and auth_ts == 0 and bool(out.get("auth_user_configured")):
         out["sync_health"] = "degraded"
         out["sync_health_reason"] = "awaiting_auth"
         return out
-    if register_ts == 0 and bool(out.get("api_key_configured") or out.get("authenticated")):
+    active_credential = (
+        bool(out.get("api_key_configured"))
+        if auth_mode == "shared_api_key"
+        else bool(out.get("authenticated"))
+    )
+    if register_ts == 0 and active_credential:
         out["sync_health"] = "degraded"
         out["sync_health_reason"] = "awaiting_register"
         return out
@@ -721,8 +742,9 @@ def _request_context() -> _RequestContext:
             client_version=str(_STATUS.get("client_version") or "1.0"),
             username=str(_AUTH_USERNAME or ""),
             password=str(_AUTH_PASSWORD or ""),
-            control_token=str(_API_KEY or _ACCESS_TOKEN or ""),
-            catalog_token=str(_ACCESS_TOKEN or _API_KEY or ""),
+            auth_mode=str(_AUTH_MODE or "user_login"),
+            control_token=str(_API_KEY if _AUTH_MODE == "shared_api_key" else _ACCESS_TOKEN),
+            catalog_token=str(_API_KEY if _AUTH_MODE == "shared_api_key" else _ACCESS_TOKEN),
             catalog_user_id=catalog_user_id,
             authenticated=bool(_STATUS.get("authenticated")),
             connected=bool(_STATUS.get("connected")),
@@ -799,7 +821,7 @@ def _maybe_retry_detection() -> None:
     _run_detection(context.server_url, generation=context.generation)
 
 
-def connect(*, server_url: str, api_key: str | None = None, device_name: str | None = None, heartbeat_sec: int | None = None) -> dict[str, object]:
+def connect(*, server_url: str, api_key: str | None = None, auth_mode: str | None = None, device_name: str | None = None, heartbeat_sec: int | None = None) -> dict[str, object]:
     """Configure and enable Jellyfin receiver runtime."""
     global _API_KEY, _AUTH_USERNAME, _AUTH_PASSWORD, _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
     global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS, _LAST_STOPPED_SIGNATURE, _LAST_STOPPED_TS
@@ -810,12 +832,13 @@ def connect(*, server_url: str, api_key: str | None = None, device_name: str | N
     # heartbeat from reopening it to the old server mid-transaction.
     with _control_socket_suspended():
         return _connect_locked(
-            server_url=server_url, api_key=api_key, device_name=device_name, heartbeat_sec=heartbeat_sec
+            server_url=server_url, api_key=api_key, auth_mode=auth_mode,
+            device_name=device_name, heartbeat_sec=heartbeat_sec
         )
 
 
-def _connect_locked(*, server_url: str, api_key: str | None, device_name: str | None, heartbeat_sec: int | None) -> dict[str, object]:
-    global _API_KEY, _AUTH_USERNAME, _AUTH_PASSWORD, _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
+def _connect_locked(*, server_url: str, api_key: str | None, auth_mode: str | None, device_name: str | None, heartbeat_sec: int | None) -> dict[str, object]:
+    global _API_KEY, _AUTH_MODE, _AUTH_USERNAME, _AUTH_PASSWORD, _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
     global _REGISTER_RETRY_FAILURES, _NEXT_REGISTER_RETRY_TS, _LAST_STOPPED_SIGNATURE, _LAST_STOPPED_TS
     with _LOCK:
         _STATUS["enabled"] = True
@@ -829,6 +852,15 @@ def _connect_locked(*, server_url: str, api_key: str | None, device_name: str | 
             _STATUS["heartbeat_sec"] = max(2, int(heartbeat_sec))
         if api_key is not None:
             _API_KEY = str(api_key or "").strip()
+        selected_mode = str(auth_mode or "").strip().lower()
+        if not selected_mode and api_key is not None:
+            selected_mode = "shared_api_key" if _API_KEY else "user_login"
+        if not selected_mode:
+            selected_mode = str(_AUTH_MODE or "").strip().lower()
+        if selected_mode not in ("shared_api_key", "user_login"):
+            selected_mode = "shared_api_key" if _API_KEY else "user_login"
+        _AUTH_MODE = selected_mode
+        _STATUS["auth_mode"] = _AUTH_MODE
         _AUTH_USERNAME = (runtime_config.snapshot().raw("RELAYTV_JELLYFIN_USERNAME") or "").strip()
         _AUTH_PASSWORD = (runtime_config.snapshot().raw("RELAYTV_JELLYFIN_PASSWORD") or "").strip()
         _ACCESS_TOKEN = ""
@@ -980,9 +1012,9 @@ def api_key() -> str:
 
 
 def control_token() -> str:
-    """Return the credential that owns the receiver's shared control plane."""
+    """Return the credential selected for the receiver control plane."""
     with _LOCK:
-        return str(_API_KEY or _ACCESS_TOKEN or "")
+        return str(_API_KEY if _AUTH_MODE == "shared_api_key" else _ACCESS_TOKEN)
 
 
 def control_socket_identity_headers(status_snapshot: dict[str, object] | None = None) -> dict[str, str]:
@@ -1020,9 +1052,9 @@ def control_socket_identity_headers(status_snapshot: dict[str, object] | None = 
 
 
 def catalog_token() -> str:
-    """Return the credential used for user-scoped catalog and media work."""
+    """Return the credential selected for catalog and media work."""
     with _LOCK:
-        return str(_ACCESS_TOKEN or _API_KEY or "")
+        return str(_API_KEY if _AUTH_MODE == "shared_api_key" else _ACCESS_TOKEN)
 
 
 def session_token() -> str:
@@ -3243,6 +3275,8 @@ def _ensure_authentication() -> None:
     if not runtime_config.snapshot().flag("RELAYTV_JELLYFIN_AUTH_ENABLED", True):
         return
     context = _request_context()
+    if context.auth_mode != "user_login":
+        return
     if not context.enabled or not context.running:
         return
     if context.authenticated:

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -1109,14 +1109,20 @@ def _build_emby_headers(*, token: str = "") -> dict[str, str]:
     return out
 
 
-def get_item_metadata(item_id: str, *, token_override: str = "", server_url_override: str = "") -> dict[str, object]:
+def get_item_metadata(
+    item_id: str,
+    *,
+    token_override: str = "",
+    server_url_override: str = "",
+    user_id_override: str = "",
+) -> dict[str, object]:
     iid = str(item_id or "").strip()
     context = _request_context()
     base = str(server_url_override or context.server_url or "").strip().rstrip("/")
     if not iid or not base:
         return {}
     token = str(token_override or context.catalog_token or "").strip()
-    user_id = context.catalog_user_id
+    user_id = str(user_id_override or context.catalog_user_id or "").strip()
     token_key = hashlib.sha1(token.encode("utf-8", "ignore")).hexdigest()[:12] if token else "-"
     cache_key = f"meta:{base}:{user_id}:{iid}:{token_key}"
     cached = _catalog_cache_get(cache_key)
@@ -1554,9 +1560,12 @@ def _catalog_base_token_user() -> tuple[str, str, str]:
     return context.server_url, context.catalog_token, context.catalog_user_id
 
 
-def get_item_detail(item_id: str, *, refresh: bool = False) -> dict[str, object]:
+def get_item_detail(
+    item_id: str, *, refresh: bool = False, user_id_override: str = ""
+) -> dict[str, object]:
     iid = str(item_id or "").strip()
     base, token, user_id = _catalog_base_token_user()
+    user_id = str(user_id_override or user_id or "").strip()
     if not iid or not base:
         return {}
     cache_key = f"detail:{base}:{user_id}:{iid}"
@@ -1604,6 +1613,7 @@ def resolve_playback_url(
     subtitle_stream_index: str = "",
     max_height: int | None = None,
     max_streaming_bitrate: int | None = None,
+    user_id_override: str = "",
 ) -> dict[str, object]:
     """
     Ask Jellyfin for a playable URL for an item, preferring transcode when requested.
@@ -1611,6 +1621,7 @@ def resolve_playback_url(
     """
     iid = str(item_id or "").strip()
     base, token, user_id = _catalog_base_token_user()
+    user_id = str(user_id_override or user_id or "").strip()
     if not iid or not base:
         return {"url": "", "method": "none", "media_source_id": ""}
     mid = str(media_source_id or "").strip()
@@ -2582,9 +2593,11 @@ def list_series_episodes(
     season_id: str = "",
     season_number: int | None = None,
     refresh: bool = False,
+    user_id_override: str = "",
 ) -> dict[str, object]:
     sid = str(series_id or "").strip()
     base, token, user_id = _catalog_base_token_user()
+    user_id = str(user_id_override or user_id or "").strip()
     if not sid or not base:
         return {"series_id": sid, "season_id": str(season_id or "").strip(), "season_number": season_number, "episodes": [], "count": 0}
 

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -491,6 +491,27 @@ def mark_heartbeat() -> None:
 def _status_with_sync_health(raw: dict[str, object]) -> dict[str, object]:
     out = dict(raw)
     now_ts = int(time.time())
+    if bool(out.get("api_key_configured")):
+        out["control_auth_source"] = "api_key"
+        out["cast_target_scope"] = "shared"
+    elif bool(out.get("authenticated")):
+        out["control_auth_source"] = "user_session"
+        out["cast_target_scope"] = "user_scoped"
+    else:
+        out["control_auth_source"] = "none"
+        out["cast_target_scope"] = "unavailable"
+    if bool(out.get("authenticated")):
+        out["catalog_auth_source"] = "user_session"
+    elif bool(out.get("api_key_configured")):
+        out["catalog_auth_source"] = "api_key"
+    else:
+        out["catalog_auth_source"] = "none"
+    out["catalog_ready"] = bool(
+        out.get("enabled")
+        and out.get("running")
+        and str(out.get("server_url") or "").strip()
+        and out.get("catalog_auth_source") != "none"
+    )
     catalog_user_id, catalog_user_source = _effective_catalog_user(raw)
     out["catalog_user_id"] = catalog_user_id
     out["catalog_user_source"] = catalog_user_source
@@ -2787,7 +2808,8 @@ def authenticate_once(*, _context: _RequestContext | None = None) -> dict[str, o
             _STATUS["last_auth_ts"] = int(time.time())
             _STATUS["last_auth_ok"] = True
             _STATUS["last_auth_error"] = None
-            _STATUS["last_error"] = None
+            if not _API_KEY:
+                _STATUS["last_error"] = None
 
         if not _publish(generation, _apply):
             logger.info("jellyfin_auth_discarded reason=config_changed")
@@ -2804,7 +2826,8 @@ def authenticate_once(*, _context: _RequestContext | None = None) -> dict[str, o
             _STATUS["last_auth_ts"] = int(time.time())
             _STATUS["last_auth_ok"] = False
             _STATUS["last_auth_error"] = msg
-            _STATUS["last_error"] = msg
+            if not _API_KEY:
+                _STATUS["last_error"] = msg
 
         if not _publish(generation, _apply_failure):
             return {"ok": False, "reason": "config_changed"}

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -985,6 +985,40 @@ def control_token() -> str:
         return str(_API_KEY or _ACCESS_TOKEN or "")
 
 
+def control_socket_identity_headers(status_snapshot: dict[str, object] | None = None) -> dict[str, str]:
+    """Identify the cast device during the websocket HTTP handshake.
+
+    The socket URL carries the credential, while this token-free header gives
+    Jellyfin the configured display name. Without it, an API-key websocket is
+    created as the server itself and falls back to DeviceId for its name, so
+    the cast menu shows e.g. ``Jellyfin Server - relaytv-...``.
+
+    Jellyfin deliberately owns the API-key session's client label (the API key
+    name) and keeps the session userless. Keeping the token out of this header
+    preserves that shared-session behavior and avoids duplicating the secret.
+    """
+    st = status_snapshot if isinstance(status_snapshot, dict) else status()
+
+    def _component(key: str, fallback: str) -> str:
+        value = str(st.get(key) or fallback).strip() or fallback
+        # Jellyfin URL-decodes authorization components. Encoding here keeps a
+        # display name containing quotes or commas from changing header fields.
+        return _urlparse.quote(value, safe="")
+
+    client_name = _component("client_name", "RelayTV")
+    device_name = _component("device_name", "RelayTV")
+    device_id = _component("device_id", "relaytv")
+    client_version = _component("client_version", "1.0")
+    return {
+        "Authorization": (
+            f'MediaBrowser Client="{client_name}", '
+            f'Device="{device_name}", '
+            f'DeviceId="{device_id}", '
+            f'Version="{client_version}"'
+        )
+    }
+
+
 def catalog_token() -> str:
     """Return the credential used for user-scoped catalog and media work."""
     with _LOCK:

--- a/app/relaytv_app/integrations/jellyfin_service.py
+++ b/app/relaytv_app/integrations/jellyfin_service.py
@@ -57,8 +57,8 @@ def _first_nonempty_str(values: list[object]) -> str:
 
 
 def catalog_token() -> str:
-    """Credential for user-scoped catalog, metadata, and media requests."""
-    return _first_nonempty_str([jellyfin_receiver.session_token(), jellyfin_receiver.api_key()])
+    """Credential selected for catalog, metadata, and media requests."""
+    return jellyfin_receiver.catalog_token()
 
 
 def extract_play_url(payload: dict | None) -> str:

--- a/app/relaytv_app/integrations/jellyfin_service.py
+++ b/app/relaytv_app/integrations/jellyfin_service.py
@@ -56,8 +56,8 @@ def _first_nonempty_str(values: list[object]) -> str:
     return ""
 
 
-def access_token() -> str:
-    """Prefer authenticated login-session token; fall back to configured API key."""
+def catalog_token() -> str:
+    """Credential for user-scoped catalog, metadata, and media requests."""
     return _first_nonempty_str([jellyfin_receiver.session_token(), jellyfin_receiver.api_key()])
 
 
@@ -1848,7 +1848,7 @@ def _restart_with_stream_params(
         settings_snapshot = state.get_settings()
     except Exception:
         settings_snapshot = {}
-    auth_token = access_token()
+    auth_token = catalog_token()
 
     source_url = build_item_stream_url(
         item_id,
@@ -2445,7 +2445,7 @@ def smart_item_from_url(url: str, *, start_pos: float | None = None, lightweight
         origin = url_origin(shared)
         server_url = origin or str(st.get("server_url") or "")
         link_api_key = _extract_api_key_from_url(shared)
-        token = link_api_key or access_token()
+        token = link_api_key or catalog_token()
         pref_audio_idx, pref_sub_idx = preferred_stream_indices(item_id)
         normalized_url = normalize_source_url(shared, server_url=server_url, api_key=token)
         normalized_url = apply_stream_params(
@@ -2690,7 +2690,7 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                 settings_snapshot = state.get_settings()
             except Exception:
                 settings_snapshot = {}
-            auth_token = access_token()
+            auth_token = catalog_token()
             pref_audio_idx = ""
             pref_sub_idx = ""
             resolved_detail: dict[str, object] = {}

--- a/app/relaytv_app/integrations/jellyfin_service.py
+++ b/app/relaytv_app/integrations/jellyfin_service.py
@@ -791,6 +791,7 @@ def select_playback_url(
     audio_stream_index: str = "",
     subtitle_stream_index: str = "",
     settings: dict | None = None,
+    user_id_override: str = "",
 ) -> dict[str, str]:
     iid = str(item_id or "").strip()
     src = str(source_url or "").strip()
@@ -805,7 +806,11 @@ def select_playback_url(
 
     detail = {}
     try:
-        detail = jellyfin_receiver.get_item_detail(iid)
+        detail = (
+            jellyfin_receiver.get_item_detail(iid, user_id_override=user_id_override)
+            if user_id_override
+            else jellyfin_receiver.get_item_detail(iid)
+        )
     except Exception:
         detail = {}
     profile = {}
@@ -857,6 +862,7 @@ def select_playback_url(
         subtitle_stream_index=sidx,
         max_height=(cap_height if cap_height > 0 else None),
         max_streaming_bitrate=target_bitrate,
+        user_id_override=user_id_override,
     )
     t_url = str((selected or {}).get("url") or "").strip()
     t_method = str((selected or {}).get("method") or "").strip()
@@ -898,13 +904,19 @@ def first_playable_episode(payload: dict | None) -> dict[str, object]:
     return {}
 
 
-def resolve_playable_item(item_id: str, *, media_source_id: str = "") -> dict[str, object]:
+def resolve_playable_item(
+    item_id: str, *, media_source_id: str = "", user_id_override: str = ""
+) -> dict[str, object]:
     iid = str(item_id or "").strip()
     if not iid:
         return {"item_id": "", "detail": {}, "media_source_id": ""}
 
     try:
-        detail = jellyfin_receiver.get_item_detail(iid)
+        detail = (
+            jellyfin_receiver.get_item_detail(iid, user_id_override=user_id_override)
+            if user_id_override
+            else jellyfin_receiver.get_item_detail(iid)
+        )
     except Exception:
         detail = {}
 
@@ -943,6 +955,7 @@ def resolve_playable_item(item_id: str, *, media_source_id: str = "") -> dict[st
         series_id,
         season_id=season_id,
         season_number=season_number,
+        user_id_override=user_id_override,
     )
     episode = first_playable_episode(episodes_payload)
     resolved_item_id = str((episode.get("item_id") if isinstance(episode, dict) else "") or "").strip()
@@ -952,7 +965,13 @@ def resolve_playable_item(item_id: str, *, media_source_id: str = "") -> dict[st
     resolved_detail = episode if isinstance(episode, dict) else {}
     if resolved_item_id != iid:
         try:
-            fetched = jellyfin_receiver.get_item_detail(resolved_item_id)
+            fetched = (
+                jellyfin_receiver.get_item_detail(
+                    resolved_item_id, user_id_override=user_id_override
+                )
+                if user_id_override
+                else jellyfin_receiver.get_item_detail(resolved_item_id)
+            )
         except Exception:
             fetched = {}
         if isinstance(fetched, dict) and fetched:
@@ -1133,7 +1152,9 @@ def _language_matches(pref: str, candidate: str) -> bool:
     return False
 
 
-def preferred_stream_indices(item_id: str) -> tuple[str, str]:
+def preferred_stream_indices(
+    item_id: str, *, user_id_override: str = ""
+) -> tuple[str, str]:
     iid = str(item_id or "").strip()
     if not iid:
         return "", ""
@@ -1144,7 +1165,11 @@ def preferred_stream_indices(item_id: str) -> tuple[str, str]:
         return "", ""
     sub_off = sub_pref in {"off", "none", "disabled", "no", "false", "0"}
     try:
-        detail = jellyfin_receiver.get_item_detail(iid)
+        detail = (
+            jellyfin_receiver.get_item_detail(iid, user_id_override=user_id_override)
+            if user_id_override
+            else jellyfin_receiver.get_item_detail(iid)
+        )
     except Exception:
         detail = {}
     audio_streams = detail.get("audio_streams") if isinstance(detail, dict) else []
@@ -2433,7 +2458,13 @@ def _extract_api_key_from_url(url: str) -> str:
         return ""
 
 
-def smart_item_from_url(url: str, *, start_pos: float | None = None, lightweight: bool = False) -> dict:
+def smart_item_from_url(
+    url: str,
+    *,
+    start_pos: float | None = None,
+    lightweight: bool = False,
+    user_id_override: str = "",
+) -> dict:
     """
     Build a playback item for smart/jellyfin paths.
     If the URL looks like Jellyfin media, enrich title/thumbnail/resume from Jellyfin APIs.
@@ -2446,7 +2477,9 @@ def smart_item_from_url(url: str, *, start_pos: float | None = None, lightweight
         server_url = origin or str(st.get("server_url") or "")
         link_api_key = _extract_api_key_from_url(shared)
         token = link_api_key or catalog_token()
-        pref_audio_idx, pref_sub_idx = preferred_stream_indices(item_id)
+        pref_audio_idx, pref_sub_idx = preferred_stream_indices(
+            item_id, user_id_override=user_id_override
+        )
         normalized_url = normalize_source_url(shared, server_url=server_url, api_key=token)
         normalized_url = apply_stream_params(
             normalized_url,
@@ -2477,6 +2510,7 @@ def smart_item_from_url(url: str, *, start_pos: float | None = None, lightweight
             audio_stream_index=pref_audio_idx,
             subtitle_stream_index=pref_sub_idx,
             settings=settings_snapshot,
+            user_id_override=user_id_override,
         )
         normalized_url = normalize_source_url(
             str(selected.get("url") or normalized_url),
@@ -2492,13 +2526,24 @@ def smart_item_from_url(url: str, *, start_pos: float | None = None, lightweight
         )
         item: dict[str, object] = {
             "url": normalized_url,
+            "title": f"Jellyfin item {item_id}",
             "provider": "jellyfin",
             "jellyfin_item_id": item_id,
+            **(
+                {"_jellyfin_metadata_user_id": user_id_override}
+                if user_id_override
+                else {}
+            ),
             **({"jellyfin_media_source_id": media_source_id} if media_source_id else {}),
             "jellyfin_stream_mode": str(selected.get("mode") or "direct"),
             "jellyfin_stream_reason": str(selected.get("reason") or ""),
         }
-        meta = jellyfin_receiver.get_item_metadata(item_id, token_override=token, server_url_override=server_url)
+        meta = jellyfin_receiver.get_item_metadata(
+            item_id,
+            token_override=token,
+            server_url_override=server_url,
+            user_id_override=user_id_override,
+        )
         if isinstance(meta, dict):
             title = str(meta.get("title") or "").strip()
             channel = str(meta.get("channel") or "").strip()
@@ -2609,7 +2654,14 @@ def should_suppress_duplicate_ui_action(command: str, item_id: str, resume_pos: 
         return suppressed
 
 
-def _playlist_entry_display_fields(entry: dict, iid: str, *, api_key: str, server_url: str) -> dict[str, str]:
+def _playlist_entry_display_fields(
+    entry: dict,
+    iid: str,
+    *,
+    api_key: str,
+    server_url: str,
+    user_id_override: str = "",
+) -> dict[str, str]:
     """
     Return display metadata (title/channel/thumbnail) for a playlist queue
     entry. Playlist payloads (series play-all, Jellyfin app casts) often carry
@@ -2620,7 +2672,12 @@ def _playlist_entry_display_fields(entry: dict, iid: str, *, api_key: str, serve
     thumbnail = ""
     if not title:
         try:
-            meta = jellyfin_receiver.get_item_metadata(iid, token_override=api_key, server_url_override=server_url)
+            meta = jellyfin_receiver.get_item_metadata(
+                iid,
+                token_override=api_key,
+                server_url_override=server_url,
+                user_id_override=user_id_override,
+            )
         except Exception:
             meta = None
         if isinstance(meta, dict):
@@ -2665,6 +2722,14 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
             return True
 
     action = normalize_action(req.action, req.payload)
+    command_user_id = ""
+    if isinstance(req.payload, dict):
+        command_user_id = _first_nonempty_str(
+            [
+                req.payload.get("ControllingUserId"),
+                req.payload.get("controlling_user_id"),
+            ]
+        )
     jellyfin_receiver.mark_command(action)
     jellyfin_receiver.mark_heartbeat()
     command_id = extract_command_id(req)
@@ -2695,7 +2760,11 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
             pref_sub_idx = ""
             resolved_detail: dict[str, object] = {}
             if item_id:
-                resolved_item = resolve_playable_item(item_id, media_source_id=media_source_id)
+                resolved_item = resolve_playable_item(
+                    item_id,
+                    media_source_id=media_source_id,
+                    user_id_override=command_user_id,
+                )
                 item_id = str(resolved_item.get("item_id") or item_id).strip()
                 resolved_detail = resolved_item.get("detail") if isinstance(resolved_item.get("detail"), dict) else {}
                 media_source_id = _first_nonempty_str([
@@ -2711,12 +2780,24 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                             "id": item_id,
                             "media_source_id": media_source_id or str(playlist_items[0].get("media_source_id") or "").strip(),
                         }
-                pref_audio_idx, pref_sub_idx = preferred_stream_indices(item_id)
+                pref_audio_idx, pref_sub_idx = (
+                    preferred_stream_indices(
+                        item_id, user_id_override=command_user_id
+                    )
+                    if command_user_id
+                    else preferred_stream_indices(item_id)
+                )
                 if not media_source_id:
                     detail = resolved_detail if isinstance(resolved_detail, dict) else {}
                     if not detail:
                         try:
-                            detail = jellyfin_receiver.get_item_detail(item_id)
+                            detail = (
+                                jellyfin_receiver.get_item_detail(
+                                    item_id, user_id_override=command_user_id
+                                )
+                                if command_user_id
+                                else jellyfin_receiver.get_item_detail(item_id)
+                            )
                         except Exception:
                             detail = {}
                     media_source_id = _first_nonempty_str(
@@ -2760,6 +2841,7 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                     audio_stream_index=audio_stream_index,
                     subtitle_stream_index=subtitle_stream_index,
                     settings=settings_snapshot,
+                    user_id_override=command_user_id,
                 )
                 source_url = normalize_source_url(
                     str(selected_stream.get("url") or source_url),
@@ -2871,13 +2953,20 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                         audio_stream_index=audio_stream_index,
                         subtitle_stream_index=subtitle_stream_index,
                         settings=settings_snapshot,
+                        user_id_override=command_user_id,
                     )
                     source_for_queue = normalize_source_url(
                         str(selected_queue.get("url") or source_for_queue),
                         server_url=str(st.get("server_url") or ""),
                         api_key=auth_token,
                     )
-                    q_item = smart_item_from_url(source_for_queue)
+                    q_item = (
+                        smart_item_from_url(
+                            source_for_queue, user_id_override=command_user_id
+                        )
+                        if command_user_id
+                        else smart_item_from_url(source_for_queue)
+                    )
                     q_title = str(q_item.get("title") or "") if isinstance(q_item, dict) else ""
                     q_channel = str(q_item.get("channel") or "") if isinstance(q_item, dict) else ""
                     source_media_source_id = _first_nonempty_str(
@@ -2907,7 +2996,11 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                     iid = str(entry.get("id") or "").strip()
                     if not iid:
                         continue
-                    q_audio_idx, q_sub_idx = preferred_stream_indices(iid)
+                    q_audio_idx, q_sub_idx = (
+                        preferred_stream_indices(iid, user_id_override=command_user_id)
+                        if command_user_id
+                        else preferred_stream_indices(iid)
+                    )
                     if explicit_audio_idx:
                         q_audio_idx = explicit_audio_idx
                     if explicit_sub_idx:
@@ -2931,6 +3024,7 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                         audio_stream_index=q_audio_idx,
                         subtitle_stream_index=q_sub_idx,
                         settings=settings_snapshot,
+                        user_id_override=command_user_id,
                     )
                     qurl = normalize_source_url(
                         str(selected_q.get("url") or qurl),
@@ -2943,7 +3037,11 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                     if _seen(iid, qurl, q_media_source_id):
                         continue
                     q_display = _playlist_entry_display_fields(
-                        entry, iid, api_key=auth_token, server_url=str(st.get("server_url") or "")
+                        entry,
+                        iid,
+                        api_key=auth_token,
+                        server_url=str(st.get("server_url") or ""),
+                        user_id_override=command_user_id,
                     )
                     queued.append(
                         {
@@ -3032,7 +3130,15 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                 logger.info("jellyfin_command_discarded action=play reason=session_retired")
                 return {"ok": False, "action": "play", "reason": "session_retired"}
             playback_service.suppress_auto_next(2.0)
-            play_item_payload = smart_item_from_url(source_url, start_pos=start_sec)
+            play_item_payload = (
+                smart_item_from_url(
+                    source_url,
+                    start_pos=start_sec,
+                    user_id_override=command_user_id,
+                )
+                if command_user_id
+                else smart_item_from_url(source_url, start_pos=start_sec)
+            )
             play_target = play_item_payload if isinstance(play_item_payload, dict) else source_url
             now = playback_service.play_now(
                 play_target,
@@ -3060,7 +3166,13 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                     if play_session_id:
                         now["jellyfin_play_session_id"] = play_session_id
                     try:
-                        detail = jellyfin_receiver.get_item_detail(item_id)
+                        detail = (
+                            jellyfin_receiver.get_item_detail(
+                                item_id, user_id_override=command_user_id
+                            )
+                            if command_user_id
+                            else jellyfin_receiver.get_item_detail(item_id)
+                        )
                     except Exception:
                         detail = {}
                     now = enrich_now_stream_metadata(
@@ -3118,7 +3230,11 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                     iid = str(entry.get("id") or "").strip()
                     if not iid:
                         continue
-                    q_audio_idx, q_sub_idx = preferred_stream_indices(iid)
+                    q_audio_idx, q_sub_idx = (
+                        preferred_stream_indices(iid, user_id_override=command_user_id)
+                        if command_user_id
+                        else preferred_stream_indices(iid)
+                    )
                     if explicit_audio_idx:
                         q_audio_idx = explicit_audio_idx
                     if explicit_sub_idx:
@@ -3143,6 +3259,7 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                         audio_stream_index=q_audio_idx,
                         subtitle_stream_index=q_sub_idx,
                         settings=settings_snapshot if isinstance(settings_snapshot, dict) else {},
+                        user_id_override=command_user_id,
                     )
                     qurl = normalize_source_url(
                         str(selected_q.get("url") or qurl),
@@ -3159,7 +3276,11 @@ def handle_command(req: CommandReqLike, *, controls: dict, ui: dict, guard=None)
                     if _seen(iid, qurl, q_media_source_id):
                         continue
                     q_display = _playlist_entry_display_fields(
-                        entry, iid, api_key=auth_token, server_url=str(st.get("server_url") or "")
+                        entry,
+                        iid,
+                        api_key=auth_token,
+                        server_url=str(st.get("server_url") or ""),
+                        user_id_override=command_user_id,
                     )
                     queued.append(
                         {

--- a/app/relaytv_app/integrations/jellyfin_ws.py
+++ b/app/relaytv_app/integrations/jellyfin_ws.py
@@ -337,7 +337,7 @@ def _connect_once(session: _Session) -> None:
     st = jellyfin_receiver.status()
     url = socket_url(
         server_url=str(st.get("server_url") or ""),
-        token=jellyfin_receiver.active_token(),
+        token=jellyfin_receiver.control_token(),
         device_id=str(st.get("device_id") or ""),
     )
     if not url:
@@ -426,7 +426,7 @@ def _identity() -> tuple[str, str, str] | None:
         return None
     server_url = str(st.get("server_url") or "").strip()
     device_id = str(st.get("device_id") or "").strip()
-    token = jellyfin_receiver.active_token()
+    token = jellyfin_receiver.control_token()
     if not server_url or not device_id or not token:
         return None
     if not jellyfin_receiver.command_sink_registered():

--- a/app/relaytv_app/integrations/jellyfin_ws.py
+++ b/app/relaytv_app/integrations/jellyfin_ws.py
@@ -349,6 +349,11 @@ def _connect_once(session: _Session) -> None:
         # already gone away must not hold either of those for ten seconds.
         "close_timeout": _CLOSE_TIMEOUT_SEC,
         "max_size": 2**20,
+        # The browser-compatible query string authenticates the socket, but it
+        # doesn't carry client identity. A token-free authorization header lets
+        # Jellyfin name this userless shared session after the configured TV
+        # instead of its own server name and RelayTV's opaque DeviceId.
+        "additional_headers": jellyfin_receiver.control_socket_identity_headers(st),
     }
     if _PROXY_KWARG_SUPPORTED:
         # websockets 15+ honours HTTP_PROXY by default, which would route a LAN

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -5983,7 +5983,12 @@ def _hydrate_jellyfin_resume_metadata(now: dict) -> dict:
         except Exception:
             origin = ""
         meta = (
-            jellyfin_receiver.get_item_metadata(item_id, token_override=token, server_url_override=origin)
+            jellyfin_receiver.get_item_metadata(
+                item_id,
+                token_override=token,
+                server_url_override=origin,
+                user_id_override=str(out.get("_jellyfin_metadata_user_id") or "").strip(),
+            )
             if item_id
             else {}
         )

--- a/app/relaytv_app/public_media.py
+++ b/app/relaytv_app/public_media.py
@@ -99,6 +99,14 @@ def public_media_item(item: object) -> object:
             if safe_url:
                 result[key] = safe_url
             continue
+        if isinstance(value, str) and value.strip().lower().startswith(("http://", "https://")):
+            # A failed metadata lookup can leave the signed stream URL in a
+            # display field such as title. Public redaction is about the value,
+            # not only the expected schema key.
+            safe_value = sanitize_public_url(value)
+            if safe_value:
+                result[key] = safe_value
+            continue
         result[key] = value
 
     if source_url and provider != "iptv":

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -706,7 +706,9 @@ def _runtime_capabilities(*, playing: bool | None = None) -> dict:
         "native_qt_mpv_runtime_duration": qt_runtime_telemetry.get("mpv_runtime_duration"),
         "native_qt_mpv_runtime_volume": qt_runtime_telemetry.get("mpv_runtime_volume"),
         "native_qt_mpv_runtime_mute": qt_runtime_telemetry.get("mpv_runtime_mute"),
-        "native_qt_mpv_runtime_path": str(qt_runtime_telemetry.get("mpv_runtime_path") or ""),
+        "native_qt_mpv_runtime_path": public_media.sanitize_public_url(
+            qt_runtime_telemetry.get("mpv_runtime_path")
+        ),
         "native_qt_mpv_runtime_current_vo": str(qt_runtime_telemetry.get("mpv_runtime_current_vo") or ""),
         "native_qt_mpv_runtime_current_ao": str(qt_runtime_telemetry.get("mpv_runtime_current_ao") or ""),
         "native_qt_mpv_runtime_aid": qt_runtime_telemetry.get("mpv_runtime_aid"),
@@ -3253,6 +3255,12 @@ def _status_payload() -> dict[str, object]:
         playing = False
         transitioning_between_items = False
     runtime = _runtime_capabilities(playing=playing)
+    # Treat the status assembler as the final trust boundary too. Runtime
+    # adapters need the signed playback URL internally, but no adapter or test
+    # double should be able to publish its credential-bearing form.
+    runtime["native_qt_mpv_runtime_path"] = public_media.sanitize_public_url(
+        runtime.get("native_qt_mpv_runtime_path")
+    )
     effective_ytdlp_format = None
     try:
         effective_ytdlp_format = str(getattr(player, "_effective_ytdl_format", lambda s=None: "")(settings_snapshot) or "")

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -2548,7 +2548,7 @@ def _first_nonempty_str(values: list[object]) -> str:
 # Pure Jellyfin helpers (docs/ARCHITECTURE.md)
 # live in integrations/jellyfin_service.py. These aliases keep the routes
 # compatibility surface and existing monkeypatch targets stable.
-_jellyfin_access_token = jellyfin_service.access_token
+_jellyfin_catalog_token = jellyfin_service.catalog_token
 _extract_jellyfin_play_url = jellyfin_service.extract_play_url
 _extract_jellyfin_item_id = jellyfin_service.extract_item_id
 _canonical_jellyfin_item_id = jellyfin_service.canonical_item_id

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -3348,6 +3348,11 @@ def _status_payload() -> dict[str, object]:
     jf_running = bool(jf_status.get("running"))
     jf_connected = bool(jf_status.get("connected"))
     jf_authenticated = bool(jf_status.get("authenticated"))
+    jf_control_auth_source = str(jf_status.get("control_auth_source") or "none")
+    jf_cast_target_scope = str(jf_status.get("cast_target_scope") or "unavailable")
+    jf_cast_target_ready = bool(jf_status.get("cast_target_ready"))
+    jf_catalog_auth_source = str(jf_status.get("catalog_auth_source") or "none")
+    jf_catalog_ready = bool(jf_status.get("catalog_ready"))
     jf_sync_health = str(jf_status.get("sync_health") or "")
     jf_sync_health_reason = str(jf_status.get("sync_health_reason") or "")
     jf_last_sync_age_sec = jf_status.get("last_sync_age_sec")
@@ -3424,6 +3429,11 @@ def _status_payload() -> dict[str, object]:
         "jellyfin_running": jf_running,
         "jellyfin_connected": jf_connected,
         "jellyfin_authenticated": jf_authenticated,
+        "jellyfin_control_auth_source": jf_control_auth_source,
+        "jellyfin_cast_target_scope": jf_cast_target_scope,
+        "jellyfin_cast_target_ready": jf_cast_target_ready,
+        "jellyfin_catalog_auth_source": jf_catalog_auth_source,
+        "jellyfin_catalog_ready": jf_catalog_ready,
         "jellyfin_sync_health": jf_sync_health,
         "jellyfin_sync_health_reason": jf_sync_health_reason,
         "jellyfin_last_sync_age_sec": jf_last_sync_age_sec,

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -4537,6 +4537,23 @@ def ui():
         </div>
 
         <div class="fieldRow">
+          <label class="fieldLbl">Server API key</label>
+          <input id="setJfApiKey" class="input" type="password" autocomplete="new-password" placeholder="(leave blank to keep existing)" />
+          <div class="hint">Makes RelayTV a shared Jellyfin cast target for users allowed to control shared devices. API keys are administrator-level secrets.</div>
+          <div class="toggleRow">
+            <div class="toggleCopy">
+              <div class="toggleTitle">Clear stored API key</div>
+              <div class="toggleHint">Remove the saved server API key on the next apply.</div>
+            </div>
+            <label class="toggleSwitch" for="setJfClearApiKey" title="Clear stored Jellyfin API key">
+              <input type="checkbox" id="setJfClearApiKey" />
+              <span class="toggleTrack" aria-hidden="true"></span>
+            </label>
+          </div>
+          <div class="hint" id="setJfApiKeyState"></div>
+        </div>
+
+        <div class="fieldRow">
           <label class="fieldLbl">Username</label>
           <input id="setJfUsername" class="input" placeholder="server username" />
         </div>

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -4547,45 +4547,58 @@ def ui():
         </div>
 
         <div class="fieldRow">
-          <label class="fieldLbl">Server API key</label>
-          <input id="setJfApiKey" class="input" type="password" autocomplete="new-password" placeholder="(leave blank to keep existing)" />
-          <div class="hint">Makes RelayTV a shared Jellyfin cast target for users allowed to control shared devices. API keys are administrator-level secrets.</div>
-          <div class="toggleRow">
-            <div class="toggleCopy">
-              <div class="toggleTitle">Clear stored API key</div>
-              <div class="toggleHint">Remove the saved server API key on the next apply.</div>
-            </div>
-            <label class="toggleSwitch" for="setJfClearApiKey" title="Clear stored Jellyfin API key">
-              <input type="checkbox" id="setJfClearApiKey" />
-              <span class="toggleTrack" aria-hidden="true"></span>
-            </label>
-          </div>
-          <div class="hint" id="setJfApiKeyState"></div>
+          <label class="fieldLbl" for="setJfAuthMode">Cast target identity</label>
+          <select id="setJfAuthMode" class="input">
+            <option value="shared_api_key">Shared cast target (server API key)</option>
+            <option value="user_login">User-scoped cast target (username and password)</option>
+          </select>
+          <div class="hint" id="setJfAuthModeHint"></div>
         </div>
 
-        <div class="fieldRow">
-          <label class="fieldLbl">Username</label>
-          <input id="setJfUsername" class="input" placeholder="server username" />
+        <div id="setJfSharedAuthFields">
+          <div class="fieldRow">
+            <label class="fieldLbl">Server API key</label>
+            <input id="setJfApiKey" class="input" type="password" autocomplete="new-password" placeholder="(leave blank to keep existing)" />
+            <div class="hint">Makes RelayTV a shared cast target for every Jellyfin user allowed to control shared devices. API keys are administrator-level secrets.</div>
+            <div class="toggleRow">
+              <div class="toggleCopy">
+                <div class="toggleTitle">Clear stored API key</div>
+                <div class="toggleHint">Remove the saved server API key on the next apply.</div>
+              </div>
+              <label class="toggleSwitch" for="setJfClearApiKey" title="Clear stored Jellyfin API key">
+                <input type="checkbox" id="setJfClearApiKey" />
+                <span class="toggleTrack" aria-hidden="true"></span>
+              </label>
+            </div>
+            <div class="hint" id="setJfApiKeyState"></div>
+          </div>
+        </div>
+
+        <div id="setJfUserAuthFields">
+          <div class="fieldRow">
+            <label class="fieldLbl">Username</label>
+            <input id="setJfUsername" class="input" placeholder="server username" />
+          </div>
+          <div class="fieldRow">
+            <label class="fieldLbl">Password</label>
+            <input id="setJfPassword" class="input" type="password" autocomplete="new-password" placeholder="(leave blank to keep existing)" />
+            <div class="toggleRow">
+              <div class="toggleCopy">
+                <div class="toggleTitle">Clear stored password</div>
+                <div class="toggleHint">Remove the saved server password on the next apply.</div>
+              </div>
+              <label class="toggleSwitch" for="setJfClearPassword" title="Clear stored password">
+                <input type="checkbox" id="setJfClearPassword" />
+                <span class="toggleTrack" aria-hidden="true"></span>
+              </label>
+            </div>
+            <div class="hint" id="setJfPasswordState"></div>
+          </div>
         </div>
         <div class="fieldRow">
           <label class="fieldLbl">Preferred user ID (optional)</label>
           <input id="setJfUserId" class="input" placeholder="Server user Id (UUID)" />
-          <div class="hint">Optional profile override for catalog browsing on this TV. Leave blank to use the authenticated user.</div>
-        </div>
-        <div class="fieldRow">
-          <label class="fieldLbl">Password</label>
-          <input id="setJfPassword" class="input" type="password" autocomplete="new-password" placeholder="(leave blank to keep existing)" />
-          <div class="toggleRow">
-            <div class="toggleCopy">
-              <div class="toggleTitle">Clear stored password</div>
-              <div class="toggleHint">Remove the saved server password on the next apply.</div>
-            </div>
-            <label class="toggleSwitch" for="setJfClearPassword" title="Clear stored password">
-              <input type="checkbox" id="setJfClearPassword" />
-              <span class="toggleTrack" aria-hidden="true"></span>
-            </label>
-          </div>
-          <div class="hint" id="setJfPasswordState"></div>
+          <div class="hint">Optional profile override for catalog browsing on this TV. In user-login mode, leave blank to use the authenticated user.</div>
         </div>
         <div class="fieldRow">
           <label class="fieldLbl">Preferred audio language</label>

--- a/app/relaytv_app/routes/settings.py
+++ b/app/relaytv_app/routes/settings.py
@@ -50,6 +50,7 @@ class SettingsReq(BaseModel):
     jellyfin_enabled: bool | None = None
     jellyfin_server_url: str | None = None
     jellyfin_api_key: str | None = None
+    jellyfin_auth_mode: str | None = None
     jellyfin_username: str | None = None
     jellyfin_password: str | None = None
     jellyfin_user_id: str | None = None
@@ -228,6 +229,17 @@ def update_settings(req: SettingsReq):
     elif clear_seerr_key:
         patch["seerr_api_key"] = ""
     requested_keys = set(patch.keys())
+    # Backward compatibility for API clients written before the explicit mode:
+    # submitting a non-empty API key historically meant shared cast behavior.
+    if "jellyfin_api_key" in requested_keys and "jellyfin_auth_mode" not in requested_keys:
+        if str(patch.get("jellyfin_api_key") or "").strip():
+            patch["jellyfin_auth_mode"] = "shared_api_key"
+            requested_keys.add("jellyfin_auth_mode")
+    if "jellyfin_auth_mode" in requested_keys:
+        auth_mode = str(patch.get("jellyfin_auth_mode") or "").strip().lower()
+        if auth_mode not in {"shared_api_key", "user_login"}:
+            raise HTTPException(status_code=400, detail="Invalid Jellyfin authentication mode")
+        patch["jellyfin_auth_mode"] = auth_mode
     if "seerr_server_url" in requested_keys:
         try:
             patch["seerr_server_url"] = normalize_server_url(patch.get("seerr_server_url"))
@@ -402,7 +414,7 @@ def update_settings(req: SettingsReq):
     if "jellyfin_server_type" in requested_keys and updated.get("jellyfin_server_type") is not None:
         runtime_config.set_value("RELAYTV_JELLYFIN_SERVER_TYPE", str(updated.get("jellyfin_server_type") or "jellyfin").strip().lower())
     if requested_keys.intersection(
-        {"jellyfin_enabled", "jellyfin_server_url", "jellyfin_api_key", "jellyfin_username", "jellyfin_password"}
+        {"jellyfin_enabled", "jellyfin_server_url", "jellyfin_api_key", "jellyfin_auth_mode", "jellyfin_username", "jellyfin_password"}
     ):
         runtime_config.set_value("RELAYTV_JELLYFIN_AUTH_ENABLED", "1")
 
@@ -485,6 +497,7 @@ def update_settings(req: SettingsReq):
         "jellyfin_enabled",
         "jellyfin_server_url",
         "jellyfin_api_key",
+        "jellyfin_auth_mode",
         "jellyfin_username",
         "jellyfin_password",
     }
@@ -493,13 +506,20 @@ def update_settings(req: SettingsReq):
             jf_enabled = bool(updated.get("jellyfin_enabled"))
             jf_server = str(updated.get("jellyfin_server_url") or "").strip()
             jf_api_key = str(updated.get("jellyfin_api_key") or "").strip()
+            jf_auth_mode = str(updated.get("jellyfin_auth_mode") or "user_login").strip()
             jf_user = str(updated.get("jellyfin_username") or "").strip()
             jf_pw = str(updated.get("jellyfin_password") or "").strip()
             jf_device_name = str(updated.get("device_name") or "RelayTV")
-            if jf_enabled and jf_server and (jf_api_key or (jf_user and jf_pw)):
+            credentials_ready = (
+                bool(jf_api_key)
+                if jf_auth_mode == "shared_api_key"
+                else bool(jf_user and jf_pw)
+            )
+            if jf_enabled and jf_server and credentials_ready:
                 jellyfin_receiver.connect(
                     server_url=jf_server,
                     api_key=jf_api_key,
+                    auth_mode=jf_auth_mode,
                     device_name=jf_device_name,
                 )
                 live_applied.extend(
@@ -510,7 +530,7 @@ def update_settings(req: SettingsReq):
                     k for k in sorted(requested_keys.intersection(jellyfin_setting_keys)) if k not in live_apply_failed
                 )
                 jellyfin_receiver.mark_error("jellyfin_server_url_required")
-            elif jf_enabled and not jf_api_key and (not jf_user or not jf_pw):
+            elif jf_enabled and not credentials_ready:
                 live_apply_failed.extend(
                     k for k in sorted(requested_keys.intersection(jellyfin_setting_keys)) if k not in live_apply_failed
                 )

--- a/app/relaytv_app/routes/settings.py
+++ b/app/relaytv_app/routes/settings.py
@@ -49,6 +49,7 @@ class SettingsReq(BaseModel):
     iptv_enabled: bool | None = None
     jellyfin_enabled: bool | None = None
     jellyfin_server_url: str | None = None
+    jellyfin_api_key: str | None = None
     jellyfin_username: str | None = None
     jellyfin_password: str | None = None
     jellyfin_user_id: str | None = None
@@ -76,6 +77,7 @@ def _settings_for_client(raw: dict | None) -> dict:
     out = dict(raw or {})
     has_jf_pw = bool(str(out.get("jellyfin_password") or "").strip())
     has_seerr_key = bool(str(out.get("seerr_api_key") or "").strip())
+    has_jf_api_key = bool(str(out.get("jellyfin_api_key") or "").strip())
     yt_cookie_path = str(out.get("youtube_cookies_path") or "").strip()
     has_yt_cookies = bool(yt_cookie_path) and os.path.exists(yt_cookie_path)
     out["jellyfin_password"] = ""
@@ -83,6 +85,7 @@ def _settings_for_client(raw: dict | None) -> dict:
     out["jellyfin_password_configured"] = has_jf_pw
     out["seerr_api_key"] = ""
     out["seerr_api_key_configured"] = has_seerr_key
+    out["jellyfin_api_key_configured"] = has_jf_api_key
     out["youtube_cookies_path"] = ""
     out["youtube_cookies_configured"] = has_yt_cookies
     out["youtube_use_invidious"] = bool(out.get("youtube_use_invidious"))
@@ -382,6 +385,8 @@ def update_settings(req: SettingsReq):
         )
     if "jellyfin_server_url" in requested_keys and updated.get("jellyfin_server_url") is not None:
         runtime_config.set_value("RELAYTV_JELLYFIN_SERVER_URL", str(updated.get("jellyfin_server_url") or "").strip())
+    if "jellyfin_api_key" in requested_keys and updated.get("jellyfin_api_key") is not None:
+        runtime_config.set_value("RELAYTV_JELLYFIN_API_KEY", str(updated.get("jellyfin_api_key") or "").strip())
     if "jellyfin_username" in requested_keys and updated.get("jellyfin_username") is not None:
         runtime_config.set_value("RELAYTV_JELLYFIN_USERNAME", str(updated.get("jellyfin_username") or "").strip())
     if "jellyfin_password" in requested_keys and updated.get("jellyfin_password") is not None:
@@ -396,7 +401,9 @@ def update_settings(req: SettingsReq):
         runtime_config.set_value("RELAYTV_JELLYFIN_PLAYBACK_MODE", str(updated.get("jellyfin_playback_mode") or "auto").strip().lower())
     if "jellyfin_server_type" in requested_keys and updated.get("jellyfin_server_type") is not None:
         runtime_config.set_value("RELAYTV_JELLYFIN_SERVER_TYPE", str(updated.get("jellyfin_server_type") or "jellyfin").strip().lower())
-    if requested_keys.intersection({"jellyfin_enabled", "jellyfin_server_url", "jellyfin_username", "jellyfin_password"}):
+    if requested_keys.intersection(
+        {"jellyfin_enabled", "jellyfin_server_url", "jellyfin_api_key", "jellyfin_username", "jellyfin_password"}
+    ):
         runtime_config.set_value("RELAYTV_JELLYFIN_AUTH_ENABLED", "1")
 
     live_applied: list[str] = []
@@ -477,6 +484,7 @@ def update_settings(req: SettingsReq):
     jellyfin_setting_keys = {
         "jellyfin_enabled",
         "jellyfin_server_url",
+        "jellyfin_api_key",
         "jellyfin_username",
         "jellyfin_password",
     }
@@ -484,13 +492,14 @@ def update_settings(req: SettingsReq):
         try:
             jf_enabled = bool(updated.get("jellyfin_enabled"))
             jf_server = str(updated.get("jellyfin_server_url") or "").strip()
+            jf_api_key = str(updated.get("jellyfin_api_key") or "").strip()
             jf_user = str(updated.get("jellyfin_username") or "").strip()
             jf_pw = str(updated.get("jellyfin_password") or "").strip()
             jf_device_name = str(updated.get("device_name") or "RelayTV")
-            if jf_enabled and jf_server and jf_user and jf_pw:
+            if jf_enabled and jf_server and (jf_api_key or (jf_user and jf_pw)):
                 jellyfin_receiver.connect(
                     server_url=jf_server,
-                    api_key="",
+                    api_key=jf_api_key,
                     device_name=jf_device_name,
                 )
                 live_applied.extend(
@@ -501,11 +510,11 @@ def update_settings(req: SettingsReq):
                     k for k in sorted(requested_keys.intersection(jellyfin_setting_keys)) if k not in live_apply_failed
                 )
                 jellyfin_receiver.mark_error("jellyfin_server_url_required")
-            elif jf_enabled and (not jf_user or not jf_pw):
+            elif jf_enabled and not jf_api_key and (not jf_user or not jf_pw):
                 live_apply_failed.extend(
                     k for k in sorted(requested_keys.intersection(jellyfin_setting_keys)) if k not in live_apply_failed
                 )
-                jellyfin_receiver.mark_error("jellyfin_login_required")
+                jellyfin_receiver.mark_error("jellyfin_credentials_required")
             else:
                 jellyfin_receiver.disconnect()
                 live_applied.extend(

--- a/app/relaytv_app/state.py
+++ b/app/relaytv_app/state.py
@@ -108,6 +108,13 @@ def _normalize_jellyfin_playback_mode(v: object) -> str:
     return "auto"
 
 
+def _normalize_jellyfin_auth_mode(v: object, *, api_key_configured: bool = False) -> str:
+    s = str(v or "").strip().lower()
+    if s in ("shared_api_key", "user_login"):
+        return s
+    return "shared_api_key" if api_key_configured else "user_login"
+
+
 def _normalize_jellyfin_server_type(v: object) -> str:
     s = str(v or "").strip().lower()
     if s in ("jellyfin", "emby"):
@@ -944,6 +951,7 @@ def _default_settings() -> dict:
     quality_mode = _normalize_quality_mode(os.getenv("RELAYTV_QUALITY_MODE"))
     quality_cap = _normalize_quality_cap(os.getenv("RELAYTV_QUALITY_CAP"))
     seerr_defaults = seerr_settings_from_env()
+    jellyfin_api_key = (os.getenv("RELAYTV_JELLYFIN_API_KEY") or "").strip()
     return {
         "device_name": device_name,
         "video_mode": (os.getenv("RELAYTV_VIDEO_MODE", "auto") or "auto").strip().lower(),
@@ -981,7 +989,10 @@ def _default_settings() -> dict:
         ),
         "jellyfin_enabled": _env_bool("RELAYTV_JELLYFIN_ENABLED", False),
         "jellyfin_server_url": (os.getenv("RELAYTV_JELLYFIN_SERVER_URL") or "").strip(),
-        "jellyfin_api_key": (os.getenv("RELAYTV_JELLYFIN_API_KEY") or "").strip(),
+        "jellyfin_api_key": jellyfin_api_key,
+        "jellyfin_auth_mode": _normalize_jellyfin_auth_mode(
+            None, api_key_configured=bool(jellyfin_api_key)
+        ),
         "jellyfin_auth_enabled": _env_bool("RELAYTV_JELLYFIN_AUTH_ENABLED", True),
         "jellyfin_username": (os.getenv("RELAYTV_JELLYFIN_USERNAME") or "").strip(),
         "jellyfin_password": (os.getenv("RELAYTV_JELLYFIN_PASSWORD") or "").strip(),
@@ -1001,6 +1012,10 @@ def load_settings() -> None:
     data = _load_json(path, {})
     if isinstance(data, dict):
         defaults.update({k: v for k, v in data.items() if v is not None})
+        if "jellyfin_auth_mode" not in data:
+            defaults["jellyfin_auth_mode"] = _normalize_jellyfin_auth_mode(
+                None, api_key_configured=bool(str(defaults.get("jellyfin_api_key") or "").strip())
+            )
         if "seerr_request_mode" not in data:
             defaults["seerr_request_mode"] = (
                 "shared_admin"
@@ -1022,6 +1037,10 @@ def load_settings() -> None:
     defaults["weather"] = _normalize_weather_settings(defaults.get("weather"))
     defaults["uploads"] = _normalize_upload_settings(defaults.get("uploads"))
     defaults["jellyfin_playback_mode"] = _normalize_jellyfin_playback_mode(defaults.get("jellyfin_playback_mode"))
+    defaults["jellyfin_auth_mode"] = _normalize_jellyfin_auth_mode(
+        defaults.get("jellyfin_auth_mode"),
+        api_key_configured=bool(str(defaults.get("jellyfin_api_key") or "").strip()),
+    )
     defaults["jellyfin_server_type"] = _normalize_jellyfin_server_type(defaults.get("jellyfin_server_type"))
     defaults["seerr_enabled"] = bool(defaults.get("seerr_enabled"))
     defaults["seerr_server_url"] = str(defaults.get("seerr_server_url") or "").strip()
@@ -1081,6 +1100,7 @@ def update_settings(patch: dict) -> dict:
         "jellyfin_enabled",
         "jellyfin_server_url",
         "jellyfin_api_key",
+        "jellyfin_auth_mode",
         "jellyfin_auth_enabled",
         "jellyfin_username",
         "jellyfin_password",
@@ -1169,6 +1189,11 @@ def update_settings(patch: dict) -> dict:
         clean["jellyfin_server_url"] = str(clean.get("jellyfin_server_url") or "").strip()
     if "jellyfin_api_key" in clean:
         clean["jellyfin_api_key"] = str(clean.get("jellyfin_api_key") or "").strip()
+    if "jellyfin_auth_mode" in clean:
+        clean["jellyfin_auth_mode"] = _normalize_jellyfin_auth_mode(
+            clean.get("jellyfin_auth_mode"),
+            api_key_configured=bool(str(clean.get("jellyfin_api_key") or "").strip()),
+        )
     if "jellyfin_username" in clean:
         clean["jellyfin_username"] = str(clean.get("jellyfin_username") or "").strip()
     if "jellyfin_password" in clean:

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -2396,6 +2396,21 @@ function syncSeerrRequestModeUi(){
   }
 }
 
+function syncJellyfinAuthModeUi(){
+  const modeSelect = document.getElementById('setJfAuthMode');
+  const mode = String(modeSelect?.value || 'user_login');
+  const sharedFields = document.getElementById('setJfSharedAuthFields');
+  const userFields = document.getElementById('setJfUserAuthFields');
+  const hint = document.getElementById('setJfAuthModeHint');
+  if (sharedFields) sharedFields.classList.toggle('hidden', mode !== 'shared_api_key');
+  if (userFields) userFields.classList.toggle('hidden', mode !== 'user_login');
+  if (hint) {
+    hint.textContent = mode === 'shared_api_key'
+      ? 'One administrator API identity advertises RelayTV to every user allowed to control shared devices.'
+      : 'The stored Jellyfin user owns the cast session and catalog; other users do not share this target identity.';
+  }
+}
+
 async function loadSettingsUi(){
   const [devRes, setRes, tvRes, jfRes, seerrRes, seerrUsersRes] = await Promise.all([
     fetch('/devices'),
@@ -2437,6 +2452,7 @@ async function loadSettingsUi(){
   const iptvEnabled = document.getElementById('setIptvEnabled');
   const jfEnabled = document.getElementById('setJfEnabled');
   const jfServerUrl = document.getElementById('setJfServerUrl');
+  const jfAuthMode = document.getElementById('setJfAuthMode');
   const jfApiKeyInput = document.getElementById('setJfApiKey');
   const jfClearApiKey = document.getElementById('setJfClearApiKey');
   const jfApiKeyState = document.getElementById('setJfApiKeyState');
@@ -2481,6 +2497,8 @@ async function loadSettingsUi(){
   );
   if (jfEnabled) jfEnabled.checked = !!cur.jellyfin_enabled;
   if (jfServerUrl) jfServerUrl.value = (cur.jellyfin_server_url || defaultJellyfinServerUrl());
+  if (jfAuthMode) jfAuthMode.value = (cur.jellyfin_auth_mode || (cur.jellyfin_api_key_configured ? 'shared_api_key' : 'user_login'));
+  syncJellyfinAuthModeUi();
   if (jfApiKeyInput) jfApiKeyInput.value = '';
   if (jfClearApiKey) jfClearApiKey.checked = false;
   if (jfApiKeyState) {
@@ -2707,6 +2725,8 @@ function bindSettingsUi(){
   const jfApplyMsg = document.getElementById('setJfApplyResult');
   const jfCacheClearBtn = document.getElementById('setJfCacheClearBtn');
   const jfCacheClearMsg = document.getElementById('setJfCacheClearResult');
+  const jfAuthModeSelect = document.getElementById('setJfAuthMode');
+  if (jfAuthModeSelect) jfAuthModeSelect.onchange = syncJellyfinAuthModeUi;
   const seerrApplyBtn = document.getElementById('setSeerrApplyBtn');
   const seerrTestBtn = document.getElementById('setSeerrTestBtn');
   const seerrApplyMsg = document.getElementById('setSeerrApplyResult');
@@ -2808,6 +2828,7 @@ function bindSettingsUi(){
     }
     const jfEnabled = !!document.getElementById('setJfEnabled')?.checked;
     const jfServer = (document.getElementById('setJfServerUrl')?.value || '').trim();
+    const jfAuthMode = String(document.getElementById('setJfAuthMode')?.value || 'user_login');
     const jfApiKey = (document.getElementById('setJfApiKey')?.value || '').trim();
     const jfClearApiKey = !!document.getElementById('setJfClearApiKey')?.checked;
     const jfApiKeyConfigured = (document.getElementById('setJfApiKeyState')?.getAttribute('data-configured') || '') === '1';
@@ -2825,13 +2846,15 @@ function bindSettingsUi(){
       if (!jfServer) { if (jfApplyMsg){ jfApplyMsg.classList.add('err'); jfApplyMsg.textContent='Server URL is required.'; } return; }
       const hasApiKey = !!jfApiKey || (jfApiKeyConfigured && !jfClearApiKey);
       const hasLogin = !!jfUser && (!!jfPass || (jfPwConfigured && !jfClearPw));
-      if (!hasApiKey && !hasLogin) { if (jfApplyMsg){ jfApplyMsg.classList.add('err'); jfApplyMsg.textContent='A server API key or username and password is required.'; } return; }
+      if (jfAuthMode === 'shared_api_key' && !hasApiKey) { if (jfApplyMsg){ jfApplyMsg.classList.add('err'); jfApplyMsg.textContent='A server API key is required for shared cast mode.'; } return; }
+      if (jfAuthMode === 'user_login' && !hasLogin) { if (jfApplyMsg){ jfApplyMsg.classList.add('err'); jfApplyMsg.textContent='A username and password is required for user-scoped mode.'; } return; }
     }
 
     const payload = {
       device_name: deviceName || 'RelayTV',
       jellyfin_enabled: jfEnabled,
       jellyfin_server_url: jfServer,
+      jellyfin_auth_mode: jfAuthMode,
       jellyfin_username: jfUser,
       jellyfin_user_id: jfUserId,
       jellyfin_audio_lang: jfAudioLang,
@@ -2982,6 +3005,7 @@ function bindSettingsUi(){
     const uploadRetentionHours = Number(document.getElementById('setUploadRetentionHours')?.value || '24');
     const jfEnabled = !!document.getElementById('setJfEnabled')?.checked;
     const jfServer = (document.getElementById('setJfServerUrl')?.value || '').trim();
+    const jfAuthMode = String(document.getElementById('setJfAuthMode')?.value || 'user_login');
     const jfApiKey = (document.getElementById('setJfApiKey')?.value || '').trim();
     const jfClearApiKey = !!document.getElementById('setJfClearApiKey')?.checked;
     const jfApiKeyConfigured = (document.getElementById('setJfApiKeyState')?.getAttribute('data-configured') || '') === '1';
@@ -3015,7 +3039,8 @@ function bindSettingsUi(){
       if (!jfServer) { alert(`${jfBrandName()} server URL is required.`); return; }
       const hasApiKey = !!jfApiKey || (jfApiKeyConfigured && !jfClearApiKey);
       const hasLogin = !!jfUser && (!!jfPass || (jfPwConfigured && !jfClearPw));
-      if (!hasApiKey && !hasLogin) { alert(`A ${jfBrandName()} server API key or username and password is required.`); return; }
+      if (jfAuthMode === 'shared_api_key' && !hasApiKey) { alert(`A ${jfBrandName()} server API key is required for shared cast mode.`); return; }
+      if (jfAuthMode === 'user_login' && !hasLogin) { alert(`A ${jfBrandName()} username and password is required for user-scoped mode.`); return; }
     }
     if (seerrEnabled && !seerrServerUrl) { alert('Seerr server URL is required.'); return; }
     if (seerrEnabled && seerrRequestMode !== 'caller_session' && !seerrApiKey && (!seerrApiKeyConfigured || seerrClearApiKey)) { alert('Seerr API key is required for shared browsing.'); return; }
@@ -3048,6 +3073,7 @@ function bindSettingsUi(){
       iptv_enabled: !!document.getElementById('setIptvEnabled')?.checked,
       jellyfin_enabled: jfEnabled,
       jellyfin_server_url: jfServer,
+      jellyfin_auth_mode: jfAuthMode,
       jellyfin_username: jfUser,
       jellyfin_user_id: jfUserId,
       jellyfin_audio_lang: jfAudioLang,

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -2437,6 +2437,9 @@ async function loadSettingsUi(){
   const iptvEnabled = document.getElementById('setIptvEnabled');
   const jfEnabled = document.getElementById('setJfEnabled');
   const jfServerUrl = document.getElementById('setJfServerUrl');
+  const jfApiKeyInput = document.getElementById('setJfApiKey');
+  const jfClearApiKey = document.getElementById('setJfClearApiKey');
+  const jfApiKeyState = document.getElementById('setJfApiKeyState');
   const jfUsername = document.getElementById('setJfUsername');
   const jfUserId = document.getElementById('setJfUserId');
   const jfPwInput = document.getElementById('setJfPassword');
@@ -2478,6 +2481,13 @@ async function loadSettingsUi(){
   );
   if (jfEnabled) jfEnabled.checked = !!cur.jellyfin_enabled;
   if (jfServerUrl) jfServerUrl.value = (cur.jellyfin_server_url || defaultJellyfinServerUrl());
+  if (jfApiKeyInput) jfApiKeyInput.value = '';
+  if (jfClearApiKey) jfClearApiKey.checked = false;
+  if (jfApiKeyState) {
+    const hasApiKey = !!cur.jellyfin_api_key_configured;
+    jfApiKeyState.textContent = hasApiKey ? 'Server API key is stored.' : 'No server API key stored.';
+    jfApiKeyState.setAttribute('data-configured', hasApiKey ? '1' : '0');
+  }
   if (jfUsername) jfUsername.value = (cur.jellyfin_username || '');
   if (jfUserId) jfUserId.value = (cur.jellyfin_user_id || '');
   if (jfAudioLang) jfAudioLang.value = (cur.jellyfin_audio_lang || '');
@@ -2791,6 +2801,9 @@ function bindSettingsUi(){
     }
     const jfEnabled = !!document.getElementById('setJfEnabled')?.checked;
     const jfServer = (document.getElementById('setJfServerUrl')?.value || '').trim();
+    const jfApiKey = (document.getElementById('setJfApiKey')?.value || '').trim();
+    const jfClearApiKey = !!document.getElementById('setJfClearApiKey')?.checked;
+    const jfApiKeyConfigured = (document.getElementById('setJfApiKeyState')?.getAttribute('data-configured') || '') === '1';
     const jfUser = (document.getElementById('setJfUsername')?.value || '').trim();
     const jfUserId = (document.getElementById('setJfUserId')?.value || '').trim();
     const jfPass = (document.getElementById('setJfPassword')?.value || '').trim();
@@ -2803,8 +2816,9 @@ function bindSettingsUi(){
 
     if (jfEnabled) {
       if (!jfServer) { if (jfApplyMsg){ jfApplyMsg.classList.add('err'); jfApplyMsg.textContent='Server URL is required.'; } return; }
-      if (!jfUser) { if (jfApplyMsg){ jfApplyMsg.classList.add('err'); jfApplyMsg.textContent='Username is required.'; } return; }
-      if (!jfPass && !jfPwConfigured) { if (jfApplyMsg){ jfApplyMsg.classList.add('err'); jfApplyMsg.textContent='Password is required.'; } return; }
+      const hasApiKey = !!jfApiKey || (jfApiKeyConfigured && !jfClearApiKey);
+      const hasLogin = !!jfUser && (!!jfPass || (jfPwConfigured && !jfClearPw));
+      if (!hasApiKey && !hasLogin) { if (jfApplyMsg){ jfApplyMsg.classList.add('err'); jfApplyMsg.textContent='A server API key or username and password is required.'; } return; }
     }
 
     const payload = {
@@ -2818,6 +2832,7 @@ function bindSettingsUi(){
       jellyfin_playback_mode: (jfPlaybackMode === 'direct' || jfPlaybackMode === 'transcode') ? jfPlaybackMode : 'auto',
       apply_now: true
     };
+    if (jfApiKey || jfClearApiKey) payload.jellyfin_api_key = jfClearApiKey ? '' : jfApiKey;
     if (jfPass || jfClearPw) payload.jellyfin_password = jfClearPw ? '' : jfPass;
 
     if (jfApplyBtn) jfApplyBtn.disabled = true;
@@ -2960,6 +2975,9 @@ function bindSettingsUi(){
     const uploadRetentionHours = Number(document.getElementById('setUploadRetentionHours')?.value || '24');
     const jfEnabled = !!document.getElementById('setJfEnabled')?.checked;
     const jfServer = (document.getElementById('setJfServerUrl')?.value || '').trim();
+    const jfApiKey = (document.getElementById('setJfApiKey')?.value || '').trim();
+    const jfClearApiKey = !!document.getElementById('setJfClearApiKey')?.checked;
+    const jfApiKeyConfigured = (document.getElementById('setJfApiKeyState')?.getAttribute('data-configured') || '') === '1';
     const jfUser = (document.getElementById('setJfUsername')?.value || '').trim();
     const jfUserId = (document.getElementById('setJfUserId')?.value || '').trim();
     const jfPass = (document.getElementById('setJfPassword')?.value || '').trim();
@@ -2988,8 +3006,9 @@ function bindSettingsUi(){
     }
     if (jfEnabled) {
       if (!jfServer) { alert(`${jfBrandName()} server URL is required.`); return; }
-      if (!jfUser) { alert(`${jfBrandName()} username is required.`); return; }
-      if (!jfPass && !jfPwConfigured) { alert(`${jfBrandName()} password is required.`); return; }
+      const hasApiKey = !!jfApiKey || (jfApiKeyConfigured && !jfClearApiKey);
+      const hasLogin = !!jfUser && (!!jfPass || (jfPwConfigured && !jfClearPw));
+      if (!hasApiKey && !hasLogin) { alert(`A ${jfBrandName()} server API key or username and password is required.`); return; }
     }
     if (seerrEnabled && !seerrServerUrl) { alert('Seerr server URL is required.'); return; }
     if (seerrEnabled && seerrRequestMode !== 'caller_session' && !seerrApiKey && (!seerrApiKeyConfigured || seerrClearApiKey)) { alert('Seerr API key is required for shared browsing.'); return; }
@@ -3043,6 +3062,7 @@ function bindSettingsUi(){
     Object.entries(tvControl).forEach(([key, value]) => {
       if (tvBaseline[key] !== undefined && value !== tvBaseline[key]) payload[key] = value;
     });
+    if (jfApiKey || jfClearApiKey) payload.jellyfin_api_key = jfClearApiKey ? '' : jfApiKey;
     if (jfPass || jfClearPw) payload.jellyfin_password = jfClearPw ? '' : jfPass;
     if (seerrApiKey) payload.seerr_api_key = seerrApiKey;
     if (seerrClearApiKey) payload.seerr_api_key_clear = true;

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -2505,8 +2505,10 @@ async function loadSettingsUi(){
     const enabled = jfStatus && Object.prototype.hasOwnProperty.call(jfStatus, 'enabled')
       ? !!jfStatus.enabled
       : !!cur.jellyfin_enabled;
-    const up = !!(enabled && jfStatus && (jfStatus.connected || jfStatus.authenticated));
-    jfBadge.textContent = enabled ? (up ? 'Connected' : 'Down') : 'Disabled';
+    const castReady = !!(enabled && jfStatus && jfStatus.cast_target_ready);
+    const up = !!(enabled && jfStatus && (castReady || jfStatus.connected || jfStatus.authenticated));
+    const castScope = String((jfStatus && jfStatus.cast_target_scope) || 'unavailable');
+    jfBadge.textContent = enabled ? (castReady ? (castScope === 'shared' ? 'Shared Cast' : 'Cast Ready') : (up ? 'Connected' : 'Down')) : 'Disabled';
     jfBadge.classList.remove('up', 'down', 'warn', 'unknown');
     jfBadge.classList.add(enabled ? (up ? 'up' : 'down') : 'unknown');
   }
@@ -2522,6 +2524,11 @@ async function loadSettingsUi(){
       const pLat = Number.isFinite(Number(jfStatus.last_progress_latency_ms)) ? `${Number(jfStatus.last_progress_latency_ms)}ms` : 'n/a';
       const sLat = Number.isFinite(Number(jfStatus.last_stopped_latency_ms)) ? `${Number(jfStatus.last_stopped_latency_ms)}ms` : 'n/a';
       const auth = jfStatus.authenticated ? 'yes' : 'no';
+      const castReady = jfStatus.cast_target_ready ? 'ready' : 'not ready';
+      const castScope = (jfStatus.cast_target_scope || 'unavailable').toString();
+      const controlAuth = (jfStatus.control_auth_source || 'none').toString();
+      const catalogReady = jfStatus.catalog_ready ? 'ready' : 'not ready';
+      const catalogAuth = (jfStatus.catalog_auth_source || 'none').toString();
       const catalogUserId = (jfStatus.catalog_user_id || '').toString().trim();
       const catalogUserSource = (jfStatus.catalog_user_source || 'none').toString().trim();
       const catalogUser = catalogUserId ? `${catalogUserId} (${catalogUserSource || 'preferred'})` : 'auto';
@@ -2534,7 +2541,7 @@ async function loadSettingsUi(){
       const healthReason = (jfStatus.sync_health_reason || '').toString().trim();
       const err = (jfStatus.last_error || '').toString().trim();
       jfSyncDiag.textContent =
-        `Health: ${health}${healthReason ? ` (${healthReason})` : ''} · Auth: ${auth} · Catalog user: ${catalogUser} · Cache: ${cacheDiag} (clears: ${cacheClears}${cacheClearReason ? `, ${cacheClearReason}` : ''}) · Progress ok/fail: ${pOk}/${pFail} (${pLat}) · Stopped ok/fail: ${sOk}/${sFail} (${sLat}) · Stop dedupe: ${sSupp}` +
+        `Health: ${health}${healthReason ? ` (${healthReason})` : ''} · Cast: ${castReady}, ${castScope} (${controlAuth}) · Catalog: ${catalogReady} (${catalogAuth}), login: ${auth}, user: ${catalogUser} · Cache: ${cacheDiag} (clears: ${cacheClears}${cacheClearReason ? `, ${cacheClearReason}` : ''}) · Progress ok/fail: ${pOk}/${pFail} (${pLat}) · Stopped ok/fail: ${sOk}/${sFail} (${sLat}) · Stop dedupe: ${sSupp}` +
         (err ? ` · Last error: ${err}` : '');
     }
   }

--- a/docs/API.md
+++ b/docs/API.md
@@ -674,6 +674,8 @@ native Qt control surface.
     - `uploads`
     - `jellyfin_enabled`
     - `jellyfin_server_url`
+    - `jellyfin_api_key` (write-only; blank preserves the stored key)
+    - `jellyfin_auth_mode` (`shared_api_key | user_login`)
     - `jellyfin_username`
     - `jellyfin_password`
     - `jellyfin_user_id`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,6 +87,10 @@ milestone logs live in git history.
   request models. Playback enters through the Jellyfin command sink and the
   established playback service; neither the route nor Seerr service writes
   playback globals.
+- Jellyfin shared-cast commands expose an initiating controller identity, but
+  RelayTV does not yet switch catalog/watch-state attribution per caller.
+  `jellyfin_auth_mode=user_login` is one operator-configured account, not a
+  caller session; dynamic caller attribution remains an open product follow-up.
 - `scripts/`: install, doctor, host operations, and release support.
 
 ## Machine-Checked Guardrails

--- a/docs/ENV_INVENTORY.md
+++ b/docs/ENV_INVENTORY.md
@@ -145,7 +145,7 @@ direct-reader set (`state.py` defaults, child processes, entrypoint,
 | `RELAYTV_IPTV_MAX_PLAYLIST_BYTES` | `integrations/iptv_service.py` | - | static env |
 | `RELAYTV_IPTV_PROBE_TIMEOUT_SEC` | `integrations/iptv_service.py` | - | static env |
 | `RELAYTV_JELLYFIN_ADJACENT_SEASON_PROBE_MAX` | `integrations/jellyfin_receiver.py` | - | static env |
-| `RELAYTV_JELLYFIN_API_KEY` | `config.py`<br>`integrations/jellyfin_receiver.py`<br>`main.py`<br>`state.py` | `main.py` | settings bus |
+| `RELAYTV_JELLYFIN_API_KEY` | `config.py`<br>`integrations/jellyfin_receiver.py`<br>`main.py`<br>`routes/settings.py`<br>`state.py` | `main.py`<br>`routes/settings.py` | settings bus |
 | `RELAYTV_JELLYFIN_AUDIO_LANG` | `config.py`<br>`integrations/jellyfin_service.py`<br>`main.py`<br>`routes/settings.py`<br>`state.py` | `integrations/jellyfin_service.py`<br>`main.py`<br>`routes/settings.py` | settings bus |
 | `RELAYTV_JELLYFIN_AUTH_ENABLED` | `config.py`<br>`integrations/jellyfin_receiver.py`<br>`main.py`<br>`routes/settings.py`<br>`state.py` | `main.py`<br>`routes/settings.py` | settings bus |
 | `RELAYTV_JELLYFIN_AUTH_TIMEOUT_SEC` | `integrations/jellyfin_receiver.py` | - | static env |

--- a/docs/JELLYFIN_OPERATIONS.md
+++ b/docs/JELLYFIN_OPERATIONS.md
@@ -162,11 +162,17 @@ Shared URL behavior:
 
 ## Shared Cast Target Authentication
 
-For a cast target that users across the Jellyfin server can select, configure
-a **Server API key** in RelayTV Settings. Create the key in the Jellyfin admin
-dashboard under **Advanced → API Keys**, then paste it into the Jellyfin / Emby
-integration section and apply. Name the key **RelayTV** if you want Jellyfin's
-cast menu to label the target as `<configured device name> - RelayTV`.
+RelayTV Settings requires an explicit **Cast target identity** choice:
+
+- **Shared cast target (server API key)** advertises one userless device to
+  every Jellyfin user whose policy allows shared-device control.
+- **User-scoped cast target (username and password)** owns the control session
+  and catalog as the one stored Jellyfin account.
+
+For shared mode, create a key in the Jellyfin admin dashboard under
+**Advanced → API Keys**, select shared mode, paste the key, and apply. Name the
+key **RelayTV** if you want Jellyfin's cast menu to label the target as
+`<configured device name> - RelayTV`.
 
 The API key owns RelayTV's control plane:
 
@@ -174,8 +180,9 @@ The API key owns RelayTV's control plane:
 - capability registration and session readback;
 - playing, progress, and stopped reports.
 
-This registers RelayTV as a userless shared device instead of attaching it to
-the account RelayTV uses for catalog browsing. Jellyfin API keys are
+This registers RelayTV as a userless shared device. The same selected API key
+is used for control and catalog/media requests; stored username/password
+credentials are inactive while shared mode is selected. Jellyfin API keys are
 administrator-level credentials. RelayTV stores the value server-side, returns
 only `jellyfin_api_key_configured` to the Settings UI, and never includes the
 key in status responses or logs. Leaving the field blank preserves the stored
@@ -190,18 +197,11 @@ user. A shared API-key target is intentionally userless, so its API-key name is
 shown as the client suffix on the first row instead. Assigning a user merely to
 populate that second row would make the target user-scoped again.
 
-Username/password authentication is independent and remains recommended for
-RelayTV's on-device catalog. When both credentials are configured:
-
-- the server API key keeps the cast target shared;
-- the login-session token supplies catalog permissions, preferences, resume
-  positions, metadata, images, playback info, and media URLs;
-- a failed catalog login does not disconnect an otherwise healthy shared cast
-  target.
-
-Without an API key, RelayTV retains the legacy user-scoped target. Other users
-may not see or control that session unless their Jellyfin policies permit
-remote control of another user's session.
+In user-login mode, the login-session token is used for both control and
+catalog/media requests; a stored API key is inactive. Other users may not see
+or control that session unless their Jellyfin policies permit remote control
+of another user's session. Retaining inactive credentials makes switching
+modes reversible, but RelayTV never silently combines the two identities.
 
 An API-key-only configuration can run the shared cast target without a
 username or password. For catalog browsing in that mode, set a preferred user
@@ -212,9 +212,11 @@ ID when user-specific catalog routes are required.
 A command from another Jellyfin user reaches the shared target, including its
 `ControllingUserId`, but RelayTV does not yet use that identity to change the
 catalog profile or attribute playback reports. The on-device catalog continues
-to use the configured RelayTV catalog user, and resume/played state is not
-guaranteed to update for the person who initiated a remote cast. Caller-specific
-attribution is tracked as a follow-up after shared-target behavior is stable.
+to use the configured preferred user when one is set, and resume/played state
+is not guaranteed to update for the person who initiated a remote cast.
+User-login mode is one fixed operator-configured account, not per-browser
+caller identity. Dynamically attributing shared casts to the initiating caller
+remains a follow-up.
 
 ## Required Environment
 
@@ -226,17 +228,17 @@ Shared cast-target authentication:
 - `RELAYTV_JELLYFIN_API_KEY=<token>`
   - Equivalent to the Server API key field in Settings.
   - Preferred for a Jellyfin target shared across permitted users.
+  - An environment-provided API key implies shared mode for backward
+    compatibility; the explicit selector is persisted when configured in the UI.
 
-Optional user-scoped catalog authentication:
+User-scoped cast-target authentication:
 
 - `RELAYTV_JELLYFIN_AUTH_ENABLED=1` (default enabled)
 - `RELAYTV_JELLYFIN_USERNAME=<jellyfin-user>`
 - `RELAYTV_JELLYFIN_PASSWORD=<jellyfin-password>`
 
-Legacy authentication:
-
-- Username/password without an API key continues to create a user-scoped cast
-  target.
+- Select **User-scoped cast target** in Settings. Username/password without an
+  API key also defaults to user-login mode for backward compatibility.
 
 Optional identity:
 
@@ -378,6 +380,7 @@ Episode adjacency resilience:
 - `connected`
 - `last_error`
 - `api_key_configured`
+- `auth_mode` (`shared_api_key` or `user_login`)
 - `control_auth_source` (`api_key`, `user_session`, or `none`)
 - `cast_target_scope` (`shared`, `user_scoped`, or `unavailable`)
 - `cast_target_ready`
@@ -414,8 +417,8 @@ Discovery runtime status:
 
 1. Registration failing repeatedly:
    - Verify `RELAYTV_JELLYFIN_SERVER_URL` is reachable from container.
-   - Verify `RELAYTV_JELLYFIN_API_KEY` for a shared target, or verify the
-     username/password login for a legacy user-scoped target.
+   - Verify `RELAYTV_JELLYFIN_API_KEY` for shared mode, or verify the
+     username/password login for user-login mode.
    - Check `last_register_error` and `register_retry_failures` in status.
 2. Connected flips false after startup:
    - Inspect `last_progress_error`; progress posts can mark receiver disconnected on transport errors.
@@ -423,16 +426,17 @@ Discovery runtime status:
 3. Commands arrive but playback does not start:
    - Check RelayTV `/status` (`player_runtime_engine`, `backend_ready`).
    - Check `/integrations/jellyfin/command` response body for `reason` or suppression flags.
-4. RelayTV appears for its catalog account but not other users:
-   - Check `cast_target_scope`; `user_scoped` means no server API key is active.
-   - Add a Server API key in RelayTV Settings and wait for
+4. RelayTV appears for its configured account but not other users:
+   - Check `auth_mode` and `cast_target_scope`; `user_scoped` is intentionally
+     limited to the stored login identity.
+   - Select shared mode, add a Server API key in RelayTV Settings, and wait for
      `cast_target_scope: shared` and `cast_target_ready: true`.
    - In Jellyfin, enable shared-device control for each user who should see the
      target.
-5. Shared casting works but RelayTV catalog login fails:
-   - Check `catalog_ready`, `catalog_auth_source`, and `last_auth_error`.
-   - The cast target can remain healthy while the on-device catalog login is
-     repaired.
+5. The wrong identity appears active:
+   - Check `auth_mode`, `control_auth_source`, and `catalog_auth_source`.
+   - Both auth-source fields must match the selected mode; inactive stored
+     credentials are never used as fallback.
 6. Rotating the API key:
    - Create the replacement key in Jellyfin first.
    - Apply it in RelayTV Settings and wait for `cast_target_ready: true`.

--- a/docs/JELLYFIN_OPERATIONS.md
+++ b/docs/JELLYFIN_OPERATIONS.md
@@ -165,7 +165,8 @@ Shared URL behavior:
 For a cast target that users across the Jellyfin server can select, configure
 a **Server API key** in RelayTV Settings. Create the key in the Jellyfin admin
 dashboard under **Advanced → API Keys**, then paste it into the Jellyfin / Emby
-integration section and apply.
+integration section and apply. Name the key **RelayTV** if you want Jellyfin's
+cast menu to label the target as `<configured device name> - RelayTV`.
 
 The API key owns RelayTV's control plane:
 
@@ -183,6 +184,11 @@ key; use **Clear stored API key** to remove it explicitly.
 Jellyfin still applies its own user policy. The target is available to all
 users whose policy allows shared-device control; RelayTV cannot make it appear
 for a user whose Jellyfin **shared device control** permission is disabled.
+
+Jellyfin Web reserves the cast menu's second row for an authenticated session
+user. A shared API-key target is intentionally userless, so its API-key name is
+shown as the client suffix on the first row instead. Assigning a user merely to
+populate that second row would make the target user-scoped again.
 
 Username/password authentication is independent and remains recommended for
 RelayTV's on-device catalog. When both credentials are configured:

--- a/docs/JELLYFIN_OPERATIONS.md
+++ b/docs/JELLYFIN_OPERATIONS.md
@@ -160,23 +160,77 @@ Shared URL behavior:
   - TV episodes: `title = Series Name`, `channel = SxxExx · Episode Name`
   - Movies: `title = Movie Name`, `channel = Movie · Year`
 
+## Shared Cast Target Authentication
+
+For a cast target that users across the Jellyfin server can select, configure
+a **Server API key** in RelayTV Settings. Create the key in the Jellyfin admin
+dashboard under **Advanced → API Keys**, then paste it into the Jellyfin / Emby
+integration section and apply.
+
+The API key owns RelayTV's control plane:
+
+- cast websocket;
+- capability registration and session readback;
+- playing, progress, and stopped reports.
+
+This registers RelayTV as a userless shared device instead of attaching it to
+the account RelayTV uses for catalog browsing. Jellyfin API keys are
+administrator-level credentials. RelayTV stores the value server-side, returns
+only `jellyfin_api_key_configured` to the Settings UI, and never includes the
+key in status responses or logs. Leaving the field blank preserves the stored
+key; use **Clear stored API key** to remove it explicitly.
+
+Jellyfin still applies its own user policy. The target is available to all
+users whose policy allows shared-device control; RelayTV cannot make it appear
+for a user whose Jellyfin **shared device control** permission is disabled.
+
+Username/password authentication is independent and remains recommended for
+RelayTV's on-device catalog. When both credentials are configured:
+
+- the server API key keeps the cast target shared;
+- the login-session token supplies catalog permissions, preferences, resume
+  positions, metadata, images, playback info, and media URLs;
+- a failed catalog login does not disconnect an otherwise healthy shared cast
+  target.
+
+Without an API key, RelayTV retains the legacy user-scoped target. Other users
+may not see or control that session unless their Jellyfin policies permit
+remote control of another user's session.
+
+An API-key-only configuration can run the shared cast target without a
+username or password. For catalog browsing in that mode, set a preferred user
+ID when user-specific catalog routes are required.
+
+### Caller-specific watch state
+
+A command from another Jellyfin user reaches the shared target, including its
+`ControllingUserId`, but RelayTV does not yet use that identity to change the
+catalog profile or attribute playback reports. The on-device catalog continues
+to use the configured RelayTV catalog user, and resume/played state is not
+guaranteed to update for the person who initiated a remote cast. Caller-specific
+attribution is tracked as a follow-up after shared-target behavior is stable.
+
 ## Required Environment
 
 - `RELAYTV_JELLYFIN_ENABLED=1`
 - `RELAYTV_JELLYFIN_SERVER_URL=http://<jellyfin-host>:8096`
 
-Preferred authentication:
+Shared cast-target authentication:
+
+- `RELAYTV_JELLYFIN_API_KEY=<token>`
+  - Equivalent to the Server API key field in Settings.
+  - Preferred for a Jellyfin target shared across permitted users.
+
+Optional user-scoped catalog authentication:
 
 - `RELAYTV_JELLYFIN_AUTH_ENABLED=1` (default enabled)
 - `RELAYTV_JELLYFIN_USERNAME=<jellyfin-user>`
 - `RELAYTV_JELLYFIN_PASSWORD=<jellyfin-password>`
 
-Optional fallback authentication:
+Legacy authentication:
 
-- `RELAYTV_JELLYFIN_API_KEY=<token>`
-  - Supported for compatibility and for API-key-only deployments.
-  - The Settings UI path prefers username/password auth and masks the password
-    on reads.
+- Username/password without an API key continues to create a user-scoped cast
+  target.
 
 Optional identity:
 
@@ -216,6 +270,11 @@ The integration is wire-compatible with Emby: point `jellyfin_server_url` (or
 `RELAYTV_JELLYFIN_SERVER_URL`) at an Emby base URL and everything else works
 unchanged — auth (username/password or API key), catalog browsing, playback,
 track selection, and progress/stopped reporting.
+
+The shared/userless session behavior and per-user shared-device permission
+described above are verified against Jellyfin. Emby accepts the same API-key
+transport, but operators should validate cast-target visibility for their Emby
+version and user-policy configuration.
 
 Server-type detection:
 
@@ -313,6 +372,11 @@ Episode adjacency resilience:
 - `connected`
 - `last_error`
 - `api_key_configured`
+- `control_auth_source` (`api_key`, `user_session`, or `none`)
+- `cast_target_scope` (`shared`, `user_scoped`, or `unavailable`)
+- `cast_target_ready`
+- `catalog_auth_source` (`user_session`, `api_key`, or `none`)
+- `catalog_ready`
 - `last_register_ts`, `last_register_ok`, `last_register_error`
 - `last_progress_ts`, `last_progress_ok`, `last_progress_error`
 - `register_retry_failures`
@@ -321,7 +385,6 @@ Episode adjacency resilience:
 - `media_control_verified` (session readback; `null` until attempted)
 - `last_register_reason` (why registration was last invalidated)
 - `last_playing_ts`, `last_playing_ok`, `last_playing_error`
-- `cast_target_ready`
 - `ws_enabled`, `ws_available`, `ws_connected`
 - `ws_last_connect_ts`, `ws_last_error`, `ws_reconnects`, `ws_keepalive_sec`
 - `ws_commands_received`, `ws_commands_dropped`
@@ -345,8 +408,8 @@ Discovery runtime status:
 
 1. Registration failing repeatedly:
    - Verify `RELAYTV_JELLYFIN_SERVER_URL` is reachable from container.
-   - Verify username/password auth is valid, or verify
-     `RELAYTV_JELLYFIN_API_KEY` when using the optional fallback.
+   - Verify `RELAYTV_JELLYFIN_API_KEY` for a shared target, or verify the
+     username/password login for a legacy user-scoped target.
    - Check `last_register_error` and `register_retry_failures` in status.
 2. Connected flips false after startup:
    - Inspect `last_progress_error`; progress posts can mark receiver disconnected on transport errors.
@@ -354,6 +417,20 @@ Discovery runtime status:
 3. Commands arrive but playback does not start:
    - Check RelayTV `/status` (`player_runtime_engine`, `backend_ready`).
    - Check `/integrations/jellyfin/command` response body for `reason` or suppression flags.
+4. RelayTV appears for its catalog account but not other users:
+   - Check `cast_target_scope`; `user_scoped` means no server API key is active.
+   - Add a Server API key in RelayTV Settings and wait for
+     `cast_target_scope: shared` and `cast_target_ready: true`.
+   - In Jellyfin, enable shared-device control for each user who should see the
+     target.
+5. Shared casting works but RelayTV catalog login fails:
+   - Check `catalog_ready`, `catalog_auth_source`, and `last_auth_error`.
+   - The cast target can remain healthy while the on-device catalog login is
+     repaired.
+6. Rotating the API key:
+   - Create the replacement key in Jellyfin first.
+   - Apply it in RelayTV Settings and wait for `cast_target_ready: true`.
+   - Revoke the previous key only after the replacement target is healthy.
 
 ## Quick Verification
 
@@ -365,6 +442,17 @@ curl -sS -X POST http://127.0.0.1:8787/integrations/jellyfin/heartbeat
 curl -sS -X POST http://127.0.0.1:8787/smart \
   -H 'content-type: application/json' \
   -d '{"url":"http://<jellyfin>/Videos/<item-id>/stream?static=true"}'
+```
+
+For a shared target, the status response should include:
+
+```json
+{
+  "api_key_configured": true,
+  "control_auth_source": "api_key",
+  "cast_target_scope": "shared",
+  "cast_target_ready": true
+}
 ```
 
 ## Deprecated Legacy Endpoint

--- a/docs/release-highlights/0.11.0.md
+++ b/docs/release-highlights/0.11.0.md
@@ -1,0 +1,8 @@
+## 📺 One RelayTV cast target for the whole household
+
+RelayTV can now appear in Jellyfin as a shared cast target for every permitted
+user, with a clear Settings choice between an administrator API key and a
+user-scoped login. Device names stay recognizable while the underlying cast
+identity remains stable through renames and reconnects.
+
+---

--- a/tests/test_jellyfin_routes.py
+++ b/tests/test_jellyfin_routes.py
@@ -735,7 +735,17 @@ def test_status_route_exposes_jellyfin_server_type(monkeypatch) -> None:
     monkeypatch.setattr(
         routes.jellyfin_receiver,
         "status",
-        lambda: {"enabled": True, "running": True, "server_type": "emby", "server_url": "http://emby.local:8096"},
+        lambda: {
+            "enabled": True,
+            "running": True,
+            "server_type": "emby",
+            "server_url": "http://emby.local:8096",
+            "control_auth_source": "api_key",
+            "cast_target_scope": "shared",
+            "cast_target_ready": True,
+            "catalog_auth_source": "user_session",
+            "catalog_ready": True,
+        },
     )
 
     client = TestClient(create_app(testing=True))
@@ -745,3 +755,8 @@ def test_status_route_exposes_jellyfin_server_type(monkeypatch) -> None:
     body = response.json()
     assert body["jellyfin_server_type"] == "emby"
     assert body["jellyfin_server_url_configured"] is True
+    assert body["jellyfin_control_auth_source"] == "api_key"
+    assert body["jellyfin_cast_target_scope"] == "shared"
+    assert body["jellyfin_cast_target_ready"] is True
+    assert body["jellyfin_catalog_auth_source"] == "user_session"
+    assert body["jellyfin_catalog_ready"] is True

--- a/tests/test_jellyfin_service.py
+++ b/tests/test_jellyfin_service.py
@@ -184,7 +184,11 @@ def _detail(**overrides) -> dict:
 
 
 def test_select_playback_url_direct_when_profile_is_healthy(monkeypatch) -> None:
-    monkeypatch.setattr(jellyfin_receiver, "get_item_detail", lambda iid, refresh=False: _detail())
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "get_item_detail",
+        lambda iid, refresh=False, user_id_override="": _detail(),
+    )
     monkeypatch.setattr(video_profile, "get_profile", lambda: {"decode_profile": "intel_amd64_qsv", "av1_allowed": True})
     monkeypatch.setattr(player, "native_qt_runtime_active", lambda: False)
 
@@ -443,10 +447,12 @@ def test_handle_command_playlist_enriches_queue_metadata(monkeypatch) -> None:
     monkeypatch.setattr(jellyfin_receiver, "session_token", lambda: "tok")
     monkeypatch.setattr(jellyfin_receiver, "api_key", lambda: "")
 
-    metadata_calls: list[str] = []
+    metadata_calls: list[tuple[str, str]] = []
 
-    def fake_metadata(iid, *, token_override="", server_url_override=""):
-        metadata_calls.append(iid)
+    def fake_metadata(
+        iid, *, token_override="", server_url_override="", user_id_override=""
+    ):
+        metadata_calls.append((iid, user_id_override))
         return {
             "title": f"Episode {iid}",
             "channel": "Series · S01",
@@ -464,22 +470,45 @@ def test_handle_command_playlist_enriches_queue_metadata(monkeypatch) -> None:
     monkeypatch.setattr(state, "NOW_PLAYING", {})
     monkeypatch.setattr(state, "persist_queue", lambda: None)
     monkeypatch.setattr(jellyfin_service, "emit_progress_hint", lambda: None)
+    smart_item_users: list[str] = []
+
+    def fake_smart_item(url, start_pos=None, user_id_override=""):
+        smart_item_users.append(user_id_override)
+        return {"url": url, "title": "Episode ep-1"}
+
     monkeypatch.setattr(
-        jellyfin_service, "smart_item_from_url", lambda url, start_pos=None: {"url": url, "title": "Episode ep-1"}
+        jellyfin_service,
+        "smart_item_from_url",
+        fake_smart_item,
     )
-    monkeypatch.setattr(jellyfin_service, "preferred_stream_indices", lambda iid: ("", ""))
+    monkeypatch.setattr(
+        jellyfin_service,
+        "preferred_stream_indices",
+        lambda iid, user_id_override="": ("", ""),
+    )
     monkeypatch.setattr(playback_service, "suppress_auto_next", lambda sec, **kw: None)
     monkeypatch.setattr(playback_service, "play_now", lambda item, **kw: dict(item))
     monkeypatch.setattr(playback_service, "update_now_playing", lambda now: None)
 
     out = jellyfin_service.handle_command(
-        FakeCommandReq(action="Play", payload={"ItemIds": ["ep-1", "ep-2", "ep-3"], "PlayCommand": "PlayNow"}),
+        FakeCommandReq(
+            action="Play",
+            payload={
+                "ItemIds": ["ep-1", "ep-2", "ep-3"],
+                "PlayCommand": "PlayNow",
+                "ControllingUserId": "gavin-user-id",
+            },
+        ),
         controls={},
         ui=_noop_ui(),
     )
 
     assert out["ok"] is True and out["action"] == "play"
-    assert metadata_calls == ["ep-2", "ep-3"]
+    assert metadata_calls == [
+        ("ep-2", "gavin-user-id"),
+        ("ep-3", "gavin-user-id"),
+    ]
+    assert smart_item_users == ["gavin-user-id"]
     assert [q["jellyfin_item_id"] for q in state.QUEUE] == ["ep-2", "ep-3"]
     assert [q["title"] for q in state.QUEUE] == ["Episode ep-2", "Episode ep-3"]
     assert state.QUEUE[0]["channel"] == "Series · S01"

--- a/tests/test_jellyfin_service.py
+++ b/tests/test_jellyfin_service.py
@@ -31,11 +31,10 @@ def _noop_ui() -> dict:
     }
 
 
-def test_catalog_token_prefers_login_session_over_server_api_key(monkeypatch) -> None:
-    monkeypatch.setattr(jellyfin_receiver, "session_token", lambda: "catalog-user-token")
-    monkeypatch.setattr(jellyfin_receiver, "api_key", lambda: "shared-api-key")
+def test_catalog_token_uses_receiver_selected_identity(monkeypatch) -> None:
+    monkeypatch.setattr(jellyfin_receiver, "catalog_token", lambda: "selected-token")
 
-    assert jellyfin_service.catalog_token() == "catalog-user-token"
+    assert jellyfin_service.catalog_token() == "selected-token"
 
 
 # --- command normalization -------------------------------------------------

--- a/tests/test_jellyfin_service.py
+++ b/tests/test_jellyfin_service.py
@@ -31,6 +31,13 @@ def _noop_ui() -> dict:
     }
 
 
+def test_catalog_token_prefers_login_session_over_server_api_key(monkeypatch) -> None:
+    monkeypatch.setattr(jellyfin_receiver, "session_token", lambda: "catalog-user-token")
+    monkeypatch.setattr(jellyfin_receiver, "api_key", lambda: "shared-api-key")
+
+    assert jellyfin_service.catalog_token() == "catalog-user-token"
+
+
 # --- command normalization -------------------------------------------------
 
 

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -85,6 +85,22 @@ def test_play_message_becomes_a_play_command() -> None:
     assert payload["MessageId"] == "m-1"
 
 
+def test_play_message_preserves_the_controlling_user() -> None:
+    routed = jellyfin_ws.normalize_message(
+        {
+            "MessageType": "Play",
+            "Data": {
+                "ItemIds": ["abc"],
+                "PlayCommand": "PlayNow",
+                "ControllingUserId": "different-user-id",
+            },
+        }
+    )
+
+    assert routed is not None
+    assert routed[1]["ControllingUserId"] == "different-user-id"
+
+
 def test_playstate_leaves_the_action_for_the_normalizer() -> None:
     """Playstate carries its verb in the body, which normalize_action reads."""
     from relaytv_app.integrations import jellyfin_service
@@ -916,6 +932,43 @@ def test_concurrent_server_switches_do_not_interleave(monkeypatch) -> None:
     product = str(jellyfin_receiver._STATUS["server_product_name"])
     expected = "Server B" if "b.local" in url else "Server A"
     assert product == expected, f"torn state: {url} reported as {product}"
+
+
+def test_rapid_api_key_rotation_leaves_one_current_shared_socket(monkeypatch) -> None:
+    """Every key rotation retires the previous shared identity exactly once."""
+    started: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(jellyfin_ws, "enabled", lambda: True)
+    monkeypatch.setattr(jellyfin_ws, "_ws_connect", object())
+    monkeypatch.setattr(jellyfin_receiver, "_start_worker", lambda: None)
+    monkeypatch.setattr(jellyfin_receiver, "_stop_worker", lambda: None)
+    monkeypatch.setattr(jellyfin_receiver, "_catalog_cache_clear", lambda: None)
+    monkeypatch.setattr(jellyfin_receiver, "_run_detection", lambda *args, **kwargs: {"ok": True})
+    monkeypatch.setattr(jellyfin_receiver, "command_sink_registered", lambda: True)
+
+    def _start(identity):
+        started.append(identity)
+        jellyfin_ws._CURRENT = jellyfin_ws._Session(identity)
+
+    monkeypatch.setattr(jellyfin_ws, "_start", _start)
+    expected_device_id = jellyfin_receiver.derive_device_id()
+    try:
+        for key in ("shared-key-1", "shared-key-2", "shared-key-3"):
+            jellyfin_receiver.connect(
+                server_url="http://jf.local:8096",
+                api_key=key,
+                device_name="Living Room",
+            )
+            jellyfin_ws.ensure_running()
+
+        assert len(started) == 3
+        assert len(set(started)) == 3
+        assert jellyfin_ws._CURRENT is not None
+        assert jellyfin_ws._CURRENT.bound == started[-1]
+        assert jellyfin_ws._CURRENT.bound == jellyfin_ws._identity()
+        assert jellyfin_receiver._STATUS["device_id"] == expected_device_id
+        assert jellyfin_receiver.control_token() == "shared-key-3"
+    finally:
+        jellyfin_ws._CURRENT = None
 
 
 # --- heartbeat generations -------------------------------------------------

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -262,6 +262,44 @@ def test_receiver_status_reports_socket_health_without_secrets() -> None:
     assert st["cast_target_ready"] is False
 
 
+def test_receiver_status_reports_shared_control_and_catalog_sources(monkeypatch) -> None:
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "running", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://jf.local:8096")
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "api_key_configured", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "authenticated", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "last_register_ok", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "media_control_verified", True)
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "_control_socket_status",
+        lambda: {"enabled": True, "available": True, "connected": True},
+    )
+
+    st = jellyfin_receiver.status()
+
+    assert st["control_auth_source"] == "api_key"
+    assert st["cast_target_scope"] == "shared"
+    assert st["cast_target_ready"] is True
+    assert st["catalog_auth_source"] == "user_session"
+    assert st["catalog_ready"] is True
+
+
+def test_receiver_status_reports_legacy_login_as_user_scoped(monkeypatch) -> None:
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "running", True)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://jf.local:8096")
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "api_key_configured", False)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "authenticated", True)
+
+    st = jellyfin_receiver.status()
+
+    assert st["control_auth_source"] == "user_session"
+    assert st["cast_target_scope"] == "user_scoped"
+    assert st["catalog_auth_source"] == "user_session"
+    assert st["catalog_ready"] is True
+
+
 # --- dispatch seam ---------------------------------------------------------
 
 
@@ -1152,6 +1190,41 @@ def test_authentication_cannot_publish_after_its_snapshot_is_disconnected(monkey
     assert jellyfin_receiver._STATUS["running"] is False
     assert jellyfin_receiver._STATUS["authenticated"] is False
     assert jellyfin_receiver._ACCESS_TOKEN == ""
+
+
+def test_catalog_auth_failure_does_not_degrade_shared_control(monkeypatch) -> None:
+    for key, value in (
+        ("enabled", True),
+        ("running", True),
+        ("connected", True),
+        ("server_url", "http://jf.local:8096"),
+        ("api_key_configured", True),
+        ("authenticated", False),
+        ("last_register_ok", True),
+        ("media_control_verified", True),
+        ("last_error", "control-plane-marker"),
+    ):
+        monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
+    monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "shared-api-key")
+    monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "")
+    monkeypatch.setattr(jellyfin_receiver, "_AUTH_USERNAME", "catalog-user")
+    monkeypatch.setattr(jellyfin_receiver, "_AUTH_PASSWORD", "bad-password")
+    monkeypatch.setattr(
+        jellyfin_receiver._urlrequest,
+        "urlopen",
+        lambda req, timeout=5: (_ for _ in ()).throw(OSError("catalog login rejected")),
+    )
+
+    result = jellyfin_receiver.authenticate_once()
+    st = jellyfin_receiver.status()
+
+    assert result["reason"] == "auth_failed"
+    assert st["connected"] is True
+    assert st["sync_health"] == "ok"
+    assert st["control_auth_source"] == "api_key"
+    assert st["cast_target_scope"] == "shared"
+    assert st["last_error"] == "control-plane-marker"
+    assert "catalog login rejected" in str(st["last_auth_error"])
 
 
 def test_context_http_request_never_reloads_a_new_servers_token(monkeypatch) -> None:

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -377,7 +377,7 @@ def test_connect_omits_proxy_on_an_older_websockets(monkeypatch) -> None:
     monkeypatch.setattr(
         jellyfin_receiver, "status", lambda: {"server_url": "http://jf.lan:8096", "device_id": "relaytv-den"}
     )
-    monkeypatch.setattr(jellyfin_receiver, "active_token", lambda: "tok")
+    monkeypatch.setattr(jellyfin_receiver, "control_token", lambda: "tok")
     monkeypatch.setattr(jellyfin_receiver, "invalidate_registration", lambda reason="": None)
 
     session = _session(deadline_sec=0.0)
@@ -479,17 +479,17 @@ def test_identity_fingerprints_the_token() -> None:
 
     real_status, real_token, real_sink = (
         jellyfin_receiver.status,
-        jellyfin_receiver.active_token,
+        jellyfin_receiver.control_token,
         jellyfin_receiver.command_sink_registered,
     )
     jellyfin_receiver.status = _fake_status
-    jellyfin_receiver.active_token = lambda: "super-secret-token"
+    jellyfin_receiver.control_token = lambda: "super-secret-token"
     jellyfin_receiver.command_sink_registered = lambda: True
     try:
         identity = mod._identity()
     finally:
         jellyfin_receiver.status = real_status
-        jellyfin_receiver.active_token = real_token
+        jellyfin_receiver.control_token = real_token
         jellyfin_receiver.command_sink_registered = real_sink
 
     assert identity is not None
@@ -559,7 +559,7 @@ def test_a_late_handshake_cannot_hijack_the_live_session(monkeypatch) -> None:
     monkeypatch.setattr(
         jellyfin_receiver, "status", lambda: {"server_url": "http://jf.lan:8096", "device_id": "relaytv-den"}
     )
-    monkeypatch.setattr(jellyfin_receiver, "active_token", lambda: "tok")
+    monkeypatch.setattr(jellyfin_receiver, "control_token", lambda: "tok")
     monkeypatch.setattr(jellyfin_receiver, "invalidate_registration", lambda reason="": invalidated.append(reason))
 
     retired = jellyfin_ws._Session(("u", "d", "f"))
@@ -594,7 +594,7 @@ def test_the_live_session_still_publishes_and_reasserts(monkeypatch) -> None:
     monkeypatch.setattr(
         jellyfin_receiver, "status", lambda: {"server_url": "http://jf.lan:8096", "device_id": "relaytv-den"}
     )
-    monkeypatch.setattr(jellyfin_receiver, "active_token", lambda: "tok")
+    monkeypatch.setattr(jellyfin_receiver, "control_token", lambda: "tok")
     monkeypatch.setattr(jellyfin_receiver, "invalidate_registration", lambda reason="": invalidated.append(reason))
 
     session = _session(deadline_sec=0.5)
@@ -629,7 +629,7 @@ def test_connect_bounds_the_closing_handshake(monkeypatch) -> None:
     monkeypatch.setattr(
         jellyfin_receiver, "status", lambda: {"server_url": "http://jf.lan:8096", "device_id": "relaytv-den"}
     )
-    monkeypatch.setattr(jellyfin_receiver, "active_token", lambda: "tok")
+    monkeypatch.setattr(jellyfin_receiver, "control_token", lambda: "tok")
     monkeypatch.setattr(jellyfin_receiver, "invalidate_registration", lambda reason="": None)
 
     session = _session(deadline_sec=0.0)
@@ -816,7 +816,7 @@ def test_disconnect_cannot_leave_a_socket_behind(monkeypatch) -> None:
         ("server_url", "http://jf.lan:8096"), ("device_id", "relaytv-abc"),
     ):
         monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
-    monkeypatch.setattr(jellyfin_receiver, "active_token", lambda: "tok")
+    monkeypatch.setattr(jellyfin_receiver, "control_token", lambda: "tok")
     monkeypatch.setattr(jellyfin_receiver, "command_sink_registered", lambda: True)
     # The real join waits a second for a parked heartbeat and then gives up.
     monkeypatch.setattr(jellyfin_receiver, "_stop_worker", lambda: time.sleep(1.0))
@@ -1059,6 +1059,39 @@ def test_authentication_captures_its_inputs_with_its_generation(monkeypatch) -> 
     assert jellyfin_receiver._request_context().generation != before
 
 
+def test_request_context_separates_shared_control_from_catalog_login(monkeypatch) -> None:
+    monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "shared-api-key")
+    monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "catalog-user-token")
+
+    context = jellyfin_receiver._request_context()
+
+    assert context.control_token == "shared-api-key"
+    assert context.catalog_token == "catalog-user-token"
+    assert jellyfin_receiver.control_token() == "shared-api-key"
+    assert jellyfin_receiver.catalog_token() == "catalog-user-token"
+
+
+def test_catalog_login_does_not_change_shared_socket_identity(monkeypatch) -> None:
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "status",
+        lambda: {
+            "enabled": True,
+            "running": True,
+            "server_url": "http://jf.local:8096",
+            "device_id": "relaytv-device",
+        },
+    )
+    monkeypatch.setattr(jellyfin_receiver, "command_sink_registered", lambda: True)
+    monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "shared-api-key")
+    monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "")
+    before = jellyfin_ws._identity()
+
+    monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "catalog-user-token")
+
+    assert jellyfin_ws._identity() == before
+
+
 def test_publish_is_a_single_critical_section() -> None:
     """Check and write must not be separable, or a transaction slips between."""
     applied: list[int] = []
@@ -1124,6 +1157,8 @@ def test_authentication_cannot_publish_after_its_snapshot_is_disconnected(monkey
 def test_context_http_request_never_reloads_a_new_servers_token(monkeypatch) -> None:
     """A URL and token captured together stay together even after a switch."""
     monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
+    monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "old-control-token")
+    monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "old-catalog-token")
     with jellyfin_receiver._LOCK:
         jellyfin_receiver._STATUS.update(
             {
@@ -1133,14 +1168,14 @@ def test_context_http_request_never_reloads_a_new_servers_token(monkeypatch) -> 
                 "device_id": "old-device",
             }
         )
-        jellyfin_receiver._ACCESS_TOKEN = "old-token"
     context = jellyfin_receiver._request_context()
 
     with jellyfin_receiver._control_socket_suspended():
         with jellyfin_receiver._LOCK:
             jellyfin_receiver._STATUS["server_url"] = "http://new.local:8096"
             jellyfin_receiver._STATUS["device_id"] = "new-device"
-            jellyfin_receiver._ACCESS_TOKEN = "new-token"
+            jellyfin_receiver._API_KEY = "new-control-token"
+            jellyfin_receiver._ACCESS_TOKEN = "new-catalog-token"
 
     requests: list[tuple[str, str | None]] = []
 
@@ -1158,7 +1193,7 @@ def test_context_http_request_never_reloads_a_new_servers_token(monkeypatch) -> 
     monkeypatch.setattr(jellyfin_receiver._urlrequest, "urlopen", _capture)
     jellyfin_receiver._post_json_for(context, "/Sessions/Playing/Progress", {"ItemId": "x"})
 
-    assert requests == [("http://old.local:8096/Sessions/Playing/Progress", "old-token")]
+    assert requests == [("http://old.local:8096/Sessions/Playing/Progress", "old-control-token")]
 
 
 def test_registration_post_and_readback_share_one_context(monkeypatch) -> None:
@@ -1170,13 +1205,14 @@ def test_registration_post_and_readback_share_one_context(monkeypatch) -> None:
         ("device_id", "relaytv-device"),
     ):
         monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
+    monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "shared-api-key")
     monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "session-token")
 
     def _post(context, path, payload, timeout=3.0):
-        seen.append(("post", id(context), context.server_url, context.token))
+        seen.append(("post", id(context), context.server_url, context.control_token))
 
     def _readback(context, device_id, timeout=3.0):
-        seen.append(("readback", id(context), context.server_url, context.token))
+        seen.append(("readback", id(context), context.server_url, context.control_token))
         return {"DeviceId": device_id, "SupportsMediaControl": True}
 
     monkeypatch.setattr(jellyfin_receiver, "_post_json_for", _post)
@@ -1186,8 +1222,8 @@ def test_registration_post_and_readback_share_one_context(monkeypatch) -> None:
 
     assert result["ok"] is True
     assert seen == [
-        ("post", seen[0][1], "http://jf.local:8096", "session-token"),
-        ("readback", seen[0][1], "http://jf.local:8096", "session-token"),
+        ("post", seen[0][1], "http://jf.local:8096", "shared-api-key"),
+        ("readback", seen[0][1], "http://jf.local:8096", "shared-api-key"),
     ]
 
 
@@ -1202,11 +1238,12 @@ def test_registration_switch_discards_the_old_context_result(monkeypatch) -> Non
         ("media_control_verified", None),
     ):
         monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
+    monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "")
     monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "old-token")
     posted: list[tuple[str, str, str]] = []
 
     def _post_then_switch(context, path, payload, timeout=3.0):
-        posted.append((_context_url(context, path), context.device_id, context.token))
+        posted.append((_context_url(context, path), context.device_id, context.control_token))
         with jellyfin_receiver._control_socket_suspended():
             with jellyfin_receiver._LOCK:
                 jellyfin_receiver._STATUS["server_url"] = "http://new.local:8096"

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -331,6 +331,7 @@ def test_receiver_status_reports_socket_health_without_secrets() -> None:
 
 
 def test_receiver_status_reports_shared_control_and_catalog_sources(monkeypatch) -> None:
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "auth_mode", "shared_api_key")
     monkeypatch.setitem(jellyfin_receiver._STATUS, "enabled", True)
     monkeypatch.setitem(jellyfin_receiver._STATUS, "running", True)
     monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://jf.local:8096")
@@ -349,7 +350,7 @@ def test_receiver_status_reports_shared_control_and_catalog_sources(monkeypatch)
     assert st["control_auth_source"] == "api_key"
     assert st["cast_target_scope"] == "shared"
     assert st["cast_target_ready"] is True
-    assert st["catalog_auth_source"] == "user_session"
+    assert st["catalog_auth_source"] == "api_key"
     assert st["catalog_ready"] is True
 
 
@@ -1202,16 +1203,31 @@ def test_authentication_captures_its_inputs_with_its_generation(monkeypatch) -> 
     assert jellyfin_receiver._request_context().generation != before
 
 
-def test_request_context_separates_shared_control_from_catalog_login(monkeypatch) -> None:
+def test_shared_mode_uses_only_api_key_even_when_login_token_exists(monkeypatch) -> None:
+    monkeypatch.setattr(jellyfin_receiver, "_AUTH_MODE", "shared_api_key")
     monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "shared-api-key")
     monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "catalog-user-token")
 
     context = jellyfin_receiver._request_context()
 
     assert context.control_token == "shared-api-key"
-    assert context.catalog_token == "catalog-user-token"
+    assert context.catalog_token == "shared-api-key"
     assert jellyfin_receiver.control_token() == "shared-api-key"
-    assert jellyfin_receiver.catalog_token() == "catalog-user-token"
+    assert jellyfin_receiver.catalog_token() == "shared-api-key"
+
+
+def test_user_login_mode_uses_only_session_even_when_api_key_is_stored(monkeypatch) -> None:
+    monkeypatch.setattr(jellyfin_receiver, "_AUTH_MODE", "user_login")
+    monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "inactive-api-key")
+    monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "user-session-token")
+
+    context = jellyfin_receiver._request_context()
+
+    assert context.auth_mode == "user_login"
+    assert context.control_token == "user-session-token"
+    assert context.catalog_token == "user-session-token"
+    assert jellyfin_receiver.control_token() == "user-session-token"
+    assert jellyfin_receiver.catalog_token() == "user-session-token"
 
 
 def test_catalog_login_does_not_change_shared_socket_identity(monkeypatch) -> None:
@@ -1226,6 +1242,7 @@ def test_catalog_login_does_not_change_shared_socket_identity(monkeypatch) -> No
         },
     )
     monkeypatch.setattr(jellyfin_receiver, "command_sink_registered", lambda: True)
+    monkeypatch.setattr(jellyfin_receiver, "_AUTH_MODE", "shared_api_key")
     monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "shared-api-key")
     monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "")
     before = jellyfin_ws._identity()
@@ -1310,6 +1327,7 @@ def test_catalog_auth_failure_does_not_degrade_shared_control(monkeypatch) -> No
         ("last_error", "control-plane-marker"),
     ):
         monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "auth_mode", "shared_api_key")
     monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "shared-api-key")
     monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "")
     monkeypatch.setattr(jellyfin_receiver, "_AUTH_USERNAME", "catalog-user")
@@ -1336,6 +1354,7 @@ def test_context_http_request_never_reloads_a_new_servers_token(monkeypatch) -> 
     """A URL and token captured together stay together even after a switch."""
     monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
     monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "old-control-token")
+    monkeypatch.setattr(jellyfin_receiver, "_AUTH_MODE", "shared_api_key")
     monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "old-catalog-token")
     with jellyfin_receiver._LOCK:
         jellyfin_receiver._STATUS.update(
@@ -1384,6 +1403,7 @@ def test_registration_post_and_readback_share_one_context(monkeypatch) -> None:
     ):
         monkeypatch.setitem(jellyfin_receiver._STATUS, key, value)
     monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "shared-api-key")
+    monkeypatch.setattr(jellyfin_receiver, "_AUTH_MODE", "shared_api_key")
     monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "session-token")
 
     def _post(context, path, payload, timeout=3.0):
@@ -1407,6 +1427,7 @@ def test_registration_post_and_readback_share_one_context(monkeypatch) -> None:
 
 def test_registration_switch_discards_the_old_context_result(monkeypatch) -> None:
     monkeypatch.setattr(jellyfin_ws, "enabled", lambda: False)
+    monkeypatch.setattr(jellyfin_receiver, "_AUTH_MODE", "user_login")
     for key, value in (
         ("enabled", True),
         ("running", True),

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -257,6 +257,58 @@ def test_socket_url_carries_the_token_and_device() -> None:
     assert jellyfin_ws.socket_url(server_url="http://jf.lan:8096", token="", device_id="d") == ""
 
 
+def test_socket_handshake_identifies_the_display_device_without_repeating_the_token(monkeypatch) -> None:
+    """API-key sockets otherwise inherit the server name and opaque DeviceId."""
+    seen: dict[str, object] = {}
+
+    class _Conn:
+        def recv(self, timeout=None):
+            raise TimeoutError
+
+        def send(self, message):
+            pass
+
+        def close(self):
+            pass
+
+    def _fake_connect(url, **kwargs):
+        seen["url"] = url
+        seen.update(kwargs)
+        return _Conn()
+
+    monkeypatch.setattr(jellyfin_ws, "_ws_connect", _fake_connect)
+    monkeypatch.setattr(
+        jellyfin_receiver,
+        "status",
+        lambda: {
+            "server_url": "http://jf.lan:8096",
+            "device_id": "relaytv-stable",
+            "device_name": "Living Room",
+            "client_name": "RelayTV",
+            "client_version": "1.0",
+        },
+    )
+    monkeypatch.setattr(jellyfin_receiver, "control_token", lambda: "shared-api-key")
+    monkeypatch.setattr(jellyfin_receiver, "invalidate_registration", lambda reason="": None)
+
+    session = _session(deadline_sec=0.0)
+    jellyfin_ws._CURRENT = session
+    try:
+        jellyfin_ws._connect_once(session)
+    finally:
+        jellyfin_ws._CURRENT = None
+
+    assert "api_key=shared-api-key" in str(seen["url"])
+    headers = seen["additional_headers"]
+    assert headers == {
+        "Authorization": (
+            'MediaBrowser Client="RelayTV", Device="Living%20Room", '
+            'DeviceId="relaytv-stable", Version="1.0"'
+        )
+    }
+    assert "shared-api-key" not in str(headers)
+
+
 def test_the_access_token_never_reaches_status_or_logs(caplog) -> None:
     """A failed handshake reports the URL it tried, and that URL holds the token."""
     token = "super-secret-token"

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -1230,6 +1230,40 @@ def test_user_login_mode_uses_only_session_even_when_api_key_is_stored(monkeypat
     assert jellyfin_receiver.catalog_token() == "user-session-token"
 
 
+def test_shared_metadata_uses_the_controlling_user_context(monkeypatch) -> None:
+    requested: list[str] = []
+    jellyfin_receiver._catalog_cache_clear()
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "server_url", "http://jf.local:8096")
+    monkeypatch.setitem(jellyfin_receiver._STATUS, "device_id", "relaytv-device")
+    monkeypatch.setattr(jellyfin_receiver, "_AUTH_MODE", "shared_api_key")
+    monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "shared-api-key")
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {"Id": "movie-id", "Name": "Visible Movie", "Type": "Movie"}
+            ).encode()
+
+    def _open(req, timeout=5):
+        requested.append(req.full_url)
+        return _Response()
+
+    monkeypatch.setattr(jellyfin_receiver._urlrequest, "urlopen", _open)
+
+    metadata = jellyfin_receiver.get_item_metadata(
+        "movie-id", user_id_override="gavin-user-id"
+    )
+
+    assert metadata["title"] == "Visible Movie"
+    assert requested == ["http://jf.local:8096/Users/gavin-user-id/Items/movie-id"]
+
+
 def test_catalog_login_does_not_change_shared_socket_identity(monkeypatch) -> None:
     monkeypatch.setattr(
         jellyfin_receiver,

--- a/tests/test_public_media.py
+++ b/tests/test_public_media.py
@@ -110,6 +110,31 @@ def test_status_payload_redacts_runtime_media_without_mutating_state(monkeypatch
     assert item["_resolved_stream"].endswith("token=secret")
 
 
+def test_status_redacts_signed_urls_in_titles_and_runtime_telemetry(monkeypatch) -> None:
+    signed = "https://media.example/master.m3u8?api_key=secret&quality=1080"
+    monkeypatch.setattr(
+        routes.state,
+        "NOW_PLAYING",
+        {"provider": "jellyfin", "title": signed, "url": signed},
+        raising=False,
+    )
+    monkeypatch.setattr(routes.state, "QUEUE", [], raising=False)
+    monkeypatch.setattr(routes.state, "SESSION_STATE", "closed", raising=False)
+    monkeypatch.setattr(routes.player, "is_playing", lambda: False)
+    monkeypatch.setattr(
+        routes,
+        "_runtime_capabilities",
+        lambda playing=None: {"native_qt_mpv_runtime_path": signed},
+    )
+
+    payload = routes._status_payload()
+    serialized = json.dumps(payload)
+
+    assert payload["now_playing"]["title"] == "https://media.example/master.m3u8?quality=1080"
+    assert payload["native_qt_mpv_runtime_path"] == "https://media.example/master.m3u8?quality=1080"
+    assert "secret" not in serialized
+
+
 def _secret_item() -> dict:
     return {
         "title": "Movie",

--- a/tests/test_settings_config_sync.py
+++ b/tests/test_settings_config_sync.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from relaytv_app import routes
+from relaytv_app import state
 from relaytv_app.config import MIRRORED_TO_ENV, SETTINGS_BUS_VARS, runtime_config
 from relaytv_app.main import create_app
 from relaytv_app.routes import settings as settings_routes
@@ -173,6 +174,15 @@ def test_settings_apply_syncs_jellyfin_config(quiet_settings_apply) -> None:
     assert _cfg("RELAYTV_JELLYFIN_AUTH_ENABLED") == "1"
 
 
+def test_legacy_jellyfin_api_key_settings_infer_shared_auth_mode(monkeypatch) -> None:
+    monkeypatch.setattr(state, "_load_json", lambda path, default: {"jellyfin_api_key": "legacy-key"})
+    monkeypatch.setattr(state, "SETTINGS", {})
+
+    state.load_settings()
+
+    assert state.get_settings()["jellyfin_auth_mode"] == "shared_api_key"
+
+
 def test_settings_apply_syncs_seerr_config(quiet_settings_apply) -> None:
     _apply(
         seerr_enabled=True,
@@ -223,11 +233,57 @@ def test_settings_apply_connects_api_key_only_receiver(quiet_settings_apply, mon
         {
             "server_url": "https://jf.example",
             "api_key": "shared-key",
+            "auth_mode": "shared_api_key",
             "device_name": "RelayTV",
         }
     ]
     assert "jellyfin_api_key" in response["live_applied"]
     assert "jellyfin_api_key" not in response["live_apply_failed"]
+
+
+def test_settings_apply_selects_user_login_even_with_stored_api_key(
+    quiet_settings_apply, monkeypatch
+) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        routes.state,
+        "get_settings",
+        lambda: {
+            "jellyfin_api_key": "inactive-key",
+            "jellyfin_password": "stored-password",
+        },
+    )
+    monkeypatch.setattr(
+        routes.state,
+        "update_settings",
+        lambda patch: {
+            "jellyfin_api_key": "inactive-key",
+            "jellyfin_password": "stored-password",
+            **patch,
+        },
+    )
+    monkeypatch.setattr(
+        settings_routes.jellyfin_receiver,
+        "connect",
+        lambda **kwargs: calls.append(dict(kwargs)),
+    )
+
+    response = _apply(
+        jellyfin_enabled=True,
+        jellyfin_server_url="https://jf.example",
+        jellyfin_auth_mode="user_login",
+        jellyfin_username="mark",
+    )
+
+    assert calls == [
+        {
+            "server_url": "https://jf.example",
+            "api_key": "inactive-key",
+            "auth_mode": "user_login",
+            "device_name": "RelayTV",
+        }
+    ]
+    assert "jellyfin_auth_mode" in response["live_applied"]
 
 
 def test_settings_apply_clears_jellyfin_api_key(quiet_settings_apply) -> None:

--- a/tests/test_settings_config_sync.py
+++ b/tests/test_settings_config_sync.py
@@ -149,6 +149,7 @@ def test_settings_apply_syncs_jellyfin_config(quiet_settings_apply) -> None:
     _apply(
         jellyfin_enabled=True,
         jellyfin_server_url=" https://jf.example ",
+        jellyfin_api_key=" shared-key ",
         jellyfin_username=" mark ",
         jellyfin_password=" hunter2 ",
         jellyfin_user_id=" uid-1 ",
@@ -160,6 +161,7 @@ def test_settings_apply_syncs_jellyfin_config(quiet_settings_apply) -> None:
 
     assert _cfg("RELAYTV_JELLYFIN_ENABLED") == "1"
     assert _cfg("RELAYTV_JELLYFIN_SERVER_URL") == "https://jf.example"
+    assert _cfg("RELAYTV_JELLYFIN_API_KEY") == "shared-key"
     assert _cfg("RELAYTV_JELLYFIN_USERNAME") == "mark"
     assert _cfg("RELAYTV_JELLYFIN_PASSWORD") == "hunter2"
     assert _cfg("RELAYTV_JELLYFIN_USER_ID") == "uid-1"
@@ -201,6 +203,39 @@ def test_settings_apply_syncs_server_type_to_live_receiver(quiet_settings_apply,
     assert applied == ["emby"]
     assert "jellyfin_server_type" in response["live_applied"]
     assert "jellyfin_server_type" not in response["live_apply_failed"]
+
+
+def test_settings_apply_connects_api_key_only_receiver(quiet_settings_apply, monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        settings_routes.jellyfin_receiver,
+        "connect",
+        lambda **kwargs: calls.append(dict(kwargs)),
+    )
+
+    response = _apply(
+        jellyfin_enabled=True,
+        jellyfin_server_url=" https://jf.example ",
+        jellyfin_api_key=" shared-key ",
+    )
+
+    assert calls == [
+        {
+            "server_url": "https://jf.example",
+            "api_key": "shared-key",
+            "device_name": "RelayTV",
+        }
+    ]
+    assert "jellyfin_api_key" in response["live_applied"]
+    assert "jellyfin_api_key" not in response["live_apply_failed"]
+
+
+def test_settings_apply_clears_jellyfin_api_key(quiet_settings_apply) -> None:
+    runtime_config.set_value("RELAYTV_JELLYFIN_API_KEY", "old-key")
+
+    _apply(jellyfin_api_key="")
+
+    assert _cfg("RELAYTV_JELLYFIN_API_KEY") == ""
 
 
 def test_settings_apply_does_not_write_env_beyond_mirror_contract(quiet_settings_apply) -> None:

--- a/tests/test_settings_routes.py
+++ b/tests/test_settings_routes.py
@@ -208,6 +208,16 @@ def test_settings_api_key_omission_preserves_and_explicit_values_replace_or_clea
     assert cleared.json()["settings"]["jellyfin_api_key_configured"] is False
 
 
+def test_settings_rejects_unknown_jellyfin_auth_mode(monkeypatch) -> None:
+    monkeypatch.setattr(routes.state, "get_settings", lambda: {})
+    client = TestClient(create_app(testing=True))
+
+    response = client.post("/settings", json={"jellyfin_auth_mode": "automatic"})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid Jellyfin authentication mode"
+
+
 def test_youtube_cookies_routes_upload_and_clear(monkeypatch, tmp_path) -> None:
     updates: list[dict[str, object]] = []
     target = tmp_path / "cookies.txt"

--- a/tests/test_settings_routes.py
+++ b/tests/test_settings_routes.py
@@ -35,6 +35,7 @@ def test_get_settings_route_sanitizes_secret_values(monkeypatch, tmp_path) -> No
     assert body["jellyfin_password_configured"] is True
     assert body["seerr_api_key"] == ""
     assert body["seerr_api_key_configured"] is True
+    assert body["jellyfin_api_key_configured"] is True
     assert body["youtube_cookies_path"] == ""
     assert body["youtube_cookies_configured"] is True
     assert body["youtube_use_invidious"] is True
@@ -167,6 +168,44 @@ def test_settings_normalize_jellyfin_server_type(monkeypatch) -> None:
     monkeypatch.setattr(state, "_atomic_write_json", lambda path, payload: None)
     assert state.update_settings({"jellyfin_server_type": " EMBY "})["jellyfin_server_type"] == "emby"
     assert state.update_settings({"jellyfin_server_type": "bogus"})["jellyfin_server_type"] == "jellyfin"
+
+
+def test_settings_api_key_omission_preserves_and_explicit_values_replace_or_clear(monkeypatch) -> None:
+    stored: dict[str, object] = {
+        "jellyfin_enabled": True,
+        "jellyfin_server_url": "https://jf.example",
+        "jellyfin_api_key": "old-key",
+        "jellyfin_username": "",
+        "jellyfin_password": "",
+    }
+    patches: list[dict[str, object]] = []
+
+    monkeypatch.setattr(routes.state, "get_settings", lambda: dict(stored))
+
+    def update(patch: dict[str, object]) -> dict[str, object]:
+        patches.append(dict(patch))
+        stored.update(patch)
+        return dict(stored)
+
+    monkeypatch.setattr(routes.state, "update_settings", update)
+    monkeypatch.setattr(routes.player, "is_playing", lambda: False)
+    monkeypatch.setattr(routes.jellyfin_receiver, "connect", lambda **kwargs: None)
+
+    client = TestClient(create_app(testing=True))
+
+    preserved = client.post("/settings", json={"jellyfin_server_url": "https://jf.example"})
+    replaced = client.post("/settings", json={"jellyfin_api_key": "new-key"})
+    cleared = client.post("/settings", json={"jellyfin_api_key": ""})
+
+    assert preserved.status_code == 200
+    assert "jellyfin_api_key" not in patches[0]
+    assert replaced.status_code == 200
+    assert patches[1]["jellyfin_api_key"] == "new-key"
+    assert cleared.status_code == 200
+    assert patches[2]["jellyfin_api_key"] == ""
+    assert replaced.json()["settings"]["jellyfin_api_key"] == ""
+    assert replaced.json()["settings"]["jellyfin_api_key_configured"] is True
+    assert cleared.json()["settings"]["jellyfin_api_key_configured"] is False
 
 
 def test_youtube_cookies_routes_upload_and_clear(monkeypatch, tmp_path) -> None:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -197,6 +197,9 @@ def test_ui_smoke() -> None:
     assert 'id="setYtUseInvidious"' in response.text
     assert 'id="setIdleQrEnabled"' in response.text
     assert 'id="setJfEnabled"' in response.text
+    assert 'id="setJfApiKey"' in response.text
+    assert 'id="setJfClearApiKey"' in response.text
+    assert js.count("payload.jellyfin_api_key = jfClearApiKey ? '' : jfApiKey;") == 2
     assert 'id="setJfClearPassword"' in response.text
     assert 'id="setJfStatus" class="sectionStatus unknown">Disabled</span>' in response.text
     assert "jfBadge.textContent = enabled ? (up ? 'Connected' : 'Down') : 'Disabled';" in js

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -197,9 +197,13 @@ def test_ui_smoke() -> None:
     assert 'id="setYtUseInvidious"' in response.text
     assert 'id="setIdleQrEnabled"' in response.text
     assert 'id="setJfEnabled"' in response.text
+    assert 'id="setJfAuthMode"' in response.text
+    assert 'value="shared_api_key"' in response.text
+    assert 'value="user_login"' in response.text
     assert 'id="setJfApiKey"' in response.text
     assert 'id="setJfClearApiKey"' in response.text
     assert js.count("payload.jellyfin_api_key = jfClearApiKey ? '' : jfApiKey;") == 2
+    assert js.count("jellyfin_auth_mode: jfAuthMode") == 2
     assert 'id="setJfClearPassword"' in response.text
     assert 'id="setJfStatus" class="sectionStatus unknown">Disabled</span>' in response.text
     assert "castScope === 'shared' ? 'Shared Cast' : 'Cast Ready'" in js

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1703,6 +1703,34 @@ def test_jellyfin_plugin_ingress_is_deprecated() -> None:
     }
 
 
+def test_jellyfin_resume_metadata_keeps_the_casting_user_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def fake_metadata(
+        item_id,
+        *,
+        token_override="",
+        server_url_override="",
+        user_id_override="",
+    ):
+        calls.append((item_id, user_id_override))
+        return {"title": "Visible Movie"}
+
+    monkeypatch.setattr(player.jellyfin_receiver, "get_item_metadata", fake_metadata)
+
+    hydrated = player._hydrate_jellyfin_resume_metadata(
+        {
+            "url": "http://jf.local/Videos/movie-id/master.m3u8?api_key=signed",
+            "title": "http://jf.local/Videos/movie-id/master.m3u8?api_key=signed",
+            "jellyfin_item_id": "movie-id",
+            "_jellyfin_metadata_user_id": "gavin-user-id",
+        }
+    )
+
+    assert calls == [("movie-id", "gavin-user-id")]
+    assert hydrated["title"] == "Visible Movie"
+
+
 def test_jellyfin_subtitle_options_include_off_row(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(routes, "_require_jellyfin_catalog_ready", lambda: {"server_url": "http://jf.local"})
     monkeypatch.setattr(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -202,7 +202,7 @@ def test_ui_smoke() -> None:
     assert js.count("payload.jellyfin_api_key = jfClearApiKey ? '' : jfApiKey;") == 2
     assert 'id="setJfClearPassword"' in response.text
     assert 'id="setJfStatus" class="sectionStatus unknown">Disabled</span>' in response.text
-    assert "jfBadge.textContent = enabled ? (up ? 'Connected' : 'Down') : 'Disabled';" in js
+    assert "castScope === 'shared' ? 'Shared Cast' : 'Cast Ready'" in js
     assert 'class="toggleSwitch"' in response.text
     assert 'data-idle-enable="${key}"' in js
     assert 'class="chk"' not in response.text


### PR DESCRIPTION
Roadmap PR 10 of 11 — closes F09 from #67.

## User impact

- Adds a clear Cast target identity selector in Settings: shared server API key or user-scoped username/password.
- Shared mode advertises one stable RelayTV target to every Jellyfin user permitted to control shared devices.
- Shared casts use the initiating command's user context for item detail, artwork, stream selection, queue enrichment, and resume hydration, so metadata works without binding the target to one household account.
- User-login mode keeps control, catalog, media, resume, and watched state on one configured user identity.
- Device renames update the display name without minting a new Jellyfin DeviceId.

## Identity and security model

The two modes are mutually exclusive at runtime. Shared mode uses only the server API key for control and catalog/media requests; user-login mode uses only its authenticated session token. Inactive stored credentials are retained so switching is reversible, but are never used as an implicit fallback. Legacy settings containing an API key infer shared mode on upgrade.

The API key and password remain write-only. `/settings` exposes only configured-state booleans. Signed playback URLs are scrubbed from public media fields and runtime telemetry at the final `/status` serialization boundary, including URL-shaped values that arrived in an unexpected display field after a metadata failure.

The shared target uses `ControllingUserId` only as request context for metadata and playback planning. Persisted caller attribution, per-user progress ownership, and user-visible attribution are not included; that caller-specific follow-up remains recorded in `docs/ARCHITECTURE.md`.

## Operator and deployment impact

Create a Jellyfin API key and select Shared cast target for an all-user device, or select User-scoped cast target and provide a username/password. Existing API-key installations migrate to shared mode automatically. No environment, route, container, or companion-app change is required.

Anyone who deployed an earlier preview revision of this branch should rotate that Jellyfin API key after updating: live soak testing found that a failed metadata lookup could temporarily expose a signed stream URL through unauthenticated status telemetry. The fix is included here; this branch has not yet shipped in a release.

Breaking changes: None.

## Testing

- 762 Python tests pass on this branch.
- 11 JavaScript tests pass on this branch.
- Ruff, Python/JavaScript syntax, generated overlay JavaScript, inventory checks, and `git diff --check` are clean.
- Four focused regressions were each confirmed to fail against their reverted fix: command-user propagation, user-scoped metadata URL selection, delayed resume hydration, and public status redaction.
- The complete open-PR integration stack passes 951 Python and 24 JavaScript tests on `test/audit-combined`.
- Live second-user testing confirmed that Gavin can discover the shared target, cast, pause, resume, and stop it while the target remains API-key authenticated and userless.

## Release highlight

Yes. Adds `docs/release-highlights/0.11.0.md` for the shared household cast target.


BEGIN_COMMIT_OVERRIDE
fix: configure shared Jellyfin cast identity
END_COMMIT_OVERRIDE

