### PR TITLE
fix: protect active media work

### DIFF
--- a/app/relaytv_app/routes/uploads.py
+++ b/app/relaytv_app/routes/uploads.py
@@ -269,12 +269,24 @@ async def ingest_media_play(request: Request, file: UploadFile = File(...), titl
         content_type=content_type,
         size_bytes=0,
     )
-    await run_in_threadpool(upload_store.write_metadata, upload_id, meta)
-
-    media_url = str(request.url_for("get_uploaded_media", upload_id=upload_id, filename=public_name))
-    target_dir = upload_store.upload_dir(upload_id)
-    await run_in_threadpool(os.makedirs, target_dir, 0o777, True)
-    final_path = os.path.join(target_dir, public_name)
+    upload_store.register_active_upload(upload_id)
+    try:
+        await run_in_threadpool(upload_store.write_metadata, upload_id, meta)
+        media_url = str(request.url_for("get_uploaded_media", upload_id=upload_id, filename=public_name))
+        target_dir = upload_store.upload_dir(upload_id)
+        await run_in_threadpool(os.makedirs, target_dir, 0o777, True)
+        final_path = os.path.join(target_dir, public_name)
+        session = upload_store.new_play_session(meta)
+        session["path"] = final_path
+        await run_in_threadpool(upload_store.write_session, upload_id, session)
+    except Exception:
+        await run_in_threadpool(upload_store.delete_upload, upload_id)
+        upload_store.unregister_active_upload(upload_id)
+        raise
+    except BaseException:
+        # Cancellation cannot leave an id permanently protected from cleanup.
+        upload_store.unregister_active_upload(upload_id)
+        raise
     size_bytes = 0
     progressive_started = False
     fallback_reason = ""
@@ -282,9 +294,6 @@ async def ingest_media_play(request: Request, file: UploadFile = File(...), titl
     playback_mode = "full_upload"
     now_playing = None
     stored_ok = False
-    session = upload_store.new_play_session(meta)
-    session["path"] = final_path
-    await run_in_threadpool(upload_store.write_session, upload_id, session)
     synced_bytes = 0
     synced_at = time.monotonic()
     try:
@@ -327,7 +336,11 @@ async def ingest_media_play(request: Request, file: UploadFile = File(...), titl
                 if progressive_started or session.get("fallback_to_full_upload") is True:
                     continue
 
-                ready, reason = upload_store.progressive_start_ready(meta, session)
+                ready, reason = await run_in_threadpool(
+                    upload_store.progressive_start_ready,
+                    meta,
+                    session,
+                )
                 if ready:
                     item = upload_store.build_item(meta, absolute_url=media_url)
                     item["_local_stream_path"] = final_path
@@ -400,3 +413,4 @@ async def ingest_media_play(request: Request, file: UploadFile = File(...), titl
                 await run_in_threadpool(upload_store.delete_upload, upload_id)
             except Exception:
                 pass
+        upload_store.unregister_active_upload(upload_id)

--- a/app/relaytv_app/thumb_cache.py
+++ b/app/relaytv_app/thumb_cache.py
@@ -356,7 +356,24 @@ def ensure_cached_sync(thumb_id: str, timeout_s: float = 3.0) -> bool:
     src = get_thumb_src(thumb_id)
     if not src:
         return False
-    # Try a direct, synchronous download + normalize (no queue) so first request can succeed.
+    if not _claim_thumb(thumb_id):
+        # Another worker already owns this id, or a recent failure is in
+        # backoff. Wait only for a real in-flight owner; never start a duplicate
+        # download and never bypass the failure budget.
+        deadline = time.monotonic() + max(0.0, float(timeout_s))
+        while True:
+            if os.path.exists(p) and os.path.getsize(p) > 0:
+                _touch(p)
+                return True
+            with _INFLIGHT_LOCK:
+                in_flight = thumb_id in _INFLIGHT
+            if not in_flight or time.monotonic() >= deadline:
+                return False
+            time.sleep(0.025)
+
+    # Try a direct, synchronous download + normalize so a first request can
+    # succeed, while owning the same claim/backoff state as the queue worker.
+    failed = True
     try:
         _ensure_dir()
         with tempfile.TemporaryDirectory() as td:
@@ -370,6 +387,9 @@ def ensure_cached_sync(thumb_id: str, timeout_s: float = 3.0) -> bool:
                 _commit_file(raw_fp, p)
         _touch(p)
         _prune_thumb_dir()
-        return os.path.exists(p) and os.path.getsize(p) > 0
+        failed = not (os.path.exists(p) and os.path.getsize(p) > 0)
+        return not failed
     except Exception:
         return False
+    finally:
+        _release_thumb(thumb_id, failed=failed)

--- a/app/relaytv_app/upload_store.py
+++ b/app/relaytv_app/upload_store.py
@@ -19,6 +19,7 @@ from .debug import get_logger
 logger = get_logger("uploads")
 
 _UPLOAD_LOCK = threading.Lock()
+_ACTIVE_UPLOADS: set[str] = set()
 _CLEANUP_WORKER_STARTED = False
 _UPLOADS_ROOT = os.getenv("RELAYTV_UPLOADS_DIR", "/data/uploads").strip() or "/data/uploads"
 _UPLOAD_URL_PREFIX = "/media/uploads/"
@@ -77,6 +78,17 @@ def normalize_upload_settings(value: object) -> dict[str, float | int]:
 
 def uploads_root() -> str:
     return _UPLOADS_ROOT
+
+
+def register_active_upload(upload_id: str) -> None:
+    """Protect an in-process upload from retention/capacity cleanup."""
+    with _UPLOAD_LOCK:
+        _ACTIVE_UPLOADS.add(str(upload_id or "").strip())
+
+
+def unregister_active_upload(upload_id: str) -> None:
+    with _UPLOAD_LOCK:
+        _ACTIVE_UPLOADS.discard(str(upload_id or "").strip())
 
 
 # Upload ids are generated, never supplied: new_upload_id() has produced
@@ -625,6 +637,8 @@ def cleanup_uploads(settings_payload: dict | None = None) -> dict[str, int]:
         total_bytes = sum(int(meta.get("size_bytes") or 0) for meta in metas if meta.get("available"))
         for meta in list(metas):
             upload_id = str(meta.get("id") or "").strip()
+            if upload_id in _ACTIVE_UPLOADS:
+                continue
             created_unix = float(meta.get("created_unix") or 0.0)
             available = bool(meta.get("available"))
             expired = (created_unix > 0.0) and (created_unix < expire_before)
@@ -640,6 +654,8 @@ def cleanup_uploads(settings_payload: dict | None = None) -> dict[str, int]:
                     break
                 upload_id = str(meta.get("id") or "").strip()
                 if not upload_id:
+                    continue
+                if upload_id in _ACTIVE_UPLOADS:
                     continue
                 delete_upload(upload_id)
                 deleted += 1

--- a/tests/test_media_cache_bounds.py
+++ b/tests/test_media_cache_bounds.py
@@ -134,6 +134,50 @@ def test_failure_map_is_bounded(thumb_env) -> None:
     assert len(thumb_cache._FAILED_AT) <= thumb_cache.THUMB_FAILURE_MAP_MAX
 
 
+def test_sync_thumbnail_path_respects_failure_backoff(thumb_env, monkeypatch) -> None:
+    url = "https://cdn.test/dead-sync.jpg"
+    tid = thumb_cache.thumb_id(url)
+    thumb_cache._remember_src(tid, url)
+    thumb_cache._release_thumb(tid, failed=True)
+    attempts: list[str] = []
+    monkeypatch.setattr(
+        thumb_cache,
+        "_download_to",
+        lambda source, path: attempts.append(source) or False,
+    )
+
+    assert thumb_cache.ensure_cached_sync(tid, timeout_s=0) is False
+    assert thumb_cache.ensure_cached_sync(tid, timeout_s=0) is False
+    assert attempts == []
+
+
+def test_sync_thumbnail_path_does_not_duplicate_inflight_work(thumb_env, monkeypatch) -> None:
+    url = "https://cdn.test/inflight.jpg"
+    tid = thumb_cache.thumb_id(url)
+    thumb_cache._remember_src(tid, url)
+    assert thumb_cache._claim_thumb(tid) is True
+    attempts: list[str] = []
+    monkeypatch.setattr(
+        thumb_cache,
+        "_download_to",
+        lambda source, path: attempts.append(source) or False,
+    )
+
+    assert thumb_cache.ensure_cached_sync(tid, timeout_s=0) is False
+    assert attempts == []
+
+
+def test_sync_thumbnail_failure_enters_backoff(thumb_env, monkeypatch) -> None:
+    url = "https://cdn.test/new-failure.jpg"
+    tid = thumb_cache.thumb_id(url)
+    thumb_cache._remember_src(tid, url)
+    monkeypatch.setattr(thumb_cache, "_download_to", lambda source, path: False)
+
+    assert thumb_cache.ensure_cached_sync(tid, timeout_s=0) is False
+    assert tid in thumb_cache._FAILED_AT
+    assert thumb_cache._claim_thumb(tid) is False
+
+
 # --- yt-dlp metadata cache ---------------------------------------------------
 
 

--- a/tests/test_upload_responsiveness.py
+++ b/tests/test_upload_responsiveness.py
@@ -50,10 +50,36 @@ def test_no_blocking_io_remains_on_the_event_loop() -> None:
                 "upload_store.write_metadata(",
                 "upload_store.cleanup_uploads(",
                 "upload_store.delete_upload(",
+                "upload_store.progressive_start_ready(",
             ):
                 if call in stripped:
                     offenders.append(f"{name}: {stripped}")
     assert not offenders, offenders
+
+
+def test_cleanup_does_not_delete_an_active_progressive_upload(uploads_root) -> None:
+    upload_id = upload_store.new_upload_id()
+    meta = {
+        "id": upload_id,
+        "stored_name": "clip.mp4",
+        "filename": "clip.mp4",
+        "mime_type": "video/mp4",
+        "size_bytes": 0,
+        "created_unix": time.time(),
+    }
+    upload_store.write_metadata(upload_id, meta)
+    upload_store.write_session(upload_id, upload_store.new_play_session(meta))
+    upload_store.register_active_upload(upload_id)
+    try:
+        result = upload_store.cleanup_uploads()
+        assert result["deleted_uploads"] == 0
+        assert upload_store.load_metadata(upload_id) == meta
+    finally:
+        upload_store.unregister_active_upload(upload_id)
+
+    result = upload_store.cleanup_uploads()
+    assert result["deleted_uploads"] == 1
+    assert upload_store.load_metadata(upload_id) is None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Register progressive uploads as active before their metadata/session become visible and exclude active IDs from retention and capacity cleanup.
- Release ownership on success, failure, and request cancellation so abandoned uploads remain reclaimable.
- Move progressive container probing into the worker threadpool and extend the event-loop source tripwire to cover that helper.
- Make synchronous thumbnail materialization use the same in-flight claim and failure backoff as queued workers, waiting briefly for an existing owner instead of duplicating it.

## User impact

Concurrent media uploads no longer risk deleting each other during the metadata-before-file window. Large progressive probes no longer pause HTTP/realtime handling, and failed or already-running thumbnail work is not duplicated by HA/native-toast requests.

## Operator and deployment impact

No configuration or migration is required. Incomplete uploads remain eligible for cleanup after their request releases ownership or after a process restart.

## Breaking changes

None.

## Tests run

- `ruff check app tests`
- `PYTHONPATH=app pytest -q` — 924 passed
- `node --test tests/js/*.test.js` — 24 passed
- `git diff --check`
- Focused upload/cache suite — 34 passed
- Revert proofs: cleanup deletes the metadata-bearing active directory without the ownership exclusion; the event-loop source tripwire catches a direct progressive probe; synchronous failure/backoff tests issue duplicate downloads without the shared claim.

## Release highlight

Not warranted; this is a correctness and responsiveness follow-up.