### PR TITLE
fix: reject stale playback telemetry

### DIFF
--- a/app/relaytv_app/playback_service.py
+++ b/app/relaytv_app/playback_service.py
@@ -463,6 +463,9 @@ def close_current(*, idle_surface_enabled: bool, keep_shell_allowed: bool) -> di
             preserve_resume = False
     except Exception:
         pass
+    session_update: dict[str, object] = {
+        "session_state": "closed" if preserve_resume else "idle",
+    }
     if preserve_resume:
         with player.MPV_LOCK:
             try:
@@ -476,9 +479,9 @@ def close_current(*, idle_surface_enabled: bool, keep_shell_allowed: bool) -> di
         if pos is None and isinstance(state.NOW_PLAYING, dict):
             pos = state.NOW_PLAYING.get("resume_pos")
         try:
-            state.set_session_position(float(pos) if pos is not None else None)
+            session_update["session_position"] = float(pos) if pos is not None else None
         except Exception:
-            state.set_session_position(None)
+            session_update["session_position"] = None
 
         try:
             if isinstance(state.NOW_PLAYING, dict) and pos is not None:
@@ -486,20 +489,14 @@ def close_current(*, idle_surface_enabled: bool, keep_shell_allowed: bool) -> di
                 np["resume_pos"] = float(pos)
                 np["closed"] = True
                 np["closed_at"] = int(time.time())
-                state.set_now_playing(np)
+                session_update["now_playing"] = np
         except Exception:
             pass
     elif getattr(state, "SESSION_STATE", "idle") != "closed":
-        try:
-            state.set_now_playing(None)
-        except Exception:
-            pass
-        try:
-            state.set_session_position(None)
-        except Exception:
-            pass
+        session_update["now_playing"] = None
+        session_update["session_position"] = None
 
-    state.set_session_state("closed" if preserve_resume else "idle")
+    state.update_session(**session_update)
     keep_qt_shell = bool(preserve_resume and idle_surface_enabled and keep_shell_allowed)
     stopped_in_place = False
     if keep_qt_shell:
@@ -636,14 +633,17 @@ def stop_current() -> dict[str, Any]:
     pos = None
     dur = None
     preserve_resume = can_preserve_closed_session()
+    session_update: dict[str, object] = {
+        "session_state": "closed" if preserve_resume else "idle",
+    }
     if preserve_resume:
         with player.MPV_LOCK:
             pos = player.mpv_get("time-pos")
             dur = player.mpv_get("duration")
         try:
-            state.set_session_position(float(pos) if pos is not None else None)
+            session_update["session_position"] = float(pos) if pos is not None else None
         except Exception:
-            state.set_session_position(None)
+            session_update["session_position"] = None
 
     if preserve_resume:
         try:
@@ -653,21 +653,16 @@ def stop_current() -> dict[str, Any]:
                     np["resume_pos"] = float(pos)
                 np["closed"] = True
                 np["closed_at"] = int(time.time())
-                state.set_now_playing(np)
+                session_update["now_playing"] = np
         except Exception:
             pass
     elif getattr(state, "SESSION_STATE", "idle") != "closed":
-        try:
-            state.set_now_playing(None)
-        except Exception:
-            pass
-        try:
-            state.set_session_position(None)
-        except Exception:
-            pass
+        session_update["now_playing"] = None
+        session_update["session_position"] = None
+
+    state.update_session(**session_update)
 
     if preserve_resume:
-        state.set_session_state("closed")
         with player.MPV_LOCK:
             stop_all()
         player.update_history_progress(
@@ -678,16 +673,6 @@ def stop_current() -> dict[str, Any]:
         )
         return {"preserve_resume": True, "position": pos, "duration": dur}
 
-    if getattr(state, "SESSION_STATE", "idle") != "closed":
-        try:
-            state.set_now_playing(None)
-        except Exception:
-            pass
-        try:
-            state.set_session_position(None)
-        except Exception:
-            pass
-    state.set_session_state("idle")
     with player.MPV_LOCK:
         stop_all()
     return {"preserve_resume": False, "position": pos, "duration": dur}

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -3460,8 +3460,12 @@ def mpv_get(prop: str):
 
 
 
-def mpv_get_many(props: list[str]) -> dict[str, Any]:
-    """Get multiple mpv properties in one IPC connection."""
+def mpv_get_many(props: list[str], *, fresh: bool = False) -> dict[str, Any]:
+    """Get multiple mpv properties in one IPC connection.
+
+    ``fresh`` bypasses both short-lived and stale-cache fallbacks for decisions
+    that must observe an effect issued immediately beforehand.
+    """
     normalized = [str(p or "").strip() for p in list(props or []) if str(p or "").strip()]
     if not normalized:
         return {}
@@ -3471,7 +3475,12 @@ def mpv_get_many(props: list[str]) -> dict[str, Any]:
     if prefer_host and (not live_ipc_required) and all(host.get(p) is not None for p in normalized):
         _mpv_cache_update(host)
         return host
-    if prefer_host and (not live_ipc_required) and all(_qt_shell_runtime_supports_mpv_property(p) for p in normalized):
+    if (
+        not fresh
+        and prefer_host
+        and (not live_ipc_required)
+        and all(_qt_shell_runtime_supports_mpv_property(p) for p in normalized)
+    ):
         stale = _mpv_cache_get_many(
             normalized,
             max_age_sec=_mpv_poll_cache_stale_sec(),
@@ -3484,7 +3493,7 @@ def mpv_get_many(props: list[str]) -> dict[str, Any]:
         if all(out.get(p) is not None for p in normalized):
             _mpv_cache_update(out)
             return out
-    if not prefer_host and (not live_ipc_required):
+    if not fresh and not prefer_host and (not live_ipc_required):
         cache_ttl = _mpv_poll_cache_ttl_sec()
         if cache_ttl > 0:
             cached = _mpv_cache_get_many(normalized, max_age_sec=cache_ttl, project_playback=True)
@@ -3498,6 +3507,8 @@ def mpv_get_many(props: list[str]) -> dict[str, Any]:
         if any(v is not None for v in fallback_host.values()):
             _mpv_cache_update(fallback_host)
             return fallback_host
+        if fresh:
+            return {}
         stale = _mpv_cache_get_many(
             normalized,
             max_age_sec=_mpv_poll_cache_stale_sec(),
@@ -4165,7 +4176,10 @@ def _attempt_playlist_next_handoff(*, poll_sleep: Callable[[float], None] | None
     last_props: dict[str, Any] = {}
     for i in range(confirm_polls):
         try:
-            sample = mpv_get_many(["playlist-pos", "playlist-count", "time-pos", "path", "pause"])
+            sample = mpv_get_many(
+                ["playlist-pos", "playlist-count", "time-pos", "path", "pause"],
+                fresh=True,
+            )
             last_props = sample if isinstance(sample, dict) else {}
             if _consume_mpv_queued_next_if_started(last_props, force_playlist_advance=True):
                 return "mpv_playlist_next"
@@ -6180,37 +6194,63 @@ def _session_tracker_tick() -> None:
     if str(getattr(state, "SESSION_STATE", "idle") or "idle").strip().lower() == "closed":
         _reset_mpv_up_next_state()
         return
+    sampled_now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
+    sampled_identity = (
+        str(sampled_now.get("history_id") or ""),
+        sampled_now.get("started"),
+        str(sampled_now.get("url") or ""),
+    ) if sampled_now else None
     props = mpv_get_many(["time-pos", "duration", "pause", "playlist-pos", "playlist-count", "path", "core-idle", "eof-reached"])
     # Queue advance owns the decision between consuming a confirmed seamless
     # handoff and retiring it for dequeue/play_item fallback. Do not let this
     # telemetry path consume the queue between the advance path's final sample
     # and its stale-playlist cleanup.
+    persist_session = False
     with state.ADVANCE_LOCK:
-        _consume_mpv_queued_next_if_started(props)
-    now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
-    if not now:
-        if _repair_orphan_runtime_playback(props):
+        consumed = _consume_mpv_queued_next_if_started(props)
+        now = state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
+        current_identity = (
+            str(now.get("history_id") or ""),
+            now.get("started"),
+            str(now.get("url") or ""),
+        ) if now else None
+        if not consumed and sampled_identity != current_identity:
+            logger.info("session_tracker_sample_retired reason=playback_changed")
             return
-        _prime_mpv_up_next_from_queue()
-        return
-    pos = props.get("time-pos")
-    paused = bool(props.get("pause"))
-    if pos is not None:
-        pos_f = float(pos)
-        updated = dict(now)
-        updated["resume_pos"] = pos_f
-        try:
-            duration_f = float(props.get("duration"))
-            if duration_f > 0:
-                updated["duration_sec"] = duration_f
-        except Exception:
-            pass
-        state.set_now_playing(updated)
-        state.set_session_position(pos_f)
-        state.set_session_state("paused" if paused else "playing")
+        if not now:
+            if _repair_orphan_runtime_playback(props):
+                return
+            _prime_mpv_up_next_from_queue()
+            return
+        pos = props.get("time-pos")
+        paused = bool(props.get("pause"))
+        updated = None
+        if pos is not None:
+            pos_f = float(pos)
+            updated = dict(now)
+            updated["resume_pos"] = pos_f
+            try:
+                duration_f = float(props.get("duration"))
+                if duration_f > 0:
+                    updated["duration_sec"] = duration_f
+            except Exception:
+                pass
+            session_update = {
+                "now_playing": updated,
+                "session_position": pos_f,
+                "session_state": "paused" if paused else "playing",
+            }
+            if not paused:
+                session_update["pause_reason"] = None
+            state.update_session(**session_update, persist=False)
+            persist_session = True
+        elif not paused:
+            state.update_session(pause_reason=None, persist=False)
+            persist_session = True
+    if persist_session:
+        state.persist_session()
+    if updated is not None:
         update_history_progress(updated)
-    if not paused:
-        state.set_pause_reason(None)
     _prime_mpv_up_next_from_queue()
 
 

--- a/docs/TRANSITION_INVENTORY.md
+++ b/docs/TRANSITION_INVENTORY.md
@@ -15,7 +15,7 @@ Write forms counted per global:
 - direct assignment through any state alias (`state.X = ...`), excluding
   comparisons;
 - calls to the `state.py` setters (`set_now_playing`, `set_session_state`,
-  `set_session_position`);
+  `set_session_position`) and composite `update_session` mutations;
 - `QUEUE` mutations (`clear`/`append`/`insert`/`pop`/`remove`/`extend`,
   index/slice assignment, rebinding);
 - for `_TEMP_PLAYBACK_STACK`, any reference at all — the stack is private
@@ -94,9 +94,9 @@ The five Phase 3 review scenarios and where they are guarded at phase start:
 | Transition global | Writers outside `state.py` (write sites) |
 | --- | --- |
 | `AUTO_NEXT_SUPPRESS_UNTIL` | `playback_service.py` (2) |
-| `NOW_PLAYING` | `playback_service.py` (6)<br>`player.py` (8)<br>`routes/__init__.py` (1) |
+| `NOW_PLAYING` | `playback_service.py` (9)<br>`player.py` (10)<br>`routes/__init__.py` (1) |
 | `QUEUE` | `integrations/jellyfin_service.py` (4)<br>`playback_service.py` (7)<br>`player.py` (5)<br>`routes/queue.py` (6)<br>`routes/uploads.py` (1)<br>`upload_store.py` (1) |
-| `SESSION_POSITION` | `playback_service.py` (7)<br>`player.py` (7) |
-| `SESSION_STATE` | `playback_service.py` (3)<br>`player.py` (10)<br>`routes/__init__.py` (4) |
+| `SESSION_POSITION` | `playback_service.py` (8)<br>`player.py` (9) |
+| `SESSION_STATE` | `playback_service.py` (8)<br>`player.py` (12)<br>`routes/__init__.py` (4) |
 | `_TEMP_PLAYBACK_STACK` | `playback_service.py` (8)<br>`routes/__init__.py` (2)<br>`routes/playback.py` (2) |
 <!-- END GENERATED TRANSITION TABLE -->

--- a/tests/test_playback_routes.py
+++ b/tests/test_playback_routes.py
@@ -402,17 +402,14 @@ def test_play_now_non_botcheck_failure_does_not_toast(monkeypatch) -> None:
 
 
 def test_close_route_preserves_queue_and_returns_closed_session(monkeypatch) -> None:
-    now_values: list[object] = []
-    session_values: list[str] = []
+    session_updates: list[dict[str, object]] = []
     stop_shell_calls: list[bool] = []
     stop_mpv_calls: list[bool] = []
     queue = [{"url": "https://example.com/next.mp4", "title": "Next"}]
 
     monkeypatch.setattr(routes.state, "QUEUE", queue, raising=False)
     monkeypatch.setattr(routes.state, "NOW_PLAYING", {"url": "https://example.com/current.mp4", "title": "Current"}, raising=False)
-    monkeypatch.setattr(routes.state, "set_now_playing", lambda value: now_values.append(value) or setattr(routes.state, "NOW_PLAYING", value))
-    monkeypatch.setattr(routes.state, "set_session_position", lambda value: setattr(routes.state, "SESSION_POSITION", value))
-    monkeypatch.setattr(routes.state, "set_session_state", lambda value: session_values.append(value) or setattr(routes.state, "SESSION_STATE", value))
+    monkeypatch.setattr(routes.state, "update_session", lambda **values: session_updates.append(values) or True)
     monkeypatch.setattr(routes.player, "native_qt_playback_explicitly_ended", lambda: False)
     monkeypatch.setattr(routes.player, "_idle_dashboard_enabled", lambda: True)
     monkeypatch.setattr(routes.player, "_qt_shell_backend_enabled", lambda: True)
@@ -430,9 +427,10 @@ def test_close_route_preserves_queue_and_returns_closed_session(monkeypatch) -> 
     assert response.json()["resume_available"] is True
     assert response.json()["kept_player_shell"] is True
     assert routes.state.QUEUE == queue
-    assert now_values[-1]["closed"] is True
-    assert now_values[-1]["resume_pos"] == 42.0
-    assert session_values[-1] == "closed"
+    assert len(session_updates) == 1
+    assert session_updates[0]["now_playing"]["closed"] is True
+    assert session_updates[0]["now_playing"]["resume_pos"] == 42.0
+    assert session_updates[0]["session_state"] == "closed"
     assert stop_shell_calls == [True]
     assert stop_mpv_calls == []
 
@@ -512,9 +510,7 @@ def test_clear_resumable_session_route_stops_and_clears_state(monkeypatch) -> No
 
 
 def test_stop_route_preserves_resumable_current_item(monkeypatch) -> None:
-    now_values: list[object] = []
-    session_positions: list[object] = []
-    session_states: list[str] = []
+    session_updates: list[dict[str, object]] = []
     stop_calls: list[bool] = []
     history_calls: list[dict[str, object]] = []
     jellyfin_calls: list[tuple[object, object]] = []
@@ -537,9 +533,7 @@ def test_stop_route_preserves_resumable_current_item(monkeypatch) -> None:
         {"url": "https://example.com/current.mp4", "title": "Current", "jellyfin_item_id": "jf-1"},
         raising=False,
     )
-    monkeypatch.setattr(routes.state, "set_now_playing", lambda value: now_values.append(value) or setattr(routes.state, "NOW_PLAYING", value))
-    monkeypatch.setattr(routes.state, "set_session_position", lambda value: session_positions.append(value))
-    monkeypatch.setattr(routes.state, "set_session_state", lambda value: session_states.append(value) or setattr(routes.state, "SESSION_STATE", value))
+    monkeypatch.setattr(routes.state, "update_session", lambda **values: session_updates.append(values) or True)
 
     client = TestClient(create_app(testing=True))
     response = client.post("/stop")
@@ -549,10 +543,11 @@ def test_stop_route_preserves_resumable_current_item(monkeypatch) -> None:
     assert body["status"] == "stopped"
     assert body["resume_available"] is True
     assert body["position"] == 31.5
-    assert now_values[-1]["closed"] is True
-    assert now_values[-1]["resume_pos"] == 31.5
-    assert session_positions == [31.5]
-    assert session_states == ["closed"]
+    assert len(session_updates) == 1
+    assert session_updates[0]["now_playing"]["closed"] is True
+    assert session_updates[0]["now_playing"]["resume_pos"] == 31.5
+    assert session_updates[0]["session_position"] == 31.5
+    assert session_updates[0]["session_state"] == "closed"
     assert stop_calls == [True]
     assert history_calls[-1]["position_sec"] == 31.5
     assert history_calls[-1]["duration_sec"] == 120.0

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2608,8 +2608,7 @@ def test_playback_state_uses_ipc_when_qt_runtime_first_reports_playing(monkeypat
 
 
 def test_close_preserves_now_playing_and_keeps_qt_shell_when_idle_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    now_values: list[object] = []
-    session_values: list[str] = []
+    session_updates: list[dict[str, object]] = []
     stop_shell_calls: list[bool] = []
     stop_mpv_calls: list[bool] = []
 
@@ -2622,9 +2621,7 @@ def test_close_preserves_now_playing_and_keeps_qt_shell_when_idle_enabled(monkey
     monkeypatch.setattr(routes.player, 'stop_mpv', lambda restart_splash=True: stop_mpv_calls.append(bool(restart_splash)))
     monkeypatch.setattr(routes, '_jellyfin_emit_stopped_hint', lambda pos, dur: None)
     monkeypatch.setattr(routes.state, 'NOW_PLAYING', {'title': 'Clip', 'url': 'https://example.com/video.mp4'}, raising=False)
-    monkeypatch.setattr(routes.state, 'set_now_playing', lambda value: now_values.append(value))
-    monkeypatch.setattr(routes.state, 'set_session_state', lambda value: session_values.append(value))
-    monkeypatch.setattr(routes.state, 'set_session_position', lambda value: None)
+    monkeypatch.setattr(routes.state, 'update_session', lambda **values: session_updates.append(values) or True)
 
     out = routes.close()
 
@@ -2633,9 +2630,10 @@ def test_close_preserves_now_playing_and_keeps_qt_shell_when_idle_enabled(monkey
     assert out['kept_player_shell'] is True
     assert stop_shell_calls == [True]
     assert stop_mpv_calls == []
-    assert session_values == ['closed']
-    assert now_values[-1]['closed'] is True
-    assert now_values[-1]['resume_pos'] == 12.5
+    assert len(session_updates) == 1
+    assert session_updates[0]['session_state'] == 'closed'
+    assert session_updates[0]['now_playing']['closed'] is True
+    assert session_updates[0]['now_playing']['resume_pos'] == 12.5
 
 
 def test_close_discards_temporary_restore_stack(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3494,7 +3492,7 @@ def test_auto_next_unconfirmed_playlist_handoff_is_retired_after_eof(monkeypatch
     monkeypatch.setattr(player, '_MPV_UPNEXT_ARMED_URL', 'https://example.com/next.mp4', raising=False)
     monkeypatch.setattr(player, '_MPV_UPNEXT_ARMED_AT', 123.0, raising=False)
     monkeypatch.setattr(player, 'mpv_command', lambda command: commands.append(list(command)) or {'error': 'success'})
-    monkeypatch.setattr(player, 'mpv_get_many', lambda props: {'playlist-pos': 0, 'playlist-count': 2, 'time-pos': None, 'path': '', 'pause': False})
+    monkeypatch.setattr(player, 'mpv_get_many', lambda props, **kwargs: {'playlist-pos': 0, 'playlist-count': 2, 'time-pos': None, 'path': '', 'pause': False})
 
     method = player._attempt_playlist_next_handoff(poll_sleep=lambda _seconds: None)
 
@@ -3520,7 +3518,11 @@ def test_auto_next_delayed_playlist_handoff_stays_seamless(monkeypatch: pytest.M
     monkeypatch.setattr(player, '_MPV_UPNEXT_ARMED_URL', 'https://example.com/next.mp4', raising=False)
     monkeypatch.setattr(player, '_MPV_UPNEXT_ARMED_AT', 123.0, raising=False)
     monkeypatch.setattr(player, 'mpv_command', lambda command: commands.append(list(command)) or {'error': 'success'})
-    monkeypatch.setattr(player, 'mpv_get_many', lambda props: next(samples))
+    def fresh_sample(props, *, fresh=False):
+        assert fresh is True
+        return next(samples)
+
+    monkeypatch.setattr(player, 'mpv_get_many', fresh_sample)
     monkeypatch.setattr(
         player,
         '_consume_mpv_queued_next_if_started',
@@ -3558,7 +3560,7 @@ def test_auto_next_unconfirmed_playlist_handoff_falls_back_without_looping(monke
     monkeypatch.setattr(
         player,
         'mpv_get_many',
-        lambda props: {
+        lambda props, **kwargs: {
             'playlist-pos': -1,
             'playlist-count': 2,
             'time-pos': None,
@@ -3615,6 +3617,39 @@ def test_session_tracker_serializes_playlist_handoff_consumption(monkeypatch: py
         player._session_tracker_tick()
 
     assert advance_lock.active is False
+
+
+def test_session_tracker_discards_sample_for_replaced_playback(monkeypatch: pytest.MonkeyPatch) -> None:
+    old = {"url": "https://example.com/old.mp4", "history_id": "old", "started": 1}
+    new = {"url": "https://example.com/new.mp4", "history_id": "new", "started": 2, "resume_pos": 0.0}
+    monkeypatch.setattr(player.state, "NOW_PLAYING", old, raising=False)
+    monkeypatch.setattr(player.state, "SESSION_STATE", "playing", raising=False)
+    monkeypatch.setattr(player, "_is_playing", lambda: True)
+
+    def sample(props):
+        player.state.NOW_PLAYING = new
+        return {
+            "time-pos": 598.0,
+            "duration": 600.0,
+            "pause": False,
+            "playlist-pos": 0,
+            "playlist-count": 1,
+            "path": old["url"],
+            "core-idle": False,
+            "eof-reached": False,
+        }
+
+    monkeypatch.setattr(player, "mpv_get_many", sample)
+    monkeypatch.setattr(player, "_consume_mpv_queued_next_if_started", lambda props: False)
+    monkeypatch.setattr(
+        player.state,
+        "update_session",
+        lambda **values: (_ for _ in ()).throw(AssertionError(f"stale publication: {values}")),
+    )
+
+    player._session_tracker_tick()
+
+    assert player.state.NOW_PLAYING == new
 
 
 def test_auto_next_resumes_interrupted_item_without_dropping_queue_tail(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_state_publication.py
+++ b/tests/test_state_publication.py
@@ -13,7 +13,7 @@ import threading
 
 import pytest
 
-from relaytv_app import state
+from relaytv_app import playback_service, player, state
 
 
 @pytest.fixture
@@ -194,6 +194,41 @@ def test_update_session_can_skip_persistence(state_dir, monkeypatch) -> None:
 
     assert state.SESSION_STATE == "playing"
     assert writes == []
+
+
+@pytest.mark.parametrize("transition", ["stop_current", "close_current"])
+def test_terminal_transition_publishes_one_composite_session(
+    state_dir,
+    monkeypatch,
+    transition,
+) -> None:
+    updates: list[dict[str, object]] = []
+    now = {"title": "Movie", "resume_pos": 1.0}
+    monkeypatch.setattr(state, "NOW_PLAYING", now, raising=False)
+    monkeypatch.setattr(state, "SESSION_STATE", "playing", raising=False)
+    monkeypatch.setattr(state, "SESSION_POSITION", 1.0, raising=False)
+    monkeypatch.setattr(state, "update_session", lambda **values: updates.append(values) or True)
+    monkeypatch.setattr(player, "native_qt_playback_explicitly_ended", lambda: False)
+    monkeypatch.setattr(player, "mpv_get", lambda prop: 42.0 if prop == "time-pos" else 100.0)
+    monkeypatch.setattr(player, "update_history_progress", lambda *args, **kwargs: None)
+    monkeypatch.setattr(playback_service, "can_preserve_closed_session", lambda: True)
+    monkeypatch.setattr(playback_service, "suppress_auto_next", lambda seconds: None)
+    monkeypatch.setattr(playback_service, "discard_interrupted_playback_state", lambda reason: None)
+    monkeypatch.setattr(playback_service, "stop_all", lambda **kwargs: None)
+
+    if transition == "close_current":
+        playback_service.close_current(
+            idle_surface_enabled=False,
+            keep_shell_allowed=False,
+        )
+    else:
+        playback_service.stop_current()
+
+    assert len(updates) == 1
+    assert updates[0]["session_state"] == "closed"
+    assert updates[0]["session_position"] == 42.0
+    assert updates[0]["now_playing"]["resume_pos"] == 42.0
+    assert updates[0]["now_playing"]["closed"] is True
 
 
 # --- failure is observable ---------------------------------------------------

--- a/tests/test_transition_inventory.py
+++ b/tests/test_transition_inventory.py
@@ -37,14 +37,17 @@ _WRITE_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
     "NOW_PLAYING": (
         re.compile(_STATE + r"NOW_PLAYING\s*=(?!=)"),
         re.compile(_STATE + r"set_now_playing\("),
+        re.compile(_STATE + r"update_session\("),
     ),
     "SESSION_STATE": (
         re.compile(_STATE + r"SESSION_STATE\s*=(?!=)"),
         re.compile(_STATE + r"set_session_state\("),
+        re.compile(_STATE + r"update_session\("),
     ),
     "SESSION_POSITION": (
         re.compile(_STATE + r"SESSION_POSITION\s*=(?!=)"),
         re.compile(_STATE + r"set_session_position\("),
+        re.compile(_STATE + r"update_session\("),
     ),
     "AUTO_NEXT_SUPPRESS_UNTIL": (
         re.compile(_STATE + r"AUTO_NEXT_SUPPRESS_UNTIL\s*=(?!=)"),


### PR DESCRIPTION
## Summary

- Require uncached mpv telemetry while confirming an immediately requested playlist handoff.
- Retire a session-tracker sample when playback changes while its mpv query is in flight.
- Publish Stop and Close session fields as one durable state transition instead of three intermediate snapshots.
- Extend the generated transition inventory to count composite `update_session` writers.

## User impact

A successful seamless queue handoff is no longer discarded because the confirmation loop reused pre-command telemetry. A slow tracker poll can no longer write the previous item’s position into its replacement, and Stop/Close no longer expose or persist partially updated session state.

## Operator and deployment impact

None. No configuration, storage migration, or companion-app change is required.

## Breaking changes

None.

## Tests run

- `ruff check app tests`
- `PYTHONPATH=app pytest -q` — 923 passed on current `main`
- `git diff --check origin/main...HEAD`
- both standalone JavaScript syntax checks and the inline X11 overlay syntax check
- `node --test tests/js/*.test.js` — 24 passed
- Revert proof: removing the fresh handoff read fails the delayed-handoff regression.
- Revert proof: removing the playback-identity publication guard fails the blocked tracker regression.
- Revert proof: restoring individual Stop/Close setters fails both atomic-publication cases.

## Release highlight

Not warranted; this is playback correctness hardening.