### PR TITLE
fix: fail closed for ambiguous snapshot gets

### DIFF
--- a/app/relaytv_app/api_auth.py
+++ b/app/relaytv_app/api_auth.py
@@ -131,8 +131,11 @@ def cross_site_mutating_get(
     source = _request_authority(str(referer or ""), absolute=True)
     target = _request_authority(str(host or ""), absolute=False)
     if source is None or target is None:
-        # Headerless non-browser API clients retain the local-first behavior.
-        return False
+        # Without either browser provenance signal, a tokenless API request is
+        # indistinguishable from an older/privacy-filtered cross-site browser.
+        # Fail closed; callers that cannot send these headers use POST or a
+        # configured bearer token (handled by the middleware).
+        return True
     # Host has no scheme, so normalize an omitted port to the Referer's scheme
     # default before comparing.
     if target[1] is None:
@@ -149,6 +152,14 @@ def write_request_allowed(
         return True
     if not is_write_request(method, path):
         return True
+    return valid_api_bearer(authorization)
+
+
+def valid_api_bearer(authorization: str | None) -> bool:
+    """Return True only for a configured token and its matching bearer value."""
+    token = configured_api_token()
+    if not token:
+        return False
     presented = bearer_token_from_header(authorization)
     if not presented:
         return False

--- a/app/relaytv_app/main.py
+++ b/app/relaytv_app/main.py
@@ -145,28 +145,30 @@ def create_app(*, testing: bool = False) -> FastAPI:
     # outermost and rejected writes still show up in request logging.
     @app.middleware("http")
     async def _api_token_guard(request: Request, call_next):
+        authorization = request.headers.get("authorization")
+        write_allowed = api_auth.write_request_allowed(
+            request.method,
+            authorization,
+            path=request.url.path,
+        )
+        if not write_allowed:
+            return JSONResponse(
+                {"detail": "api token required"},
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
         if api_auth.cross_site_mutating_get(
             request.method,
             request.url.path,
             sec_fetch_site=request.headers.get("sec-fetch-site"),
             referer=request.headers.get("referer"),
             host=request.headers.get("host"),
-        ):
+        ) and not api_auth.valid_api_bearer(authorization):
             return JSONResponse(
                 {"detail": "cross-site write request rejected"},
                 status_code=403,
             )
-        if api_auth.write_request_allowed(
-            request.method,
-            request.headers.get("authorization"),
-            path=request.url.path,
-        ):
-            return await call_next(request)
-        return JSONResponse(
-            {"detail": "api token required"},
-            status_code=401,
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        return await call_next(request)
 
     @app.middleware("http")
     async def _log_slow_requests(request: Request, call_next):

--- a/docs/API.md
+++ b/docs/API.md
@@ -125,7 +125,8 @@ must not control the WebSocket origin check.
   Once the underlying download completes, the player swaps mpv onto the
   finalized local spool file (gaining seeking) and this route drops out.
   Not part of the public API surface — clients should never call it.
-- `GET /snapshot` and `POST /snapshot`: capture a snapshot of active playback
+- `POST /snapshot`: capture a snapshot of active playback
+- `GET /snapshot`: compatibility alias; tokenless callers must supply same-origin browser provenance, while headerless API clients must use POST or a valid bearer token
 - `GET /share`
   - query: `url` or `link`, optional `cec`
   - share-target compatible immediate play helper

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -249,7 +249,7 @@ def test_referer_fallback_rejects_cross_origin_snapshot(monkeypatch) -> None:
     assert response.status_code == 403
 
 
-def test_same_origin_and_headerless_snapshot_clients_remain_compatible(monkeypatch) -> None:
+def test_same_origin_snapshot_remains_open_but_headerless_get_fails_closed(monkeypatch) -> None:
     monkeypatch.delenv("RELAYTV_API_TOKEN", raising=False)
     runtime_config.refresh_from_env()
     client = _client()
@@ -264,10 +264,26 @@ def test_same_origin_and_headerless_snapshot_clients_remain_compatible(monkeypat
     )
     headerless = client.get("/snapshot")
 
-    # No playback is active, so reaching the handler yields 409. The important
-    # contract is that neither legitimate shape is rejected by the CSRF guard.
+    # No playback is active, so the same-origin request reaches the handler.
+    # Headerless tokenless GET cannot be distinguished from an older browser
+    # with its Referer suppressed, so callers must use POST instead.
     assert same_origin.status_code == 409
-    assert headerless.status_code == 409
+    assert headerless.status_code == 403
+    assert headerless.json()["detail"] == "cross-site write request rejected"
+
+
+def test_valid_bearer_allows_a_headerless_snapshot_get(monkeypatch) -> None:
+    monkeypatch.setenv("RELAYTV_API_TOKEN", TOKEN)
+    runtime_config.refresh_from_env()
+
+    response = _client().get(
+        "/snapshot",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+    )
+
+    # A bearer credential is not browser-forgeable, so the compatibility GET
+    # may reach the handler without optional browser provenance headers.
+    assert response.status_code == 409
 
 
 def test_share_target_redirects_without_playing(monkeypatch) -> None:

--- a/tests/test_snapshot_routes.py
+++ b/tests/test_snapshot_routes.py
@@ -151,7 +151,10 @@ def test_idle_playback_still_conflicts(snap_dir, client, monkeypatch) -> None:
 
 def test_get_alias_behaves_the_same(snap_dir, client, monkeypatch) -> None:
     monkeypatch.setattr(player, "mpv_command", lambda cmd: {"error": "property not found"})
-    assert client.get("/snapshot").status_code == 502
+    assert client.get(
+        "/snapshot",
+        headers={"Sec-Fetch-Site": "same-origin"},
+    ).status_code == 502
 
 
 def test_timeout_setting_falls_back_on_garbage(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Fail closed for tokenless `GET /snapshot` requests when both optional browser provenance signals are absent.
- Keep same-origin browser requests and the legacy GET route available.
- Treat a valid bearer token as sufficient for headerless API clients, while preserving the normal 401 response for missing/invalid credentials on token-enabled installs.
- Document POST as the preferred snapshot API and the compatibility requirements for GET.

## User impact

An older or privacy-filtered browser can no longer suppress Referer and reach the tokenless snapshot side effect from a hostile page. Same-origin UI behavior is unchanged.

## Operator and deployment impact

Headerless tokenless clients using `GET /snapshot` must switch to `POST /snapshot`. Home Assistant already sends POST first and attaches the bearer token to its legacy GET fallback, so no companion release is required.

## Breaking changes

Headerless tokenless `GET /snapshot` now returns 403. The route itself remains available, and POST is unchanged.

## Tests run

- `ruff check app tests`
- `PYTHONPATH=app pytest -q` — 921 passed
- `node --test tests/js/*.test.js` — 24 passed
- `git diff --check`
- Focused auth/route/snapshot suite — 37 passed
- Revert proof: the new headerless-tokenless regression reaches the snapshot handler against the merged guard instead of returning 403.

## Release highlight

Not warranted; this is a security boundary correction.