### PR TITLE
fix: reject idle and retired service diagnostics

### DIFF
--- a/app/relaytv_app/integrations/iptv_service.py
+++ b/app/relaytv_app/integrations/iptv_service.py
@@ -561,7 +561,7 @@ def refresh_source(
     try:
         if publish_guard is not None and not publish_guard():
             return _retired_refresh(source_id)
-        store().mark_refresh_attempt(source_id)
+        store().mark_refresh_attempt(source_id, publish_guard=publish_guard)
         text, etag, last_modified, not_modified, final_url = _fetch_source(source)
         if publish_guard is not None and not publish_guard():
             return _retired_refresh(source_id)

--- a/app/relaytv_app/integrations/iptv_store.py
+++ b/app/relaytv_app/integrations/iptv_store.py
@@ -241,8 +241,19 @@ class IptvStore:
             cur = conn.execute("DELETE FROM iptv_sources WHERE id = ?", (source_id,))
             return cur.rowcount > 0
 
-    def mark_refresh_attempt(self, source_id: str) -> None:
+    def mark_refresh_attempt(
+        self,
+        source_id: str,
+        *,
+        publish_guard: Callable[[], bool] | None = None,
+    ) -> None:
         with self._lock, self._connect() as conn:
+            # The caller's first ownership check happens before it can wait on
+            # this store lock. Re-check at the actual publication boundary so
+            # a worker retired during that wait cannot advance the schedule or
+            # clear the live source's error.
+            if publish_guard is not None and not publish_guard():
+                raise CatalogPublishRetired(source_id)
             conn.execute(
                 "UPDATE iptv_sources SET last_attempt_at = ?, last_error = '' WHERE id = ?",
                 (time.time(), source_id),

--- a/app/relaytv_app/playback_service.py
+++ b/app/relaytv_app/playback_service.py
@@ -162,17 +162,6 @@ def natural_end() -> str:
     transition guards, suppression window) stays with the monitor; this is
     the decision policy. Returns the action taken, for logging/tests.
     """
-    # Record why this item ended before deciding what happens next. The
-    # queue-empty handler below also does it, but that branch is only reached
-    # with an empty queue — so playlist and queue users, the common case, got no
-    # diagnostic at all, and the successor's play_item then cleared it.
-    try:
-        player.note_playback_failure_if_no_progress(
-            state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
-        )
-    except Exception:
-        pass
-
     with state.QUEUE_LOCK:
         has_queue = bool(state.QUEUE)
     if not has_queue:
@@ -183,6 +172,17 @@ def natural_end() -> str:
             return "already_idle"
         player._handle_playback_idle_no_queue()
         return "idle"
+
+    # The queue-empty handler above owns failure attribution for its branch.
+    # Record here only when a successor is about to start; otherwise the same
+    # ended item is reported twice. This must still happen before advance_queue
+    # because the successor's play_item moves the mpv log boundary.
+    try:
+        player.note_playback_failure_if_no_progress(
+            state.NOW_PLAYING if isinstance(state.NOW_PLAYING, dict) else None
+        )
+    except Exception:
+        pass
 
     player._set_auto_next_transition(True)
     try:

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -5595,8 +5595,14 @@ def note_playback_failure_if_no_progress(now: dict | None) -> str:
     failure rather than a finished video, and the operator deserves the reason
     in the ordinary log instead of having to enable debug and reproduce it.
     """
+    if not isinstance(now, dict) or not now:
+        # An idle Qt/mpv runtime can write harmless initialization errors before
+        # any item exists. With no item there is no playback attempt to diagnose;
+        # attributing that log tail produces a false status error on every idle
+        # autoplay tick and floods the container log.
+        return ""
     try:
-        position = float((now or {}).get("resume_pos") or 0.0)
+        position = float(now.get("resume_pos") or 0.0)
     except Exception:
         position = 0.0
     if (position - playback_started_pos()) >= 2.0:
@@ -5611,7 +5617,7 @@ def note_playback_failure_if_no_progress(now: dict | None) -> str:
     set_last_playback_error(reason)
     logger.info(
         "playback_failed title=%r reason=%s",
-        str((now or {}).get("title") or "")[:80],
+        str(now.get("title") or "")[:80],
         reason,
     )
     return reason

--- a/tests/test_service_generations.py
+++ b/tests/test_service_generations.py
@@ -14,6 +14,7 @@ import pytest
 
 from relaytv_app import discovery_mdns, postlive_relay
 from relaytv_app.integrations import iptv_service
+from relaytv_app.integrations.iptv_store import IptvStore
 
 
 class _FakeZeroconf:
@@ -384,7 +385,7 @@ def test_iptv_refresh_result_is_discarded_after_worker_stop(monkeypatch) -> None
             }
 
         @staticmethod
-        def mark_refresh_attempt(source_id):
+        def mark_refresh_attempt(source_id, **kwargs):
             return None
 
         @staticmethod
@@ -430,6 +431,74 @@ def test_iptv_refresh_result_is_discarded_after_worker_stop(monkeypatch) -> None
     assert not worker.is_alive()
     assert result == [{"ok": False, "source_id": "source-1", "retired": True}]
     assert replaced == []
+
+
+def test_iptv_retirement_while_attempt_waits_for_store_lock_does_not_publish(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Retire after the outer check but before the actual database update."""
+    catalog = IptvStore(str(tmp_path / "iptv.sqlite3"))
+    source_id = "source-retired-at-attempt"
+    catalog.create_source(
+        source_id=source_id,
+        name="Retirement test",
+        kind="url",
+        location="https://example.test/list.m3u",
+    )
+
+    guard_entered = threading.Event()
+    release_guard = threading.Event()
+    attempt_entered = threading.Event()
+    stop = threading.Event()
+    guard_calls = 0
+    results: list[dict[str, object]] = []
+
+    original_mark = catalog.mark_refresh_attempt
+
+    def observed_mark(source_id, **kwargs):
+        attempt_entered.set()
+        return original_mark(source_id, **kwargs)
+
+    def publish_guard() -> bool:
+        nonlocal guard_calls
+        guard_calls += 1
+        if guard_calls == 1:
+            guard_entered.set()
+            assert release_guard.wait(5.0)
+        return not stop.is_set()
+
+    monkeypatch.setattr(catalog, "mark_refresh_attempt", observed_mark)
+    monkeypatch.setattr(iptv_service, "store", lambda: catalog)
+    monkeypatch.setattr(
+        iptv_service,
+        "_fetch_source",
+        lambda source: ("#EXTM3U\n", "", "", False, source["location"]),
+    )
+
+    worker = threading.Thread(
+        target=lambda: results.append(
+            iptv_service.refresh_source(source_id, publish_guard=publish_guard)
+        ),
+        daemon=True,
+    )
+    worker.start()
+    assert guard_entered.wait(5.0), "refresh never reached its initial ownership check"
+
+    # Hold the real store lock while the live check completes, then retire the
+    # worker only after mark_refresh_attempt is genuinely waiting to publish.
+    catalog._lock.acquire()
+    try:
+        release_guard.set()
+        assert attempt_entered.wait(5.0), "refresh never reached attempt publication"
+        stop.set()
+    finally:
+        catalog._lock.release()
+
+    worker.join(timeout=5.0)
+    assert not worker.is_alive()
+    assert results == [{"ok": False, "source_id": source_id, "retired": True}]
+    assert catalog.get_source(source_id)["last_attempt_at"] is None
 
 
 def test_iptv_probe_result_is_discarded_after_worker_stop(monkeypatch) -> None:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -6453,6 +6453,53 @@ def test_a_failed_play_records_a_reason_and_a_finished_one_clears_it(monkeypatch
     assert player.last_playback_error() is None
 
 
+def test_idle_without_an_item_does_not_inherit_an_mpv_startup_error(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """An idle runtime has no playback attempt to which a log line can belong."""
+    from relaytv_app import player
+
+    log = tmp_path / "mpv.log"
+    log.write_text(
+        "[ 0.10][e][cplayer] Error opening/initializing the VO window.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MPV_LOG_FILE", str(log))
+    monkeypatch.setattr(player, "_PLAYBACK_LOG_OFFSET", 0, raising=False)
+    monkeypatch.setattr(player, "_PLAYBACK_STARTED_POS", 0.0, raising=False)
+    player.set_last_playback_error(None)
+
+    assert player.note_playback_failure_if_no_progress(None) == ""
+    assert player.last_playback_error() is None
+
+
+def test_queue_empty_natural_end_records_failure_once(monkeypatch) -> None:
+    """The queue-empty handler owns diagnostics; natural_end must not duplicate it."""
+    from relaytv_app import playback_service, player, state
+
+    now = {"title": "Ended", "resume_pos": 0.0}
+    seen: list[object] = []
+    monkeypatch.setattr(state, "NOW_PLAYING", now, raising=False)
+    monkeypatch.setattr(state, "QUEUE", [], raising=False)
+    monkeypatch.setattr(player, "playback_transitioning", lambda: False)
+    monkeypatch.setattr(player, "auto_next_transitioning", lambda: False)
+    monkeypatch.setattr(player, "_session_already_idle_without_queue", lambda: False)
+    monkeypatch.setattr(
+        player,
+        "note_playback_failure_if_no_progress",
+        lambda item: seen.append(item) or "",
+    )
+    monkeypatch.setattr(
+        player,
+        "_handle_playback_idle_no_queue",
+        lambda: player.note_playback_failure_if_no_progress(state.NOW_PLAYING),
+    )
+
+    assert playback_service.natural_end() == "idle"
+    assert seen == [now]
+
+
 def test_the_image_version_probe_ignores_the_persisted_install(monkeypatch) -> None:
     """Stripping PATH alone cannot see the image's yt-dlp.
 


### PR DESCRIPTION
## Summary

- require a concrete playback item before attributing mpv log errors, so idle Qt initialization messages cannot become playback failures
- let the queue-empty transition own failure reporting while preserving pre-advance reporting when a successor is queued
- pass IPTV worker ownership into `mark_refresh_attempt()` and re-check it after acquiring the real store lock, preventing retired workers from advancing refresh schedules or clearing live errors
- add deterministic regression coverage for the idle path, exactly-once queue-empty diagnostics, and the store-lock retirement interleaving

## User impact

Idle devices no longer surface false playback failures or flood logs with an empty-title error. Real failed items remain visible, including when the queue advances. IPTV sources cannot have their next refresh deferred by an attempt published from a retired worker.

## Operator/deployment impact

No configuration or data migration is required. Normal image deployment is sufficient.

## Breaking changes

None.

## Tests run

- `ruff check app tests`
- `PYTHONPATH=app pytest -q` — 967 passed
- `git diff --check`
- `node --check app/relaytv_app/static/ui/app.js`
- `node --check app/relaytv_app/static/ui/realtime_transport.js`
- embedded X11 overlay script piped to `node --check -`
- `node --test tests/js/*.test.js` — 24 passed
- revert proof: idle attribution test fails when the no-item guard is removed
- revert proof: exactly-once diagnostic test fails when reporting is moved back ahead of the queue-empty decision
- revert proof: real store-lock interleaving test fails when the publication-boundary ownership check is removed

## Release highlight

Not warranted; this is a reliability fix and belongs in generated release notes.

<!-- BEGIN_COMMIT_OVERRIDE -->
fix: reject idle and retired service diagnostics
<!-- END_COMMIT_OVERRIDE -->
