### PR TITLE
feat: UX overhaul across remote, queue, Jellyfin, and idle surfaces

### DIFF
--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -1395,6 +1395,30 @@ def _tmdb_provider_id(data: dict[str, object]) -> int | None:
     return value if 0 < value <= 2_147_483_647 else None
 
 
+def _library_label_from_path(path: object, *, title: str = "", series_name: str = "") -> str:
+    """Best-effort library hint from an item's filesystem path.
+
+    Jellyfin's item payloads carry no library name, so search results from two
+    libraries with the same title and year are indistinguishable. The segment
+    above the item's own folder is the library root on typical layouts; only
+    that single label crosses into the UI, never the full path.
+    """
+    raw = str(path or "").replace("\\", "/")
+    segs = [s for s in raw.split("/") if s]
+    if len(segs) < 2:
+        return ""
+    for name in (series_name, title):
+        n = str(name or "").strip().lower()
+        if not n:
+            continue
+        for i, seg in enumerate(segs):
+            cleaned = seg.strip().lower()
+            if cleaned == n or cleaned.startswith(f"{n} (") or cleaned.startswith(f"{n}."):
+                if i >= 1:
+                    return segs[i - 1]
+    return segs[-2]
+
+
 def _normalize_catalog_item(data: dict[str, object], *, base: str, token: str) -> dict[str, object]:
     iid = str(data.get("Id") or "").strip()
     item_type = str(data.get("Type") or "").strip().lower()
@@ -1527,6 +1551,7 @@ def _normalize_catalog_item(data: dict[str, object], *, base: str, token: str) -
         "video_fps": video_fps,
         "video_bitrate": video_bitrate,
         "tmdb_id": _tmdb_provider_id(data),
+        "library_name": _library_label_from_path(data.get("Path"), title=title, series_name=series_name),
     }
     _attach_thumb(out)
     if out.get("thumbnail_local"):
@@ -2191,7 +2216,7 @@ def search_catalog(query: str, *, limit: int = 30, refresh: bool = False) -> dic
             "Recursive": "true",
             "Limit": str(lim),
             "IncludeItemTypes": "Movie,Episode,Series",
-            "Fields": "Overview,ImageTags,BackdropImageTags,ProductionYear,PremiereDate,RunTimeTicks,UserData,SeriesName,ParentIndexNumber,IndexNumber",
+            "Fields": "Overview,ImageTags,BackdropImageTags,ProductionYear,PremiereDate,RunTimeTicks,UserData,SeriesName,ParentIndexNumber,IndexNumber,Path",
         }
     )
     candidates: list[str] = []

--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import contextlib
+from contextvars import ContextVar
 from dataclasses import dataclass
 import os
 import threading
@@ -23,6 +24,10 @@ logger = get_logger("jellyfin_receiver")
 
 _LOCK = threading.Lock()
 _THREAD_LOCK = threading.Lock()
+
+# Only the authenticated server socket selects cast credentials for media work.
+# Context-local scope keeps concurrent browser requests on the client login.
+_CAST_CATALOG = ContextVar("jellyfin_cast_catalog", default=False)
 
 # Serializes whole configuration transactions (connect / disconnect / rename /
 # stop) against each other. _LOCK only guards individual _STATUS writes, which
@@ -180,6 +185,8 @@ def _catalog_cache_max_entries() -> int:
 
 
 def _catalog_cache_get(key: str) -> object | None:
+    if _CAST_CATALOG.get():
+        key = f"cast:{key}"
     now = time.time()
     with _CATALOG_CACHE_LOCK:
         item = _CATALOG_CACHE.get(key)
@@ -199,6 +206,8 @@ def _catalog_cache_get(key: str) -> object | None:
 
 
 def _catalog_cache_set(key: str, payload: object, *, ttl_sec: float) -> None:
+    if _CAST_CATALOG.get():
+        key = f"cast:{key}"
     if ttl_sec <= 0:
         return
     with _CATALOG_CACHE_LOCK:
@@ -421,7 +430,7 @@ def _start_locked() -> None:
         _AUTH_USER_ID = ""
         _AUTH_SESSION_ID = ""
         _STATUS["api_key_configured"] = bool(_API_KEY)
-        _STATUS["auth_user_configured"] = bool(_AUTH_USERNAME and _AUTH_PASSWORD)
+        _STATUS["auth_user_configured"] = bool(_AUTH_USERNAME or _AUTH_PASSWORD)
         _STATUS["authenticated"] = False
         _STATUS["auth_user"] = _AUTH_USERNAME
         _STATUS["auth_user_id"] = ""
@@ -516,9 +525,13 @@ def _status_with_sync_health(raw: dict[str, object]) -> dict[str, object]:
     else:
         out["control_auth_source"] = "none"
         out["cast_target_scope"] = "unavailable"
-    if auth_mode == "user_login" and bool(out.get("authenticated")):
+    if bool(out.get("authenticated")):
         out["catalog_auth_source"] = "user_session"
-    elif auth_mode == "shared_api_key" and bool(out.get("api_key_configured")):
+    elif (
+        auth_mode == "shared_api_key"
+        and bool(out.get("api_key_configured"))
+        and not bool(out.get("auth_user_configured"))
+    ):
         out["catalog_auth_source"] = "api_key"
     else:
         out["catalog_auth_source"] = "none"
@@ -744,7 +757,7 @@ def _request_context() -> _RequestContext:
             password=str(_AUTH_PASSWORD or ""),
             auth_mode=str(_AUTH_MODE or "user_login"),
             control_token=str(_API_KEY if _AUTH_MODE == "shared_api_key" else _ACCESS_TOKEN),
-            catalog_token=str(_API_KEY if _AUTH_MODE == "shared_api_key" else _ACCESS_TOKEN),
+            catalog_token=_catalog_token_locked(),
             catalog_user_id=catalog_user_id,
             authenticated=bool(_STATUS.get("authenticated")),
             connected=bool(_STATUS.get("connected")),
@@ -867,7 +880,7 @@ def _connect_locked(*, server_url: str, api_key: str | None, auth_mode: str | No
         _AUTH_USER_ID = ""
         _AUTH_SESSION_ID = ""
         _STATUS["api_key_configured"] = bool(_API_KEY)
-        _STATUS["auth_user_configured"] = bool(_AUTH_USERNAME and _AUTH_PASSWORD)
+        _STATUS["auth_user_configured"] = bool(_AUTH_USERNAME or _AUTH_PASSWORD)
         _STATUS["authenticated"] = False
         _STATUS["auth_user"] = _AUTH_USERNAME
         _STATUS["auth_user_id"] = ""
@@ -1051,10 +1064,30 @@ def control_socket_identity_headers(status_snapshot: dict[str, object] | None = 
     }
 
 
+def _catalog_token_locked() -> str:
+    """Prefer client credentials; never elevate a pending/failed login to an API key.
+
+    Caller holds _LOCK. API-only configurations retain their existing catalog
+    access when no client credentials have been supplied.
+    """
+    if _CAST_CATALOG.get() and _AUTH_MODE == "shared_api_key":
+        return str(_API_KEY or "")
+    if _ACCESS_TOKEN or _AUTH_USERNAME or _AUTH_PASSWORD or _AUTH_MODE == "user_login":
+        return str(_ACCESS_TOKEN or "")
+    return str(_API_KEY or "")
+
+
 def catalog_token() -> str:
-    """Return the credential selected for catalog and media work."""
+    """Return the client credential for catalog and media work."""
     with _LOCK:
-        return str(_API_KEY if _AUTH_MODE == "shared_api_key" else _ACCESS_TOKEN)
+        return _catalog_token_locked()
+
+
+def _catalog_device_id(context: _RequestContext, token: str) -> str:
+    device_id = context.device_id or "relaytv"
+    if context.auth_mode == "shared_api_key" and token != context.control_token:
+        return f"{device_id}-client"
+    return device_id
 
 
 def session_token() -> str:
@@ -1087,11 +1120,11 @@ def extract_item_id_from_url(url: str | None) -> str:
 
 
 def _build_emby_headers(*, token: str = "") -> dict[str, str]:
-    st = status()
-    client_name = str(st.get("client_name") or "RelayTV")
-    device_name = str(st.get("device_name") or "RelayTV")
-    device_id = str(st.get("device_id") or "relaytv")
-    client_version = str(st.get("client_version") or "1.0")
+    context = _request_context()
+    client_name = context.client_name
+    device_name = context.device_name
+    device_id = _catalog_device_id(context, token)
+    client_version = context.client_version
     out: dict[str, str] = {}
     tok = str(token or "").strip()
     if tok:
@@ -1132,7 +1165,7 @@ def get_item_metadata(
 
     client_name = context.client_name
     device_name = context.device_name
-    device_id = context.device_id or "relaytv"
+    device_id = _catalog_device_id(context, token)
     client_version = context.client_version
 
     def _headers() -> dict[str, str]:
@@ -2739,7 +2772,11 @@ def dispatch_command(action: str, payload: dict[str, object], *, guard=None) -> 
     sink = _COMMAND_SINK
     if sink is None:
         raise RuntimeError("no jellyfin command sink registered")
-    return sink(action, payload, guard=guard)
+    scope = _CAST_CATALOG.set(True)
+    try:
+        return sink(action, payload, guard=guard)
+    finally:
+        _CAST_CATALOG.reset(scope)
 
 
 def command_sink_registered() -> bool:
@@ -2866,6 +2903,9 @@ def authenticate_once(*, _context: _RequestContext | None = None) -> dict[str, o
     password = context.password
     device_name = context.device_name
     device_id = context.device_id or "relaytv"
+    # The browsing login must not attach a user to the shared cast device.
+    if context.auth_mode == "shared_api_key":
+        device_id = f"{device_id}-client"
     client_name = context.client_name
     client_version = context.client_version
     if not username or not password:
@@ -2924,6 +2964,10 @@ def authenticate_once(*, _context: _RequestContext | None = None) -> dict[str, o
         msg = _format_http_error(e)
 
         def _apply_failure() -> None:
+            global _ACCESS_TOKEN, _AUTH_USER_ID, _AUTH_SESSION_ID
+            _ACCESS_TOKEN = ""
+            _AUTH_USER_ID = ""
+            _AUTH_SESSION_ID = ""
             _STATUS["authenticated"] = False
             _STATUS["auth_user_id"] = ""
             _STATUS["auth_session_id"] = ""
@@ -2935,6 +2979,7 @@ def authenticate_once(*, _context: _RequestContext | None = None) -> dict[str, o
 
         if not _publish(generation, _apply_failure):
             return {"ok": False, "reason": "config_changed"}
+        _catalog_cache_clear()
         return {"ok": False, "reason": "auth_failed", "error": msg}
 
 
@@ -3313,8 +3358,6 @@ def _ensure_authentication() -> None:
     if not runtime_config.snapshot().flag("RELAYTV_JELLYFIN_AUTH_ENABLED", True):
         return
     context = _request_context()
-    if context.auth_mode != "user_login":
-        return
     if not context.enabled or not context.running:
         return
     if context.authenticated:

--- a/app/relaytv_app/integrations/jellyfin_service.py
+++ b/app/relaytv_app/integrations/jellyfin_service.py
@@ -1204,13 +1204,13 @@ def preferred_stream_indices(
 def retarget_queue_stream_preferences() -> int:
     """Best-effort: rewrite queued Jellyfin URLs using current language prefs."""
     with state.QUEUE_LOCK:
-        snapshot = list(state.QUEUE)
+        state.ensure_queue_item_ids(state.QUEUE)
+        snapshot = [dict(entry) if isinstance(entry, dict) else entry for entry in state.QUEUE]
     if not snapshot:
         return 0
 
-    changed = 0
-    updated_queue: list[object] = list(snapshot)
-    for i, entry in enumerate(snapshot):
+    updates: dict[str, tuple[str, str, str]] = {}
+    for entry in snapshot:
         if not isinstance(entry, dict):
             continue
         raw_url = str(entry.get("url") or "").strip()
@@ -1238,18 +1238,26 @@ def retarget_queue_stream_preferences() -> int:
         )
         next_url = apply_media_source_param(next_url, media_source_id=media_source_id)
         if next_url and next_url != raw_url:
-            out_entry = dict(entry)
-            out_entry["url"] = next_url
-            if item_id:
-                out_entry["jellyfin_item_id"] = item_id
-            updated_queue[i] = out_entry
-            changed += 1
+            updates[state.queue_item_id(entry)] = (raw_url, next_url, item_id)
 
-    if changed <= 0:
+    if not updates:
         return 0
 
+    changed = 0
     with state.QUEUE_LOCK:
-        state.QUEUE[:] = updated_queue
+        for i, entry in enumerate(state.QUEUE):
+            update = updates.get(state.queue_item_id(entry))
+            if not update or str(entry.get("url") or "").strip() != update[0]:
+                continue
+            out_entry = dict(entry)
+            out_entry["url"] = update[1]
+            if update[2]:
+                out_entry["jellyfin_item_id"] = update[2]
+            state.QUEUE[i] = out_entry
+            changed += 1
+    if not changed:
+        logger.info("queue_preferences_publish_skipped reason=queue_changed")
+        return 0
     try:
         state.persist_queue()
     except Exception:

--- a/app/relaytv_app/playback_service.py
+++ b/app/relaytv_app/playback_service.py
@@ -90,6 +90,27 @@ def queue_item(item: dict) -> tuple[int, list[dict]]:
     return qlen, snapshot
 
 
+def remove_queue_items_by_id(queue_ids: set[str]) -> tuple[int, list[dict]]:
+    """Remove only the accepted queue instances after a peer transfer.
+
+    Selection and removal share one lock, including the whole-queue case.
+    Missing instances are already gone; an equal URL is never a substitute.
+    """
+    with state.QUEUE_LOCK:
+        kept = [item for item in state.QUEUE if state.queue_item_id(item) not in queue_ids]
+        removed = len(state.QUEUE) - len(kept)
+        if removed:
+            state.QUEUE[:] = kept
+        snapshot = list(state.QUEUE)
+    if removed:
+        state.persist_queue()
+        try:
+            player.prime_mpv_up_next_from_queue(force=True)
+        except Exception:
+            pass
+    return removed, snapshot
+
+
 def queue_items(items: list[dict]) -> tuple[int, list[dict]]:
     """Append several items at once, persisting and warming caches one time.
 

--- a/app/relaytv_app/playback_service.py
+++ b/app/relaytv_app/playback_service.py
@@ -50,6 +50,7 @@ def play_now(
     clear_queue: bool,
     mode: str,
     start_pos: float | None = None,
+    raise_on_superseded: bool = False,
 ):
     """Start playing an item or raw URL immediately.
 
@@ -65,6 +66,8 @@ def play_now(
     }
     if start_pos is not None:
         kwargs["start_pos"] = start_pos
+    if raise_on_superseded:
+        kwargs["raise_on_superseded"] = True
     return player.play_item(item_or_text, **kwargs)
 
 
@@ -382,6 +385,7 @@ def handoff_snapshot() -> dict[str, Any] | None:
     nothing to hand off. IPTV sessions are excluded deliberately — their stream
     URLs are re-resolved from a local catalog the other device does not have.
     """
+    intent = player.current_playback_intent()
     if not player.is_playing():
         return None
     now = state.NOW_PLAYING
@@ -412,7 +416,34 @@ def handoff_snapshot() -> dict[str, Any] | None:
         duration = float(dur) if dur is not None else None
     except Exception:
         duration = None
-    return {"item": dict(now), "position": position, "duration": duration}
+    if not player.playback_intent_current(intent):
+        return None
+    return {"item": dict(now), "position": position, "duration": duration, "playback_intent": intent}
+
+
+def complete_peer_handoff(snapshot: dict, *, idle_surface_enabled: bool) -> bool:
+    """Stop only the session we sent; leave a replacement entirely alone."""
+    intent = snapshot.get("playback_intent")
+    if not isinstance(intent, int):
+        return False
+
+    def finish() -> None:
+        discard_interrupted_playback_state("peer_handoff")
+        # Use the process adapters, not stop_all/clear_session: this callback
+        # already owns retirement under the intent lock.
+        kept_shell = idle_surface_enabled and player.stop_playback_keep_qt_shell()
+        if not kept_shell:
+            player.stop_mpv(restart_splash=idle_surface_enabled)
+        state.update_session(now_playing=None, session_position=None, session_state="idle")
+        # The autoplay worker advances remaining local entries. Do not start
+        # a resolver inside this critical section or claim a newer Play here.
+        clear_auto_next_suppression()
+
+    with player.MPV_LOCK:
+        completed = player.finish_playback_intent(intent, finish)
+    if not completed:
+        logger.info("peer_handoff_teardown_skipped reason=playback_changed")
+    return completed
 
 
 def rollback_play_now_preserve(preserved: dict | None) -> list[dict] | None:

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -701,6 +701,27 @@ def playback_intent_current(intent: int) -> bool:
         return intent == _PLAYBACK_INTENT
 
 
+def current_playback_intent() -> int:
+    with _INTENT_LOCK:
+        return _PLAYBACK_INTENT
+
+
+def finish_playback_intent(intent: int, effect: Callable[[], None]) -> bool:
+    """Retire and finish only the captured generation, as one owned effect.
+
+    Caller holds MPV_LOCK first, matching the load path's lock order. The
+    callback may stop the local runtime, but must not resolve media, perform
+    peer I/O, or call another intent-claiming transition.
+    """
+    global _PLAYBACK_INTENT
+    with _INTENT_LOCK:
+        if intent != _PLAYBACK_INTENT:
+            return False
+        _PLAYBACK_INTENT += 1
+        effect()
+        return True
+
+
 def retire_playback_intents(reason: str = "") -> int:
     """Retire every unresolved play. Called by Stop, Close, and resume-clear.
 
@@ -714,6 +735,8 @@ def retire_playback_intents(reason: str = "") -> int:
 
 class _PlaybackSuperseded(Exception):
     """Raised inside play_item when a newer intent has taken over."""
+
+PlaybackSupersededError = _PlaybackSuperseded
 
 IPC_PATH = os.getenv("MPV_IPC_PATH", "/tmp/mpv.sock")
 SPLASH_PROC: subprocess.Popen | None = None
@@ -5036,7 +5059,8 @@ def _runtime_gap_completion_plausible(now: dict | None) -> bool:
     return elapsed >= required_elapsed
 
 
-def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mode: str, start_pos: float | None = None):
+def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mode: str, start_pos: float | None = None,
+              *, raise_on_superseded: bool = False):
     """Play a queue item dict or a raw shared URL/text."""
     # Claim before any resolving, IPTV lookup, relay preparation, or
     # availability wait, so this play both supersedes older ones and can be
@@ -5057,6 +5081,8 @@ def play_item(item_or_text, use_resolver: bool, cec: bool, clear_queue: bool, mo
         # resolving. Report whatever actually owns playback now rather than
         # this call's stale intention.
         logger.info("play_item_superseded stage=%s intent=%d mode=%s", exc, intent, mode)
+        if raise_on_superseded:
+            raise
         current = state.NOW_PLAYING
         return current if isinstance(current, dict) else {}
 

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -103,6 +103,7 @@ from .playback import (
     SeekAbsReq as SeekAbsReq,
     SeekReq as SeekReq,
     VolumeReq as VolumeReq,
+    _play_now_item as _play_now_item,
     _preserve_current_to_queue_front as _preserve_current_to_queue_front,
     clear_now_playing as clear_now_playing,
     clear_resumable_session as clear_resumable_session,

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -1068,8 +1068,11 @@ def _ui_event_push(event_name: str, event: dict) -> None:
 def _ui_event_push_queue(action: str, queue: list[object] | None = None, queue_length: int | None = None, source: str = "api") -> None:
     if queue is None:
         with state.QUEUE_LOCK:
+            state.ensure_queue_item_ids(state.QUEUE)
             queue = list(state.QUEUE)
-    queue = _annotate_upload_items(queue)
+    else:
+        state.ensure_queue_item_ids(queue)
+    queue = _annotate_queue_items(queue)
     qlen = int(queue_length) if queue_length is not None else len(queue)
     _ui_event_push(
         "queue",
@@ -1090,6 +1093,17 @@ def _annotate_upload_item(item: object) -> object:
 
 def _annotate_upload_items(items: list[object] | None) -> list[object]:
     return [_annotate_upload_item(item) for item in list(items or [])]
+
+
+def _annotate_queue_items(items: list[object] | None) -> list[object]:
+    annotated: list[object] = []
+    for item in list(items or []):
+        public = _annotate_upload_item(item)
+        queue_id = state.queue_item_id(item)
+        if queue_id and isinstance(public, dict):
+            public["queue_id"] = queue_id
+        annotated.append(public)
+    return annotated
 
 
 def _ui_event_push_jellyfin(
@@ -3239,6 +3253,7 @@ def _playback_state_fast_snapshot() -> dict[str, object]:
 def _status_payload() -> dict[str, object]:
     settings_snapshot = state.get_settings() if hasattr(state, "get_settings") else {}
     with state.QUEUE_LOCK:
+        state.ensure_queue_item_ids(state.QUEUE)
         q = list(state.QUEUE)
     sess = getattr(state, "SESSION_STATE", "idle")
     has_now_playing = isinstance(getattr(state, "NOW_PLAYING", None), dict)
@@ -3437,7 +3452,7 @@ def _status_payload() -> dict[str, object]:
         )
     )
     annotated_now_playing = _annotate_upload_item(now_playing)
-    annotated_queue = _annotate_upload_items(q)
+    annotated_queue = _annotate_queue_items(q)
     iptv_status: dict[str, object] = {"enabled": iptv_service.enabled()}
     if iptv_status["enabled"]:
         try:

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -4608,41 +4608,16 @@ def ui():
           <div class="hint">Use your local Jellyfin or Emby base URL, for example `http://10.0.55.2:8096`. The server type is detected automatically.</div>
         </div>
 
-        <div class="fieldRow">
-          <label class="fieldLbl" for="setJfAuthMode">Cast target identity</label>
-          <select id="setJfAuthMode" class="input">
-            <option value="shared_api_key">Shared cast target (server API key)</option>
-            <option value="user_login">User-scoped cast target (username and password)</option>
-          </select>
-          <div class="hint" id="setJfAuthModeHint"></div>
-        </div>
-
-        <div id="setJfSharedAuthFields">
+        <div id="setJfUserAuthFields" role="group" aria-labelledby="setJfClientHeading">
+          <h3 id="setJfClientHeading">Client login</h3>
+          <div class="hint">Sign in for RelayTV’s media browser, personal library, and resume points. This login works alongside the shared cast target below.</div>
+          <div class="hint" id="setJfClientStatus" role="status"></div>
           <div class="fieldRow">
-            <label class="fieldLbl">Server API key</label>
-            <input id="setJfApiKey" class="input" type="password" autocomplete="new-password" placeholder="(leave blank to keep existing)" />
-            <div class="hint">Makes RelayTV a shared cast target for every Jellyfin user allowed to control shared devices. API keys are administrator-level secrets.</div>
-            <div class="toggleRow">
-              <div class="toggleCopy">
-                <div class="toggleTitle">Clear stored API key</div>
-                <div class="toggleHint">Remove the saved server API key on the next apply.</div>
-              </div>
-              <label class="toggleSwitch" for="setJfClearApiKey" title="Clear stored Jellyfin API key">
-                <input type="checkbox" id="setJfClearApiKey" />
-                <span class="toggleTrack" aria-hidden="true"></span>
-              </label>
-            </div>
-            <div class="hint" id="setJfApiKeyState"></div>
-          </div>
-        </div>
-
-        <div id="setJfUserAuthFields">
-          <div class="fieldRow">
-            <label class="fieldLbl">Username</label>
+            <label class="fieldLbl" for="setJfUsername">Username</label>
             <input id="setJfUsername" class="input" placeholder="server username" />
           </div>
           <div class="fieldRow">
-            <label class="fieldLbl">Password</label>
+            <label class="fieldLbl" for="setJfPassword">Password</label>
             <input id="setJfPassword" class="input" type="password" autocomplete="new-password" placeholder="(leave blank to keep existing)" />
             <div class="toggleRow">
               <div class="toggleCopy">
@@ -4660,8 +4635,41 @@ def ui():
         <div class="fieldRow">
           <label class="fieldLbl">Preferred user ID (optional)</label>
           <input id="setJfUserId" class="input" placeholder="Server user Id (UUID)" />
-          <div class="hint">Optional profile override for catalog browsing on this TV. In user-login mode, leave blank to use the authenticated user.</div>
+          <div class="hint">Leave blank to use the signed-in account. For API-key-only browsing, enter a server user ID. A login can only access profiles its account is allowed to read.</div>
         </div>
+
+        <div id="setJfSharedAuthFields" role="group" aria-labelledby="setJfCastHeading">
+          <h3 id="setJfCastHeading">Shared cast target</h3>
+          <div class="toggleRow">
+            <div class="toggleCopy">
+              <div class="toggleTitle">Share this cast target using an API key</div>
+              <div class="toggleHint">Let permitted Jellyfin users cast to this TV independently of the client login.</div>
+            </div>
+            <label class="toggleSwitch" for="setJfSharedCastEnabled" title="Enable shared cast target">
+              <input type="checkbox" id="setJfSharedCastEnabled" />
+              <span class="toggleTrack" aria-hidden="true"></span>
+            </label>
+          </div>
+          <div class="hint" id="setJfAuthModeHint"></div>
+          <div class="hint" id="setJfCastStatus" role="status"></div>
+          <div class="fieldRow">
+            <label class="fieldLbl" for="setJfApiKey">Server API key</label>
+            <input id="setJfApiKey" class="input" type="password" autocomplete="new-password" placeholder="(leave blank to keep existing)" />
+            <div class="hint">Create a key in Jellyfin Dashboard → Advanced → API Keys. It keeps the shared cast target connected while client browsing uses the login above. API keys are administrator-level secrets.</div>
+            <div class="toggleRow">
+              <div class="toggleCopy">
+                <div class="toggleTitle">Clear stored API key</div>
+                <div class="toggleHint">Remove the saved server API key on the next apply.</div>
+              </div>
+              <label class="toggleSwitch" for="setJfClearApiKey" title="Clear stored Jellyfin API key">
+                <input type="checkbox" id="setJfClearApiKey" />
+                <span class="toggleTrack" aria-hidden="true"></span>
+              </label>
+            </div>
+            <div class="hint" id="setJfApiKeyState"></div>
+          </div>
+        </div>
+
         <div class="fieldRow">
           <label class="fieldLbl">Preferred audio language</label>
           <input id="setJfAudioLang" class="input" placeholder="e.g. en, pt-BR" />

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -1513,13 +1513,24 @@ def _idle_html() -> str:
     .statusWrap{
       display:grid;
       justify-items:end;
-      gap:.3125rem
+      gap:.3125rem;
+      min-width:0;
+      max-width:100%
     }
     .footerStatus{
       color:rgba(221,233,248,.7);
       font-size:.875rem;
       letter-spacing:.14em;
-      text-transform:uppercase
+      text-transform:uppercase;
+      max-width:100%;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis
+    }
+    /* Keep the status line clear of the fixed QR card */
+    body.hasQr .footer{padding-right:calc(var(--idleQrSizePx,10.5rem) + 1.5rem)}
+    @media (max-width:760px){
+      body.hasQr .footer{padding-right:calc(var(--idleQrSizeMobilePx,7.25rem) + 1.25rem)}
     }
     .footerMeta{
       color:rgba(197,214,235,.56);
@@ -1649,17 +1660,14 @@ def _idle_html() -> str:
       const img = document.getElementById('idleQrImg');
       const label = document.getElementById('idleQrLabel');
       if (!wrap || !img || !label) return;
-      if (!__idleQrEnabled || !url) {
+      const show = !!(__idleQrEnabled && url && String(url).trim());
+      document.body.classList.toggle('hasQr', show);
+      if (!show) {
         wrap.classList.add('hidden');
         wrap.setAttribute('aria-hidden', 'true');
         return;
       }
       const target = String(url || '').trim();
-      if (!target) {
-        wrap.classList.add('hidden');
-        wrap.setAttribute('aria-hidden', 'true');
-        return;
-      }
       if (__idleQrUrl !== target) {
         __idleQrUrl = target;
         img.src = `/qr/connect.svg?logo=1&u=${encodeURIComponent(target)}&ts=${Date.now()}`;
@@ -1897,7 +1905,17 @@ def _idle_html() -> str:
         }
         renderPanels(settings.idle_panels||{}, settings, weatherData);
         const np=st.now_playing||null;
-        document.getElementById('now').textContent=np ? `Now Playing: ${np.title||np.url||'Playing'}` : 'Idle';
+        // Only live sessions may say Now Playing; a retained item after close
+        // is "Ended", not something still on the screen.
+        const sessState = String(st.state || '').trim().toLowerCase();
+        const npTitle = np ? String(np.title || np.url || 'Playing') : '';
+        let nowText = 'Idle';
+        if (np && (st.playing || st.paused || sessState === 'playing' || sessState === 'paused')) {
+          nowText = `${(st.paused || sessState === 'paused') ? 'Paused' : 'Now Playing'}: ${npTitle}`;
+        } else if (np && sessState === 'closed') {
+          nowText = `Ended: ${npTitle}`;
+        }
+        document.getElementById('now').textContent = nowText;
       }catch(_e){}
     }
     setInterval(refresh,3000); refresh();

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -1070,8 +1070,8 @@ def _ui_event_push_queue(action: str, queue: list[object] | None = None, queue_l
         with state.QUEUE_LOCK:
             state.ensure_queue_item_ids(state.QUEUE)
             queue = list(state.QUEUE)
-    else:
-        state.ensure_queue_item_ids(queue)
+    # Supplied snapshots already carry ids assigned at insertion under the
+    # queue lock. Publication must never mutate their shared dictionaries.
     queue = _annotate_queue_items(queue)
     qlen = int(queue_length) if queue_length is not None else len(queue)
     _ui_event_push(

--- a/app/relaytv_app/routes/__init__.py
+++ b/app/relaytv_app/routes/__init__.py
@@ -4070,6 +4070,15 @@ def ui():
 
         <div class="nIdleMsg" aria-hidden="true">Nothing playing — share a link or pick from the queue</div>
 
+        <div id="nowUpNext" class="nUpNext hidden">
+          <span class="nUpNextLabel">Up next</span>
+          <div class="nUpNextItem">
+            <span id="upNextThumb" class="nUpNextThumb" aria-hidden="true"></span>
+            <span id="upNextTitle" class="nUpNextTitle"></span>
+          </div>
+          <button id="upNextPlayBtn" class="nUpNextPlay" title="Play next in queue" aria-label="Play next in queue">Play</button>
+        </div>
+
         <div id="progress" class="progress" title="Drag to seek (or tap)">
           <div id="progFill" class="progressFill"></div>
         </div>

--- a/app/relaytv_app/routes/peers.py
+++ b/app/relaytv_app/routes/peers.py
@@ -31,10 +31,13 @@ class PeerSendReq(BaseModel):
     # ``index`` predates per-item selection and is kept for companion apps.
     index: int | None = None
     indexes: list[int] | None = None
+    queue_id: str | None = None
+    queue_ids: list[str] | None = None
 
 
 class PeerHandoffReq(BaseModel):
     indexes: list[int] | None = None
+    queue_ids: list[str] | None = None
     # A handoff that keeps the local session is the "Copy" gesture: the peer
     # starts playing, this device carries on. Defaulting to False keeps the
     # original meaning of the endpoint for callers that send no body.
@@ -209,6 +212,26 @@ def _selected_indexes(queue_length: int, *, index: int | None, indexes: list[int
     return sorted(set(resolved))
 
 
+def _selected_queue_items(
+    queue: list[object],
+    *,
+    index: int | None,
+    indexes: list[int] | None,
+    queue_id: str | None = None,
+    queue_ids: list[str] | None = None,
+) -> list[object]:
+    """Select stable queue instances, with indexes retained for old callers."""
+    if queue_ids is not None or queue_id:
+        chosen = list(queue_ids) if queue_ids is not None else [str(queue_id or "")]
+        wanted = [str(value or "").strip().lower() for value in chosen if str(value or "").strip()]
+        by_id = {state.queue_item_id(item): item for item in queue if state.queue_item_id(item)}
+        if any(item_id not in by_id for item_id in wanted):
+            raise HTTPException(status_code=409, detail="queue changed; refresh and retry")
+        return [by_id[item_id] for item_id in dict.fromkeys(wanted)]
+    selection = _selected_indexes(len(queue), index=index, indexes=indexes)
+    return queue if selection is None else [queue[position] for position in selection]
+
+
 @router.post("/peers/{peer_id}/send")
 def peers_send(peer_id: str, req: PeerSendReq) -> dict[str, object]:
     """Send the queue (or one queue item) to a peer device.
@@ -223,9 +246,15 @@ def peers_send(peer_id: str, req: PeerSendReq) -> dict[str, object]:
         mode = "append"
 
     with state.QUEUE_LOCK:
+        state.ensure_queue_item_ids(state.QUEUE)
         queue = list(state.QUEUE)
-    selection = _selected_indexes(len(queue), index=req.index, indexes=req.indexes)
-    items: list[object] = queue if selection is None else [queue[i] for i in selection]
+    items = _selected_queue_items(
+        queue,
+        index=req.index,
+        indexes=req.indexes,
+        queue_id=req.queue_id,
+        queue_ids=req.queue_ids,
+    )
     if not items:
         raise HTTPException(status_code=400, detail="nothing selected to send")
     try:
@@ -257,9 +286,14 @@ def peers_handoff(peer_id: str, req: PeerHandoffReq | None = None) -> dict[str, 
         raise HTTPException(status_code=409, detail="nothing is playing to hand off")
 
     with state.QUEUE_LOCK:
+        state.ensure_queue_item_ids(state.QUEUE)
         queue = list(state.QUEUE)
-    selection = _selected_indexes(len(queue), index=None, indexes=request.indexes)
-    items: list[object] = queue if selection is None else [queue[i] for i in selection]
+    items = _selected_queue_items(
+        queue,
+        index=None,
+        indexes=request.indexes,
+        queue_ids=request.queue_ids,
+    )
     try:
         result, accepted = peers.handoff_playback(peer_id, snapshot=snapshot, items=items)
     except peers.PeerError as exc:

--- a/app/relaytv_app/routes/peers.py
+++ b/app/relaytv_app/routes/peers.py
@@ -252,7 +252,7 @@ def peers_handoff(peer_id: str, req: PeerHandoffReq | None = None) -> dict[str, 
     # that is exactly right — this device continues into whatever it kept.
     result["local_queue_length"] = _remove_local_queue_items(accepted)
 
-    from .playback import clear_now_playing
+    from .playback import _idle_visual_surface_enabled_for_player
 
     stopped = False
     try:
@@ -260,11 +260,9 @@ def peers_handoff(peer_id: str, req: PeerHandoffReq | None = None) -> dict[str, 
         # would leave this device showing the item it just gave away and
         # offering to resume it — playing the same thing in two rooms. The
         # session moved, so it is cleared here.
-        clear_now_playing()
-        # A handoff leaves this device available rather than deliberately
-        # parked, so the long auto-next hold that clearing applies is dropped.
-        playback_service.clear_auto_next_suppression()
-        stopped = True
+        stopped = playback_service.complete_peer_handoff(
+            snapshot, idle_surface_enabled=_idle_visual_surface_enabled_for_player(),
+        )
     except Exception as exc:  # pragma: no cover - local teardown is best effort
         logger.warning("peer_handoff_local_stop_failed error=%s", exc)
     result["local_stopped"] = stopped

--- a/app/relaytv_app/routes/peers.py
+++ b/app/relaytv_app/routes/peers.py
@@ -124,74 +124,15 @@ def peers_probe_saved(peer_id: str) -> dict[str, object]:
         raise _peer_error(exc) from exc
 
 
-def _clear_local_queue() -> int:
-    """Drop the local queue after a confirmed transfer.
-
-    Delegates to the queue routes rather than touching ``state.QUEUE`` here:
-    queue writers are pinned by tests/test_transition_inventory.py, and those
-    functions already persist, re-prime mpv's up-next, and emit the UI event.
-    """
-    from .queue import clear as clear_queue
-
-    clear_queue()
-    with state.QUEUE_LOCK:
-        return len(state.QUEUE)
-
-
-def _queue_index_of(target: object) -> int | None:
-    """Locate an item in the live queue. Call with ``state.QUEUE_LOCK`` held."""
-    for index, item in enumerate(state.QUEUE):
-        if item is target:
-            return index
-    # Persisting and reloading the queue replaces the objects, so identity can
-    # legitimately miss; the URL is the next best handle on the same item.
-    url = str(target.get("url") or "") if isinstance(target, dict) else ""
-    if not url:
-        return None
-    for index, item in enumerate(state.QUEUE):
-        if isinstance(item, dict) and str(item.get("url") or "") == url:
-            return index
-    return None
-
-
 def _remove_local_queue_items(items: list[object]) -> int:
-    """Drop exactly the items the peer took, as the queue stands right now.
+    """Drop accepted queue instances atomically, ignoring any already gone."""
+    from .queue import _ui_event_push_queue
 
-    Positions from before the send are deliberately not reused. A send can take
-    tens of seconds, and auto-next or another client may have shifted the queue
-    in the meantime — reusing an index would delete whichever item had moved
-    into that slot, destroying something that was never sent. Matching the item
-    itself also leaves behind anything the peer rejected and anything that
-    could not travel at all, so giving up ownership never loses more than it
-    handed over.
-    """
-    targets = list(items or [])
-    if not targets:
-        with state.QUEUE_LOCK:
-            return len(state.QUEUE)
-
-    with state.QUEUE_LOCK:
-        current = list(state.QUEUE)
-    # The whole queue going at once is the common case; clearing keeps it to a
-    # single persist, re-prime, and UI event instead of one per item.
-    if current and len(targets) >= len(current):
-        if all(any(item is target for target in targets) for item in current):
-            return _clear_local_queue()
-
-    from .queue import QueueRemoveReq, queue_remove
-
-    for target in targets:
-        with state.QUEUE_LOCK:
-            index = _queue_index_of(target)
-        if index is None:
-            # Already gone: played out, or removed by someone else mid-transfer.
-            continue
-        try:
-            queue_remove(QueueRemoveReq(index=index))
-        except HTTPException:
-            continue
-    with state.QUEUE_LOCK:
-        return len(state.QUEUE)
+    accepted_ids = {state.queue_item_id(item) for item in items if state.queue_item_id(item)}
+    removed, snapshot = playback_service.remove_queue_items_by_id(accepted_ids)
+    if removed:
+        _ui_event_push_queue("remove", queue=snapshot, queue_length=len(snapshot), source="peer_transfer")
+    return len(snapshot)
 
 
 def _selected_indexes(queue_length: int, *, index: int | None, indexes: list[int] | None) -> list[int] | None:

--- a/app/relaytv_app/routes/playback.py
+++ b/app/relaytv_app/routes/playback.py
@@ -302,47 +302,39 @@ def next_track():
     return result
 
 
-@router.post("/play_now")
-def play_now(req: PlayNowReq):
-    """Play immediately, optionally preserving the currently playing item."""
+def _play_now_item(
+    item_or_text: dict[str, object] | str,
+    *,
+    request_url: str,
+    preserve_current: bool = True,
+    preserve_to: str = "queue_front",
+    resume_current: bool = True,
+    reason: str | None = None,
+    title_hint: str | None = None,
+    resume_pos: float | None = None,
+) -> dict:
+    """Run the play-now transition without flattening an existing item.
+
+    Public ``PlayNowReq`` callers intentionally expose only generic media
+    fields. Internal callers such as queue playback already own a trusted,
+    server-built item and must retain provider metadata needed for play-time
+    resolution (for example IPTV catalog references).
+    """
     playback_service.suppress_auto_next(2.0)
 
     preserved = None
-    if req.preserve_current and req.preserve_to == "queue_front" and req.resume_current:
+    if preserve_current and preserve_to == "queue_front" and resume_current:
         preserved = _preserve_current_to_queue_front()
 
     try:
-        if (
-            req.title
-            or req.thumbnail
-            or req.resume_pos is not None
-            or req.history_id
-            or req.resolved_stream
-        ):
-            item = {"url": req.url}
-            if req.title:
-                item["title"] = req.title
-            if req.thumbnail:
-                item["thumbnail"] = req.thumbnail
-            if req.history_id:
-                item["history_id"] = req.history_id
-            if req.resolved_stream:
-                item["_resolved_source_url"] = (req.resolved_source_url or req.url or "").strip()
-                item["_resolved_stream"] = req.resolved_stream.strip()
-                if req.resolved_audio:
-                    item["_resolved_audio"] = req.resolved_audio.strip()
-                if req.resolved_at is not None:
-                    item["_resolved_at"] = req.resolved_at
-            now = playback_service.play_now(
-                item,
-                use_resolver=True,
-                cec=False,
-                clear_queue=False,
-                mode=(req.reason or "play_now"),
-                start_pos=req.resume_pos,
-            )
-        else:
-            now = playback_service.play_now(req.url, use_resolver=True, cec=False, clear_queue=False, mode=(req.reason or "play_now"))
+        now = playback_service.play_now(
+            item_or_text,
+            use_resolver=True,
+            cec=False,
+            clear_queue=False,
+            mode=(reason or "play_now"),
+            start_pos=resume_pos,
+        )
     except Exception as exc:
         if isinstance(exc, player.YouTubePostLiveProcessingError):
             try:
@@ -376,7 +368,7 @@ def play_now(req: PlayNowReq):
             # otherwise drops back to idle with no explanation.
             try:
                 _push_overlay_toast(
-                    text=f"Can't play (YouTube bot check): {req.title or req.url}",
+                    text=f"Can't play (YouTube bot check): {title_hint or request_url}",
                     duration=6.0,
                     level="warn",
                     icon="play",
@@ -387,7 +379,7 @@ def play_now(req: PlayNowReq):
     try:
         title = now.get("title") if isinstance(now, dict) else None
         _push_overlay_toast(
-            text=f"Playing now: {title or req.url}",
+            text=f"Playing now: {title or title_hint or request_url}",
             duration=_playback_notification_display_sec(),
             level="success",
             icon="play",
@@ -407,6 +399,44 @@ def play_now(req: PlayNowReq):
         "preserved": _annotate_upload_item(preserved),
         "queue_length": qlen,
     }
+
+
+@router.post("/play_now")
+def play_now(req: PlayNowReq):
+    """Play immediately, optionally preserving the currently playing item."""
+    item_or_text: dict[str, object] | str = req.url
+    if (
+        req.title
+        or req.thumbnail
+        or req.resume_pos is not None
+        or req.history_id
+        or req.resolved_stream
+    ):
+        item: dict[str, object] = {"url": req.url}
+        if req.title:
+            item["title"] = req.title
+        if req.thumbnail:
+            item["thumbnail"] = req.thumbnail
+        if req.history_id:
+            item["history_id"] = req.history_id
+        if req.resolved_stream:
+            item["_resolved_source_url"] = (req.resolved_source_url or req.url or "").strip()
+            item["_resolved_stream"] = req.resolved_stream.strip()
+            if req.resolved_audio:
+                item["_resolved_audio"] = req.resolved_audio.strip()
+            if req.resolved_at is not None:
+                item["_resolved_at"] = req.resolved_at
+        item_or_text = item
+    return _play_now_item(
+        item_or_text,
+        request_url=req.url,
+        preserve_current=req.preserve_current,
+        preserve_to=req.preserve_to,
+        resume_current=req.resume_current,
+        reason=req.reason,
+        title_hint=req.title,
+        resume_pos=req.resume_pos,
+    )
 
 
 @router.post("/play_temporary")

--- a/app/relaytv_app/routes/playback.py
+++ b/app/relaytv_app/routes/playback.py
@@ -312,6 +312,7 @@ def _play_now_item(
     reason: str | None = None,
     title_hint: str | None = None,
     resume_pos: float | None = None,
+    raise_on_superseded: bool = False,
 ) -> dict:
     """Run the play-now transition without flattening an existing item.
 
@@ -327,6 +328,7 @@ def _play_now_item(
         preserved = _preserve_current_to_queue_front()
 
     try:
+        strict_options = {"raise_on_superseded": True} if raise_on_superseded else {}
         now = playback_service.play_now(
             item_or_text,
             use_resolver=True,
@@ -334,6 +336,7 @@ def _play_now_item(
             clear_queue=False,
             mode=(reason or "play_now"),
             start_pos=resume_pos,
+            **strict_options,
         )
     except Exception as exc:
         if isinstance(exc, player.YouTubePostLiveProcessingError):

--- a/app/relaytv_app/routes/queue.py
+++ b/app/relaytv_app/routes/queue.py
@@ -118,6 +118,7 @@ def _play_now_queue_item(item: dict[str, object], *, resume_pos: float | None) -
         reason="queue_play",
         title_hint=str(item.get("title") or "").strip() or None,
         resume_pos=resume_pos,
+        raise_on_superseded=True,
     )
 
 
@@ -651,10 +652,12 @@ def queue_play(req: QueueRemoveReq):
         playable_item.pop(state.QUEUE_ITEM_ID_KEY, None)
         with play_scope:
             result = _play_now_queue_item(playable_item, resume_pos=resume_pos)
-    except Exception:
+    except Exception as exc:
         restored = _restore(owned_mutations=play_scope.mutations)
         if restored is not None:
             _ui_event_push_queue("add", queue=restored, queue_length=len(restored), source="queue_play_restore")
+        if isinstance(exc, player.PlaybackSupersededError):
+            raise HTTPException(status_code=409, detail="playback superseded by a newer action") from exc
         raise
 
     try:

--- a/app/relaytv_app/routes/queue.py
+++ b/app/relaytv_app/routes/queue.py
@@ -547,6 +547,90 @@ def queue_remove(req: QueueRemoveReq):
     }
 
 
+@router.post("/queue/play")
+def queue_play(req: QueueRemoveReq):
+    """Play a queued item immediately by index, preserving current playback.
+
+    Like ``history_play``, the index refers to the server's unredacted copy:
+    public queue payloads carry display-safe URLs, so a client cannot simply
+    repost what it rendered. The item leaves the queue only for a play the
+    server accepts — a failed play restores it at its original position,
+    matching the rollback pattern of ``advance_queue_playback``.
+    """
+    idx = int(req.index)
+    with state.QUEUE_LOCK:
+        if idx < 0 or idx >= len(state.QUEUE):
+            raise HTTPException(status_code=400, detail="index out of range")
+        item = state.QUEUE.pop(idx)
+        snapshot = {"queue": list(state.QUEUE), "saved_at": int(time.time())}
+    try:
+        state.persist_queue_payload(snapshot)
+    except Exception as e:
+        logger.warning("queue_persist_failed route=queue_play error=%s", e)
+
+    def _restore() -> list[object]:
+        with state.QUEUE_LOCK:
+            state.QUEUE.insert(min(idx, len(state.QUEUE)), item)
+            rollback = {"queue": list(state.QUEUE), "saved_at": int(time.time())}
+        try:
+            state.persist_queue_payload(rollback)
+        except Exception as e:
+            logger.warning("queue_persist_failed route=queue_play_restore error=%s", e)
+        return list(rollback["queue"])
+
+    if not isinstance(item, dict):
+        _restore()
+        raise HTTPException(status_code=400, detail="queue item is not playable")
+    url = item.get("url")
+    if not isinstance(url, str) or not url.strip():
+        _restore()
+        raise HTTPException(status_code=400, detail="queue item missing url")
+
+    resume_pos = None
+    try:
+        raw_resume = item.get("resume_pos")
+        resume_pos = float(raw_resume) if raw_resume is not None else None
+    except Exception:
+        resume_pos = None
+    try:
+        resolved_at = float(item.get("_resolved_at")) if item.get("_resolved_at") is not None else None
+    except Exception:
+        resolved_at = None
+    try:
+        result = _play_now_from_history(
+            {
+                "url": url.strip(),
+                "preserve_current": True,
+                "reason": "queue_play",
+                "title": str(item.get("title") or "").strip() or None,
+                "thumbnail": str(item.get("thumbnail") or "").strip() or None,
+                "resume_pos": resume_pos,
+                "history_id": str(item.get("history_id") or "").strip() or None,
+                "resolved_source_url": str(item.get("_resolved_source_url") or "").strip() or None,
+                "resolved_stream": str(item.get("_resolved_stream") or "").strip() or None,
+                "resolved_audio": str(item.get("_resolved_audio") or "").strip() or None,
+                "resolved_at": resolved_at,
+            }
+        )
+    except Exception:
+        restored = _restore()
+        _ui_event_push_queue("add", queue=restored, queue_length=len(restored), source="queue_play_restore")
+        raise
+
+    try:
+        player.prime_mpv_up_next_from_queue(force=True)
+    except Exception:
+        pass
+    with state.QUEUE_LOCK:
+        queue_snapshot = list(state.QUEUE)
+    # play_now only pushes its queue event when something was preserved or the
+    # queue is non-empty; the pop must be announced either way.
+    _ui_event_push_queue("remove", queue=queue_snapshot, queue_length=len(queue_snapshot), source="queue_play")
+    if isinstance(result, dict):
+        return {**result, "queue": _annotate_upload_items(queue_snapshot), "queue_length": len(queue_snapshot)}
+    return {"status": "playing", "queue": _annotate_upload_items(queue_snapshot), "queue_length": len(queue_snapshot)}
+
+
 def _queue_item_dedupe_key(item: object) -> tuple[str, str]:
     if not isinstance(item, dict):
         return ("raw", str(item))

--- a/app/relaytv_app/routes/queue.py
+++ b/app/relaytv_app/routes/queue.py
@@ -61,12 +61,17 @@ class QueueHandoffReq(BaseModel):
 
 
 class QueueRemoveReq(BaseModel):
-    index: int
+    # Index remains for companion/API compatibility. The browser sends the
+    # stable id so a delayed action cannot slide onto a different item.
+    index: int | None = None
+    queue_id: str | None = None
 
 
 class QueueMoveReq(BaseModel):
-    from_index: int
-    to_index: int
+    from_index: int | None = None
+    to_index: int | None = None
+    queue_id: str | None = None
+    to_queue_id: str | None = None
 
 
 class HistoryPlayReq(BaseModel):
@@ -124,6 +129,34 @@ def _annotate_upload_items(items: list[object] | None) -> list[object]:
     return [_annotate_upload_item(item) for item in list(items or [])]
 
 
+def _annotate_queue_item(item: object) -> object:
+    public = _annotate_upload_item(item)
+    queue_id = state.queue_item_id(item)
+    if queue_id and isinstance(public, dict):
+        public["queue_id"] = queue_id
+    return public
+
+
+def _annotate_queue_items(items: list[object] | None) -> list[object]:
+    return [_annotate_queue_item(item) for item in list(items or [])]
+
+
+def _queue_index_locked(index: int | None, queue_id: str | None, *, label: str = "index") -> int:
+    """Resolve a stable queue id, falling back to an index for legacy callers."""
+    wanted = str(queue_id or "").strip().lower()
+    if wanted:
+        for position, item in enumerate(state.QUEUE):
+            if state.queue_item_id(item) == wanted:
+                return position
+        raise HTTPException(status_code=409, detail="queue changed; refresh and retry")
+    if index is None:
+        raise HTTPException(status_code=400, detail=f"{label} or queue_id is required")
+    position = int(index)
+    if position < 0 or position >= len(state.QUEUE):
+        raise HTTPException(status_code=400, detail=f"{label} out of range")
+    return position
+
+
 @router.post("/enqueue")
 @router.post("/queue/add")
 @router.post("/api/queue/add")
@@ -144,7 +177,7 @@ def enqueue(req: EnqueueReq):
     _ui_event_push_queue("add", queue=queue_snapshot, queue_length=qlen, source="enqueue")
     return {
         "status": "queued",
-        "item": _annotate_upload_item(item),
+        "item": _annotate_queue_item(item),
         "queue_length": qlen,
         "now_playing": _annotate_upload_item(state.NOW_PLAYING),
     }
@@ -327,7 +360,7 @@ def _apply_peer_import(
         "accepted": len(accepted_items),
         "results": results,
         "queue_length": qlen,
-        "queue": _annotate_upload_items(queue_snapshot),
+        "queue": _annotate_queue_items(queue_snapshot),
         "now_playing": _annotate_upload_item(state.NOW_PLAYING),
     }
 
@@ -410,7 +443,7 @@ def queue_handoff(req: QueueHandoffReq):
         "accepted": int((imported or {}).get("accepted") or 0),
         "results": list((imported or {}).get("results") or []),
         "queue_length": len(queue_snapshot),
-        "queue": _annotate_upload_items(queue_snapshot),
+        "queue": _annotate_queue_items(queue_snapshot),
     }
 
 
@@ -431,10 +464,11 @@ def clear():
 @router.get("/queue")
 def queue():
     with state.QUEUE_LOCK:
+        state.ensure_queue_item_ids(state.QUEUE)
         q = list(state.QUEUE)
     return {
         "now_playing": _annotate_upload_item(state.NOW_PLAYING),
-        "queue": _annotate_upload_items(q),
+        "queue": _annotate_queue_items(q),
         "queue_length": len(q),
     }
 
@@ -537,9 +571,8 @@ def history_play(req: HistoryPlayReq):
 @router.post("/queue/remove")
 def queue_remove(req: QueueRemoveReq):
     with state.QUEUE_LOCK:
-        idx = int(req.index)
-        if idx < 0 or idx >= len(state.QUEUE):
-            raise HTTPException(status_code=400, detail="index out of range")
+        state.ensure_queue_item_ids(state.QUEUE)
+        idx = _queue_index_locked(req.index, req.queue_id)
         removed = state.QUEUE.pop(idx)
         snapshot = {"queue": list(state.QUEUE), "saved_at": int(time.time())}
 
@@ -556,14 +589,14 @@ def queue_remove(req: QueueRemoveReq):
     return {
         "status": "removed",
         "removed": _annotate_upload_item(removed),
-        "queue": _annotate_upload_items(snapshot["queue"]),
+        "queue": _annotate_queue_items(snapshot["queue"]),
         "queue_length": len(snapshot["queue"]),
     }
 
 
 @router.post("/queue/play")
 def queue_play(req: QueueRemoveReq):
-    """Play a queued item immediately by index, preserving current playback.
+    """Play a queued item immediately by stable id or legacy index.
 
     Like ``history_play``, the index refers to the server's unredacted copy:
     public queue payloads carry display-safe URLs, so a client cannot simply
@@ -571,19 +604,25 @@ def queue_play(req: QueueRemoveReq):
     server accepts — a failed play restores it at its original position,
     matching the rollback pattern of ``advance_queue_playback``.
     """
-    idx = int(req.index)
     with state.QUEUE_LOCK:
-        if idx < 0 or idx >= len(state.QUEUE):
-            raise HTTPException(status_code=400, detail="index out of range")
+        state.ensure_queue_item_ids(state.QUEUE)
+        idx = _queue_index_locked(req.index, req.queue_id)
         item = state.QUEUE.pop(idx)
+        dequeued_revision = state.queue_revision()
         snapshot = {"queue": list(state.QUEUE), "saved_at": int(time.time())}
     try:
         state.persist_queue_payload(snapshot)
     except Exception as e:
         logger.warning("queue_persist_failed route=queue_play error=%s", e)
 
-    def _restore() -> list[object]:
+    def _restore(*, owned_mutations: int = 0) -> list[object] | None:
         with state.QUEUE_LOCK:
+            if state.queue_revision() != (dequeued_revision + owned_mutations):
+                logger.info(
+                    "queue_play_restore_skipped reason=queue_changed queue_id=%s",
+                    state.queue_item_id(item),
+                )
+                return None
             state.QUEUE.insert(min(idx, len(state.QUEUE)), item)
             rollback = {"queue": list(state.QUEUE), "saved_at": int(time.time())}
         try:
@@ -606,11 +645,16 @@ def queue_play(req: QueueRemoveReq):
         resume_pos = float(raw_resume) if raw_resume is not None else None
     except Exception:
         resume_pos = None
+    play_scope = state.queue_mutation_scope()
     try:
-        result = _play_now_queue_item(item, resume_pos=resume_pos)
+        playable_item = dict(item)
+        playable_item.pop(state.QUEUE_ITEM_ID_KEY, None)
+        with play_scope:
+            result = _play_now_queue_item(playable_item, resume_pos=resume_pos)
     except Exception:
-        restored = _restore()
-        _ui_event_push_queue("add", queue=restored, queue_length=len(restored), source="queue_play_restore")
+        restored = _restore(owned_mutations=play_scope.mutations)
+        if restored is not None:
+            _ui_event_push_queue("add", queue=restored, queue_length=len(restored), source="queue_play_restore")
         raise
 
     try:
@@ -623,8 +667,8 @@ def queue_play(req: QueueRemoveReq):
     # queue is non-empty; the pop must be announced either way.
     _ui_event_push_queue("remove", queue=queue_snapshot, queue_length=len(queue_snapshot), source="queue_play")
     if isinstance(result, dict):
-        return {**result, "queue": _annotate_upload_items(queue_snapshot), "queue_length": len(queue_snapshot)}
-    return {"status": "playing", "queue": _annotate_upload_items(queue_snapshot), "queue_length": len(queue_snapshot)}
+        return {**result, "queue": _annotate_queue_items(queue_snapshot), "queue_length": len(queue_snapshot)}
+    return {"status": "playing", "queue": _annotate_queue_items(queue_snapshot), "queue_length": len(queue_snapshot)}
 
 
 def _queue_item_dedupe_key(item: object) -> tuple[str, str]:
@@ -681,20 +725,19 @@ def queue_dedupe():
         "changed": changed,
         "removed_count": removed,
         "queue_length": len(state.QUEUE),
-        "queue": _annotate_upload_items(state.QUEUE),
+        "queue": _annotate_queue_items(state.QUEUE),
     }
 
 
 @router.post("/queue/move")
 def queue_move(req: QueueMoveReq):
-    frm = int(req.from_index)
-    to = int(req.to_index)
     with state.QUEUE_LOCK:
+        state.ensure_queue_item_ids(state.QUEUE)
         n = len(state.QUEUE)
         if n == 0:
             raise HTTPException(status_code=400, detail="queue is empty")
-        if frm < 0 or frm >= n or to < 0 or to >= n:
-            raise HTTPException(status_code=400, detail="index out of range")
+        frm = _queue_index_locked(req.from_index, req.queue_id, label="from_index")
+        to = _queue_index_locked(req.to_index, req.to_queue_id, label="to_index")
         item = state.QUEUE.pop(frm)
         state.QUEUE.insert(to, item)
         snapshot = {"queue": list(state.QUEUE), "saved_at": int(time.time())}
@@ -709,4 +752,4 @@ def queue_move(req: QueueMoveReq):
         pass
     _ui_event_push_queue("move", queue=snapshot["queue"], queue_length=len(snapshot["queue"]), source="queue_move")
 
-    return {"status": "moved", "queue": _annotate_upload_items(snapshot["queue"]), "queue_length": len(snapshot["queue"])}
+    return {"status": "moved", "queue": _annotate_queue_items(snapshot["queue"]), "queue_length": len(snapshot["queue"])}

--- a/app/relaytv_app/routes/queue.py
+++ b/app/relaytv_app/routes/queue.py
@@ -102,6 +102,20 @@ def _play_now_from_history(payload: dict[str, object]) -> dict:
     return play_now(PlayNowReq(**payload))
 
 
+def _play_now_queue_item(item: dict[str, object], *, resume_pos: float | None) -> dict:
+    from . import _play_now_item
+
+    url = str(item.get("url") or "").strip()
+    return _play_now_item(
+        item,
+        request_url=url,
+        preserve_current=True,
+        reason="queue_play",
+        title_hint=str(item.get("title") or "").strip() or None,
+        resume_pos=resume_pos,
+    )
+
+
 def _annotate_upload_item(item: object) -> object:
     return public_media.public_media_item(upload_store.annotate_item(item))
 
@@ -593,25 +607,7 @@ def queue_play(req: QueueRemoveReq):
     except Exception:
         resume_pos = None
     try:
-        resolved_at = float(item.get("_resolved_at")) if item.get("_resolved_at") is not None else None
-    except Exception:
-        resolved_at = None
-    try:
-        result = _play_now_from_history(
-            {
-                "url": url.strip(),
-                "preserve_current": True,
-                "reason": "queue_play",
-                "title": str(item.get("title") or "").strip() or None,
-                "thumbnail": str(item.get("thumbnail") or "").strip() or None,
-                "resume_pos": resume_pos,
-                "history_id": str(item.get("history_id") or "").strip() or None,
-                "resolved_source_url": str(item.get("_resolved_source_url") or "").strip() or None,
-                "resolved_stream": str(item.get("_resolved_stream") or "").strip() or None,
-                "resolved_audio": str(item.get("_resolved_audio") or "").strip() or None,
-                "resolved_at": resolved_at,
-            }
-        )
+        result = _play_now_queue_item(item, resume_pos=resume_pos)
     except Exception:
         restored = _restore()
         _ui_event_push_queue("add", queue=restored, queue_length=len(restored), source="queue_play_restore")

--- a/app/relaytv_app/state.py
+++ b/app/relaytv_app/state.py
@@ -548,7 +548,33 @@ class _RevisionedQueue(list):
     must prevent the failed play from restoring the item.
     """
 
+    def __init__(self, values=()):
+        super().__init__(self._prepare(values, ()))
+
+    @staticmethod
+    def _prepare(values, existing):
+        """Assign instance ids before entries become visible to any reader.
+
+        Writers hold QUEUE_LOCK. Preserve ids on existing entries and clone
+        repeated instances, including insertion ahead of an existing copy.
+        """
+        seen = {queue_item_id(item) for item in existing}
+        prepared = []
+        for item in values:
+            if isinstance(item, dict):
+                item_id = queue_item_id(item, create=True)
+                if item_id in seen:
+                    item = dict(item)
+                    item.pop(QUEUE_ITEM_ID_KEY, None)
+                    item_id = queue_item_id(item, create=True)
+                seen.add(item_id)
+            prepared.append(item)
+        return prepared
+
     def __setitem__(self, key, value):
+        remaining = list(self)
+        del remaining[key]
+        value = self._prepare(value, remaining) if isinstance(key, slice) else self._prepare([value], remaining)[0]
         super().__setitem__(key, value)
         _advance_queue_revision()
 
@@ -557,17 +583,15 @@ class _RevisionedQueue(list):
         _advance_queue_revision()
 
     def __iadd__(self, value):
-        result = super().__iadd__(value)
-        _advance_queue_revision()
-        return result
+        self.extend(value)
+        return self
 
     def __imul__(self, value):
-        result = super().__imul__(value)
-        _advance_queue_revision()
-        return result
+        self[:] = list(self) * value
+        return self
 
     def append(self, value) -> None:
-        super().append(value)
+        super().append(self._prepare([value], self)[0])
         _advance_queue_revision()
 
     def clear(self) -> None:
@@ -575,11 +599,11 @@ class _RevisionedQueue(list):
         _advance_queue_revision()
 
     def extend(self, values) -> None:
-        super().extend(values)
+        super().extend(self._prepare(values, self))
         _advance_queue_revision()
 
     def insert(self, index, value) -> None:
-        super().insert(index, value)
+        super().insert(index, self._prepare([value], self)[0])
         _advance_queue_revision()
 
     def pop(self, index=-1):

--- a/app/relaytv_app/state.py
+++ b/app/relaytv_app/state.py
@@ -6,6 +6,7 @@ import time
 import re
 import platform
 import tempfile
+import uuid
 from .config import (
     env_bool as _env_bool,
     normalize_optional_positive_int as _normalize_optional_positive_int,
@@ -375,6 +376,9 @@ def _persistable_queue_item(item: dict) -> dict | None:
         "provider": provider,
     }
 
+    queue_id = queue_item_id(item)
+    if queue_id:
+        out[QUEUE_ITEM_ID_KEY] = queue_id
     for key in (
         "channel",
         "subtitle",
@@ -449,6 +453,7 @@ def _load_persisted_queue_item(item: dict) -> dict | None:
     out = _persistable_queue_item(item)
     if not isinstance(out, dict):
         return None
+    queue_item_id(out, create=True)
     return out
 
 
@@ -459,6 +464,9 @@ def _persistable_history_item(item: dict) -> dict | None:
         return None
 
     out = dict(base)
+    # Queue identity belongs to one queued instance, not to the media's
+    # history/now-playing identity.
+    out.pop(QUEUE_ITEM_ID_KEY, None)
     ts = item.get("ts")
     if ts is not None:
         try:
@@ -498,7 +506,140 @@ def _load_persisted_history_item(item: dict) -> dict | None:
 # Queue + Smart behavior
 # =========================
 
-QUEUE: list[dict] = []  # each item: {"url":..., "title":..., "provider":...}
+QUEUE_ITEM_ID_KEY = "_relaytv_queue_id"
+_QUEUE_REVISION = 0
+_QUEUE_MUTATION_LOCAL = threading.local()
+
+
+class _QueueMutationScope:
+    """Track structural mutations owned by one synchronous queue operation."""
+
+    def __init__(self) -> None:
+        self.mutations = 0
+        self._previous = None
+
+    def __enter__(self):
+        self._previous = getattr(_QUEUE_MUTATION_LOCAL, "owner", None)
+        _QUEUE_MUTATION_LOCAL.owner = self
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        _QUEUE_MUTATION_LOCAL.owner = self._previous
+
+
+def queue_mutation_scope() -> _QueueMutationScope:
+    """Return a scope whose same-thread mutations can be excluded from races."""
+    return _QueueMutationScope()
+
+
+def _advance_queue_revision() -> None:
+    global _QUEUE_REVISION
+    _QUEUE_REVISION += 1
+    owner = getattr(_QUEUE_MUTATION_LOCAL, "owner", None)
+    if isinstance(owner, _QueueMutationScope):
+        owner.mutations += 1
+
+
+class _RevisionedQueue(list):
+    """List that records every structural queue decision, including no-ops.
+
+    A clear issued while a play-now request temporarily holds the only queue
+    item still matters: the list is already empty, but that newer decision
+    must prevent the failed play from restoring the item.
+    """
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        _advance_queue_revision()
+
+    def __delitem__(self, key):
+        super().__delitem__(key)
+        _advance_queue_revision()
+
+    def __iadd__(self, value):
+        result = super().__iadd__(value)
+        _advance_queue_revision()
+        return result
+
+    def __imul__(self, value):
+        result = super().__imul__(value)
+        _advance_queue_revision()
+        return result
+
+    def append(self, value) -> None:
+        super().append(value)
+        _advance_queue_revision()
+
+    def clear(self) -> None:
+        super().clear()
+        _advance_queue_revision()
+
+    def extend(self, values) -> None:
+        super().extend(values)
+        _advance_queue_revision()
+
+    def insert(self, index, value) -> None:
+        super().insert(index, value)
+        _advance_queue_revision()
+
+    def pop(self, index=-1):
+        value = super().pop(index)
+        _advance_queue_revision()
+        return value
+
+    def remove(self, value) -> None:
+        super().remove(value)
+        _advance_queue_revision()
+
+    def reverse(self) -> None:
+        super().reverse()
+        _advance_queue_revision()
+
+    def sort(self, *args, **kwargs) -> None:
+        super().sort(*args, **kwargs)
+        _advance_queue_revision()
+
+
+def queue_revision() -> int:
+    """Return the structural queue revision. Read while ``QUEUE_LOCK`` is held."""
+    return _QUEUE_REVISION
+
+
+def queue_item_id(item: object, *, create: bool = False) -> str:
+    """Return an item's opaque queue-instance id, creating it when requested."""
+    if not isinstance(item, dict):
+        return ""
+    current = str(item.get(QUEUE_ITEM_ID_KEY) or "").strip().lower()
+    if re.fullmatch(r"[0-9a-f]{32}", current):
+        return current
+    if not create:
+        return ""
+    current = uuid.uuid4().hex
+    item[QUEUE_ITEM_ID_KEY] = current
+    return current
+
+
+def ensure_queue_item_ids(items: list[object]) -> None:
+    """Give every dictionary queue entry a stable opaque instance id in place."""
+    seen: dict[str, object] = {}
+    for index, original in enumerate(items):
+        item = original
+        queue_id = queue_item_id(item, create=True)
+        if not queue_id or queue_id not in seen:
+            if queue_id:
+                seen[queue_id] = item
+            continue
+        if item is seen[queue_id]:
+            # The same dictionary was appended twice. Give the later queue
+            # instance its own container so the ids can actually differ.
+            item = dict(item)
+            items[index] = item
+        item.pop(QUEUE_ITEM_ID_KEY, None)
+        queue_id = queue_item_id(item, create=True)
+        seen[queue_id] = item
+
+
+QUEUE: list[dict] = _RevisionedQueue()  # each item: {"url":..., "title":..., "provider":...}
 QUEUE_LOCK = threading.Lock()
 NOW_PLAYING: dict | None = None  # {"input","url","title","provider","stream","audio","started","mode"}
 
@@ -655,6 +796,7 @@ def _persist_queue() -> bool:
         # describes; the write itself happens outside, so no state lock is
         # ever held across disk I/O.
         version = _QUEUE_PUBLISHER.reserve()
+        ensure_queue_item_ids(QUEUE)
         queue = []
         for it in list(QUEUE):
             normalized = _persistable_queue_item(it)
@@ -730,6 +872,7 @@ def _load_persisted_state() -> None:
                 normalized = _load_persisted_queue_item(it)
                 if isinstance(normalized, dict):
                     loaded.append(normalized)
+            ensure_queue_item_ids(loaded)
             QUEUE[:] = loaded
 
     hdata = _load_json(hpath, {})

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -100,7 +100,7 @@
     /* Header controls share one glass-chip material */
     .jfLaunch, .hdrAddBtn, .hdrMenuBtn{
       min-height: 0 !important;
-      height: 36px;
+      height: 40px;
       width: auto !important;
       padding: 0 12px !important;
       border-radius: 12px !important;
@@ -1001,8 +1001,8 @@
     }
     .nSkipBtn,
     .nGhostBtn{
-      min-height: 0;
-      padding: 5px 12px;
+      min-height: 40px;
+      padding: 8px 16px;
       border-radius: 999px;
       font-size: 12px;
       font-weight: 700;
@@ -1409,6 +1409,7 @@
       --remote-vol-track-end: rgba(120, 165, 250, .14);
       --remote-vol-track-border: rgba(160, 200, 255, .16);
       width: 100%;
+      height: 30px;
       margin: 0;
       appearance: none;
       -webkit-appearance: none;
@@ -1652,8 +1653,8 @@
     }
     .qClearBtn{
       margin-left: auto;
-      min-height: 0;
-      padding: 5px 12px;
+      min-height: 40px;
+      padding: 8px 16px;
       border-radius: 999px;
       font-size: 12px;
       font-weight: 700;
@@ -1810,15 +1811,44 @@
     }
 
     /* Override global button sizing for compact queue controls */
+    .qMenuBtn{
+      flex: 0 0 auto;
+      align-self: center;
+      min-height: 0;
+      padding: 0;
+      width: 40px;
+      height: 40px;
+      border-radius: 999px;
+      font-size: 17px;
+      font-weight: 800;
+      line-height: 1;
+      border: 1px solid rgba(140,190,255,.34);
+      background: rgba(20,26,40,.60);
+      color: rgba(210,228,255,.82);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+      z-index: 2;
+      box-shadow: none;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+    .qMenuBtn:hover{
+      color: #eaf3ff;
+      border-color: rgba(150,210,255,.60);
+      background: rgba(34,60,120,.70);
+      transform: none;
+    }
     .qDelBtn{
       flex: 0 0 auto;
       align-self: center;
       min-height: 0;
       padding: 0;
-      width: 28px;
-      height: 28px;
+      width: 40px;
+      height: 40px;
       border-radius: 999px;
-      font-size: 13px;
+      font-size: 15px;
       font-weight: 800;
       line-height: 1;
       border: 1px solid rgba(255, 130, 150, .42);
@@ -1841,6 +1871,104 @@
       transform: none;
     }
     .qDelBtn:active{ transform: none; }
+
+    .qTile.qPendingRemove{ opacity: .42; filter: saturate(.6); }
+    .qTile.qPendingRemove .qTitleText{ text-decoration: line-through; }
+
+    /* Anchored action menu for queue tiles */
+    .qPopBackdrop{
+      position: fixed;
+      inset: 0;
+      z-index: 90;
+      background: transparent;
+    }
+    .qPopMenu{
+      position: fixed;
+      z-index: 91;
+      min-width: 190px;
+      padding: 6px;
+      border-radius: 14px;
+      background: linear-gradient(180deg, rgba(22,34,64,.97), rgba(12,20,42,.97));
+      border: 1px solid rgba(140,190,255,.30);
+      box-shadow: 0 18px 44px rgba(2,8,26,.55), inset 0 1px 0 rgba(190,220,255,.10);
+      backdrop-filter: blur(14px);
+      -webkit-backdrop-filter: blur(14px);
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .qPopItem{
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      width: 100%;
+      min-height: 44px;
+      padding: 8px 12px;
+      border: none;
+      border-radius: 10px;
+      background: transparent;
+      color: #dbe7ff;
+      font-size: 14px;
+      font-weight: 600;
+      text-align: left;
+      box-shadow: none;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+    .qPopItem svg{ width: 17px; height: 17px; flex: 0 0 auto; opacity: .85; }
+    .qPopItem:hover{ background: rgba(56,120,246,.22); transform: none; }
+    .qPopItem.danger{ color: rgba(255,170,182,.95); }
+    .qPopItem.danger:hover{ background: rgba(220,38,38,.24); }
+
+    /* Undo / status toast */
+    .qToast{
+      position: fixed;
+      left: 50%;
+      bottom: max(18px, env(safe-area-inset-bottom, 0px) + 12px);
+      transform: translateX(-50%);
+      z-index: 95;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      max-width: min(92vw, 420px);
+      padding: 10px 10px 10px 16px;
+      border-radius: 999px;
+      background: linear-gradient(180deg, rgba(24,38,72,.97), rgba(13,22,44,.97));
+      border: 1px solid rgba(140,190,255,.32);
+      box-shadow: 0 14px 36px rgba(2,8,26,.55);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      color: #eaf3ff;
+      font-size: 13.5px;
+      font-weight: 600;
+      animation: qToastIn .18s ease-out;
+    }
+    @keyframes qToastIn{
+      from{ opacity: 0; transform: translateX(-50%) translateY(8px); }
+      to{ opacity: 1; transform: translateX(-50%) translateY(0); }
+    }
+    .qToast.warn{ border-color: rgba(255,190,110,.45); }
+    .qToastLabel{
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .qToastAction{
+      flex: 0 0 auto;
+      min-height: 36px;
+      padding: 6px 16px;
+      border-radius: 999px;
+      font-size: 13px;
+      font-weight: 800;
+      letter-spacing: .04em;
+      color: #eaf3ff;
+      border: 1px solid rgba(96,170,255,.50);
+      background: linear-gradient(180deg, rgba(43,108,231,.85), rgba(22,56,142,.90));
+      box-shadow: none;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+    .qToastAction:hover{ transform: none; box-shadow: 0 0 12px rgba(72,150,255,.30); }
 
     .qBody{
       flex: 1 1 auto;

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -1119,6 +1119,88 @@
     .nowCard.isIdle .progress,
     .nowCard.isIdle .nTimeRow{ display: none; }
     .nowCard.isIdle .nIdleMsg{ display: block; }
+    .nowCard.isEnded .nHeroArt{ filter: saturate(.55) brightness(.72); }
+    .nowCard.isEnded .nHeroFade{
+      background: linear-gradient(180deg, rgba(4,8,18,.28) 0%, rgba(4,8,18,.72) 78%, rgba(4,8,18,.88) 100%);
+    }
+
+    /* Up-next strip: sits in the now card when nothing live is on it */
+    .nUpNext{
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-top: 12px;
+      padding: 10px 12px;
+      border-radius: 14px;
+      border: 1px solid rgba(120,180,255,.22);
+      background: rgba(16,26,52,.48);
+    }
+    .nUpNextLabel{
+      flex: 0 0 auto;
+      font-size: 10.5px;
+      font-weight: 800;
+      letter-spacing: .10em;
+      text-transform: uppercase;
+      color: rgba(159,208,255,.78);
+    }
+    .nUpNextItem{
+      flex: 1 1 auto;
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .nUpNextThumb{
+      flex: 0 0 auto;
+      width: 56px;
+      aspect-ratio: 16 / 9;
+      border-radius: 8px;
+      background-size: cover;
+      background-position: center;
+      background-color: rgba(20,34,66,.85);
+      border: 1px solid rgba(120,180,255,.18);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .nUpNextThumb:not(.hasThumb)::after{
+      content: '▶';
+      font-size: 14px;
+      color: rgba(159,208,255,.55);
+    }
+    .nUpNextTitle{
+      min-width: 0;
+      font-size: 13px;
+      font-weight: 650;
+      line-height: 1.25;
+      color: #eaf3ff;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+    }
+    .nUpNextPlay{
+      flex: 0 0 auto;
+      min-height: 40px;
+      padding: 8px 20px;
+      border-radius: 999px;
+      font-size: 12.5px;
+      font-weight: 800;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      color: #f0f9ff;
+      border: 1px solid rgba(125,211,252,.55);
+      background: linear-gradient(180deg, rgba(56,189,248,.82), rgba(37,99,235,.78));
+      box-shadow: 0 4px 14px rgba(37,99,235,.30);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+    .nUpNextPlay:hover{
+      transform: none;
+      background: linear-gradient(180deg, rgba(94,207,255,.92), rgba(59,130,246,.85));
+      box-shadow: 0 4px 16px rgba(37,99,235,.42);
+    }
     .nowCard.isLive .progress{ display: none; }
     .nowCard.isLive .nTimeRow{ margin-top: 14px; }
     .nowCard.isLive .nTimeRow #pos{
@@ -2438,6 +2520,18 @@
       .queueList:empty::after{ color: rgba(30,50,100,.48); }
       .queueCard .footerRow{ color: rgba(30,50,100,.58); }
       .nIdleMsg{ color: rgba(30,50,100,.52); }
+      /* Keep the ended hero on the light fade so its dark title stays readable */
+      .nowCard.isEnded .nHeroArt{ filter: saturate(.7) brightness(.92); }
+      .nowCard.isEnded .nHeroFade{
+        background: linear-gradient(180deg, rgba(240,246,255,.18) 0%, rgba(240,246,255,.62) 62%, rgba(242,247,255,.97) 100%);
+      }
+      .nUpNext{
+        border-color: rgba(37,99,235,.22);
+        background: rgba(219,232,255,.45);
+      }
+      .nUpNextLabel{ color: rgba(30,64,175,.70); }
+      .nUpNextTitle{ color: #14295e; }
+      .nUpNextThumb{ background-color: rgba(37,99,235,.14); border-color: rgba(37,99,235,.20); }
       .nTimeRow{ color: #1d4ed8; }
       .remoteVolumeValue{ color: #1d4ed8; }
       .rVolIcon{ color: #1e3a8a; }

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -1922,38 +1922,6 @@
       background: rgba(34,60,120,.70);
       transform: none;
     }
-    .qDelBtn{
-      flex: 0 0 auto;
-      align-self: center;
-      min-height: 0;
-      padding: 0;
-      width: 40px;
-      height: 40px;
-      border-radius: 999px;
-      font-size: 15px;
-      font-weight: 800;
-      line-height: 1;
-      border: 1px solid rgba(255, 130, 150, .42);
-      background: rgba(20, 26, 40, .60);
-      color: rgba(255, 165, 180, .90);
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      position: relative;
-      z-index: 2;
-      box-shadow: none;
-      backdrop-filter: none;
-      -webkit-backdrop-filter: none;
-    }
-    .qDelBtn:hover{
-      background: rgba(220, 38, 38, .88);
-      border-color: rgba(255, 150, 165, .70);
-      color: #fff;
-      box-shadow: 0 0 12px rgba(255, 120, 140, .30);
-      transform: none;
-    }
-    .qDelBtn:active{ transform: none; }
-
     .qTile.qPendingRemove{ opacity: .42; filter: saturate(.6); }
     .qTile.qPendingRemove .qTitleText{ text-decoration: line-through; }
 
@@ -2638,8 +2606,7 @@
    none) keep the always-visible inline buttons. */
 @media (hover: hover) and (min-width: 761px){
   .qTile .qHandle,
-  .qTile .qMenuBtn,
-  .qTile .qDelBtn{
+  .qTile .qMenuBtn{
     position: absolute;
     top: calc(50% - 20px);
     opacity: 0;
@@ -2647,15 +2614,12 @@
     transition: opacity .15s ease;
     z-index: 3;
   }
-  .qTile .qHandle{ right: 98px; }
-  .qTile .qMenuBtn{ right: 54px; }
-  .qTile .qDelBtn{ right: 10px; }
+  .qTile .qHandle{ right: 54px; }
+  .qTile .qMenuBtn{ right: 10px; }
   .qTile:hover .qHandle,
   .qTile:hover .qMenuBtn,
-  .qTile:hover .qDelBtn,
   .qTile:focus-within .qHandle,
-  .qTile:focus-within .qMenuBtn,
-  .qTile:focus-within .qDelBtn{
+  .qTile:focus-within .qMenuBtn{
     opacity: 1;
     pointer-events: auto;
   }

--- a/app/relaytv_app/static/ui/app.css
+++ b/app/relaytv_app/static/ui/app.css
@@ -2610,3 +2610,53 @@
   .rSeek{ min-height: 58px; }
   .remoteVolumeRow{ margin-top: 10px; }
 }
+
+/* --- UX overhaul: roomier desktop queue, consistent phone header --- */
+
+/* Phone: every integration launcher becomes the same icon-only chip so the
+   device name — the "which TV am I on?" anchor — keeps the header space. */
+@media (max-width: 680px){
+  header{ gap: 8px; }
+  .hdrRight{ gap: 7px; }
+  .jfLaunch .jfBrand{ display: none; }
+  .jfLaunch .jfDot{ width: 10px; height: 10px; }
+  .iptvLaunch span:last-child{ display: none; }
+  .iptvLaunch{ padding: 7px 12px; }
+}
+
+/* Desktop: the wrap widens past 920px and the queue column gets a floor, so
+   queue titles stop collapsing to a few characters. */
+@media (min-width: 761px){
+  .topgrid{ grid-template-columns: minmax(0,1.2fr) minmax(300px,0.8fr); }
+}
+@media (min-width: 1100px){
+  .wrap{ max-width: 1080px; }
+}
+
+/* Pointer devices: tile actions stay out of the title's way until the tile is
+   hovered or focused, then overlay its right edge. Touch layouts (hover:
+   none) keep the always-visible inline buttons. */
+@media (hover: hover) and (min-width: 761px){
+  .qTile .qHandle,
+  .qTile .qMenuBtn,
+  .qTile .qDelBtn{
+    position: absolute;
+    top: calc(50% - 20px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .15s ease;
+    z-index: 3;
+  }
+  .qTile .qHandle{ right: 98px; }
+  .qTile .qMenuBtn{ right: 54px; }
+  .qTile .qDelBtn{ right: 10px; }
+  .qTile:hover .qHandle,
+  .qTile:hover .qMenuBtn,
+  .qTile:hover .qDelBtn,
+  .qTile:focus-within .qHandle,
+  .qTile:focus-within .qMenuBtn,
+  .qTile:focus-within .qDelBtn{
+    opacity: 1;
+    pointer-events: auto;
+  }
+}

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -1249,24 +1249,46 @@ function _showToast(label, {actionLabel = null, onAction = null, duration = 4000
    fires when the undo window closes. If the tab goes away first, the item
    simply stays queued — the safer failure direction. */
 let __pendingRemove = null;
+let __removeFlushPromise = null;
+
+function _commitPendingRemove(pending){
+  if (!pending) return Promise.resolve();
+  const flush = Promise.resolve(qRemove(pending.index)).finally(() => {
+    if (__removeFlushPromise === flush) __removeFlushPromise = null;
+  });
+  __removeFlushPromise = flush;
+  return flush;
+}
 
 function _flushPendingRemove(){
-  if (!__pendingRemove) return;
+  if (__removeFlushPromise) return __removeFlushPromise;
+  if (!__pendingRemove) return Promise.resolve();
   const pending = __pendingRemove;
   __pendingRemove = null;
   clearTimeout(pending.timer);
-  qRemove(pending.index);
+  return _commitPendingRemove(pending);
 }
 
 function qSoftRemove(index){
-  _flushPendingRemove();
+  if (__removeFlushPromise) {
+    _showToast('Finishing the previous removal…', {duration: 2500});
+    return;
+  }
+  if (__pendingRemove) {
+    _flushPendingRemove();
+    // The selected index came from the pre-removal queue. Do not reuse it
+    // after the first request shifts the server-side indexes; the refreshed
+    // queue will expose a safe target for the user's next action.
+    _showToast('Previous removal saved — select Remove again', {duration: 3000});
+    return;
+  }
   const tile = document.querySelector(`.qTile[data-index="${index}"]`);
   if (tile) tile.classList.add('qPendingRemove');
   const timer = setTimeout(() => {
     const pending = __pendingRemove;
     __pendingRemove = null;
     _hideToast();
-    if (pending) qRemove(pending.index);
+    if (pending) _commitPendingRemove(pending);
   }, 6000);
   __pendingRemove = { index, timer };
   _showToast('Removed from queue', {

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -1604,13 +1604,6 @@ function renderStatus(st) {
     body.appendChild(title);
     body.appendChild(chan);
 
-    const del = document.createElement('button');
-    del.className = 'qDelBtn';
-    del.textContent = '✕';
-    del.title = 'Remove from queue';
-    del.setAttribute('aria-label', 'Remove from queue');
-    del.onclick = () => qSoftRemove(idx, item && item.queue_id);
-
     // One indirection into the tile's actions keeps the tile clean; a button
     // per action would not scale and crams tap targets together.
     const menuBtn = document.createElement('button');
@@ -1626,7 +1619,6 @@ function renderStatus(st) {
     li.appendChild(body);
     li.appendChild(handle);
     li.appendChild(menuBtn);
-    li.appendChild(del);
     ol.appendChild(li);
   });
   }

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -1350,15 +1350,25 @@ function renderStatus(st) {
   const paused = !!st.paused && hasNow;
   const activelyPlaying = !!st.playing && !st.paused && hasNow;
   const liveNow = !!hasNow && _isNowPlayingLive(np);
+  // Ended/closed: an item is still on the card but playback is down and no
+  // transition is in flight. This is the state that used to render as a live
+  // card with dead "--:--" times.
+  const ended = hasNow && !st.playing && !st.paused
+    && !st.transitioning_between_items && !st.transition_in_progress
+    && String(st.playback_runtime_state || '') !== 'buffering';
+  const resumePos = (np && typeof np.resume_pos === 'number' && Number.isFinite(np.resume_pos)) ? np.resume_pos : null;
+  const npDuration = (np && typeof np.duration_sec === 'number' && Number.isFinite(np.duration_sec) && np.duration_sec > 0) ? np.duration_sec : null;
+  const effDuration = st.duration != null ? st.duration : (ended ? npDuration : null);
   if (nowCardEl){
     nowCardEl.classList.toggle('isIdle', !hasNow);
     nowCardEl.classList.toggle('isPaused', paused);
     nowCardEl.classList.toggle('isLive', liveNow);
+    nowCardEl.classList.toggle('isEnded', ended);
   }
   const stateTag = document.getElementById('nowStateTag');
   if (stateTag) {
-    stateTag.textContent = paused ? 'Paused' : 'Live';
-    stateTag.classList.toggle('hidden', !paused && !liveNow);
+    stateTag.textContent = paused ? 'Paused' : (ended ? 'Ended' : 'Live');
+    stateTag.classList.toggle('hidden', !paused && !liveNow && !ended);
     stateTag.classList.toggle('live', liveNow && !paused);
   }
   const stateDot = document.getElementById('nowStateDot');
@@ -1367,8 +1377,8 @@ function renderStatus(st) {
     stateDot.classList.toggle('live', liveNow && activelyPlaying);
   }
 
-  const posTxt = liveNow ? 'LIVE' : fmtTime(st.position);
-  const durTxt = liveNow ? (paused ? 'Paused' : 'Streaming') : fmtTime(st.duration);
+  const posTxt = liveNow ? 'LIVE' : fmtTime((ended && st.position == null && resumePos != null) ? resumePos : st.position);
+  const durTxt = liveNow ? (paused ? 'Paused' : 'Streaming') : fmtTime(effDuration);
 
   // Only overwrite the pos readout if not scrubbing
   if (!__scrubbing) document.getElementById('pos').textContent = posTxt;
@@ -1388,7 +1398,12 @@ function renderStatus(st) {
     if (muteLbl) muteLbl.textContent = mute ? 'Unmute' : 'Mute';
   }
   const ppb = document.getElementById('playPauseBtn');
-  if (ppb) ppb.classList.toggle('isPlaying', !!st.playing && !st.paused);
+  if (ppb) {
+    ppb.classList.toggle('isPlaying', !!st.playing && !st.paused);
+    // In the ended state the button resumes the closed session; say so.
+    const ppLbl = ppb.querySelector('.rLabel');
+    if (ppLbl) ppLbl.textContent = ended ? 'Resume' : 'Play/Pause';
+  }
   const qCount = document.getElementById('queueCount');
   if (qCount) qCount.textContent = String(st.queue_length || 0);
   const qClear = document.getElementById('queueClearBtn');
@@ -1405,10 +1420,34 @@ function renderStatus(st) {
   // progress bar fill
   if (!__scrubbing && liveNow) {
     _setProgressFill(0);
+  } else if (!__scrubbing && ended && resumePos != null && effDuration != null && effDuration > 0) {
+    // Show where a resume would pick up, not an empty bar.
+    _setProgressFill(resumePos / effDuration);
   } else if (!__scrubbing && st.position != null && st.duration != null && st.duration > 0) {
     _setProgressFill(st.position / st.duration);
   } else if (!__scrubbing && (!st.playing || st.duration == null || st.duration <= 0)) {
     _setProgressFill(0);
+  }
+
+  // up-next strip: the queue's head with a direct play action, shown whenever
+  // nothing live is on the card (ended item or empty idle card).
+  const upNextEl = document.getElementById('nowUpNext');
+  if (upNextEl) {
+    const nextItem = (Array.isArray(st.queue) && st.queue.length) ? st.queue[0] : null;
+    const showUpNext = !!nextItem && (ended || !hasNow);
+    upNextEl.classList.toggle('hidden', !showUpNext);
+    if (showUpNext) {
+      const titleEl = document.getElementById('upNextTitle');
+      if (titleEl) titleEl.textContent = nextItem.title || nextItem.url || '';
+      const thumbEl = document.getElementById('upNextThumb');
+      if (thumbEl) {
+        const tu = thumbUrl(nextItem);
+        thumbEl.style.backgroundImage = tu ? `url('${tu}')` : '';
+        thumbEl.classList.toggle('hasThumb', !!tu);
+      }
+      const playBtn = document.getElementById('upNextPlayBtn');
+      if (playBtn) playBtn.onclick = () => qPlayNow(0);
+    }
   }
 
   // queue list

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -547,6 +547,8 @@ function bindQueuePointerDnD(){
 
   let startFrom = null;
   let overTo = null;
+  let startQueueId = '';
+  let overQueueId = '';
   let startX = 0, startY = 0;
   let active = false;
   const MOVE_PX = 4;
@@ -556,6 +558,8 @@ function bindQueuePointerDnD(){
     active = false;
     startFrom = null;
     overTo = null;
+    startQueueId = '';
+    overQueueId = '';
     __dragStartTs = 0;
     document.body.classList.remove('noScroll');
     document.querySelectorAll('.qTile.dragging').forEach(x => x.classList.remove('dragging'));
@@ -567,10 +571,12 @@ function bindQueuePointerDnD(){
   const finish = async () => {
     const from = startFrom;
     const to = overTo;
+    const fromQueueId = startQueueId;
+    const toQueueId = overQueueId;
     const didDrag = active; // capture before cleanup() resets state
     cleanup();
     if (didDrag && from != null && to != null && from !== to) {
-      await qMove(from, to);
+      await qMove(from, to, fromQueueId, toQueueId);
     }
   };
 
@@ -588,6 +594,8 @@ function bindQueuePointerDnD(){
 
     startFrom = fromIdx;
     overTo = fromIdx;
+    startQueueId = String(tile.dataset.queueId || '');
+    overQueueId = startQueueId;
     startX = e.clientX || 0;
     startY = e.clientY || 0;
     active = false;
@@ -615,6 +623,7 @@ function bindQueuePointerDnD(){
     const toIdx = parseInt(tile.dataset.index || '', 10);
     if (isNaN(toIdx)) return;
     overTo = toIdx;
+    overQueueId = String(tile.dataset.queueId || '');
 
     document.querySelectorAll('.qTile.dragOver').forEach(x => x.classList.remove('dragOver'));
     tile.classList.add('dragOver');
@@ -1117,9 +1126,11 @@ function _applyQueueSnapshot(payload){
   return true;
 }
 
-async function qRemove(index){
+async function qRemove(index, queueId){
   try {
-    const res = await fetch('/queue/remove', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({index})});
+    const request = {index};
+    if (queueId) request.queue_id = String(queueId);
+    const res = await fetch('/queue/remove', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(request)});
     let payload = null;
     try { payload = await res.json(); } catch(_) {}
     if (!res.ok) {
@@ -1133,9 +1144,11 @@ async function qRemove(index){
   await refresh();
 }
 
-async function qPlayNow(index){
+async function qPlayNow(index, queueId){
   try {
-    const res = await fetch('/queue/play', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({index})});
+    const request = {index};
+    if (queueId) request.queue_id = String(queueId);
+    const res = await fetch('/queue/play', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(request)});
     let payload = null;
     try { payload = await res.json(); } catch(_) {}
     if (!res.ok) {
@@ -1188,11 +1201,12 @@ function openQueueMenu(index, item, anchor){
   menu.className = 'qPopMenu';
   menu.setAttribute('role', 'menu');
   menu.setAttribute('aria-label', 'Queue item actions');
-  menu.appendChild(_queueMenuItem('Play now', 'M8 5.5v13l11-6.5z', () => qPlayNow(index)));
+  const queueId = String((item && item.queue_id) || '');
+  menu.appendChild(_queueMenuItem('Play now', 'M8 5.5v13l11-6.5z', () => qPlayNow(index, queueId)));
   menu.appendChild(_queueMenuItem('Send to device', 'M4 12h13m0 0-4.5-4.5M17 12l-4.5 4.5M20 5v14', () => {
-    if (window.relaytvPeers) window.relaytvPeers.open({index, title: (item && (item.title || item.url)) || ''});
+    if (window.relaytvPeers) window.relaytvPeers.open({index, queueId, title: (item && (item.title || item.url)) || ''});
   }));
-  menu.appendChild(_queueMenuItem('Remove', 'M5 7h14M10 7V5h4v2m-7 0 1 12h8l1-12', () => qSoftRemove(index), 'danger'));
+  menu.appendChild(_queueMenuItem('Remove', 'M5 7h14M10 7V5h4v2m-7 0 1 12h8l1-12', () => qSoftRemove(index, queueId), 'danger'));
 
   document.body.appendChild(backdrop);
   document.body.appendChild(menu);
@@ -1253,8 +1267,12 @@ let __removeFlushPromise = null;
 
 function _commitPendingRemove(pending){
   if (!pending) return Promise.resolve();
-  const flush = Promise.resolve(qRemove(pending.index)).finally(() => {
+  const flush = Promise.resolve(qRemove(pending.index, pending.queueId)).finally(() => {
     if (__removeFlushPromise === flush) __removeFlushPromise = null;
+    if (typeof __lastStatus !== 'undefined' && __lastStatus &&
+        typeof _uiRefreshInteractionLockActive === 'function' && !_uiRefreshInteractionLockActive()) {
+      renderStatus(__lastStatus);
+    }
   });
   __removeFlushPromise = flush;
   return flush;
@@ -1269,7 +1287,7 @@ function _flushPendingRemove(){
   return _commitPendingRemove(pending);
 }
 
-function qSoftRemove(index){
+function qSoftRemove(index, queueId){
   if (__removeFlushPromise) {
     _showToast('Finishing the previous removal…', {duration: 2500});
     return;
@@ -1290,7 +1308,7 @@ function qSoftRemove(index){
     _hideToast();
     if (pending) _commitPendingRemove(pending);
   }, 6000);
-  __pendingRemove = { index, timer };
+  __pendingRemove = { index, queueId: String(queueId || ''), timer };
   _showToast('Removed from queue', {
     actionLabel: 'Undo',
     duration: 6000,
@@ -1300,13 +1318,20 @@ function qSoftRemove(index){
       _hideToast();
       const t = document.querySelector(`.qTile[data-index="${index}"]`);
       if (t) t.classList.remove('qPendingRemove');
+      if (typeof __lastStatus !== 'undefined' && __lastStatus &&
+          typeof _uiRefreshInteractionLockActive === 'function' && !_uiRefreshInteractionLockActive()) {
+        renderStatus(__lastStatus);
+      }
     },
   });
 }
 
-async function qMove(from_index, to_index){
+async function qMove(from_index, to_index, queueId, toQueueId){
   try {
-    const res = await fetch('/queue/move', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({from_index, to_index})});
+    const request = {from_index, to_index};
+    if (queueId) request.queue_id = String(queueId);
+    if (toQueueId) request.to_queue_id = String(toQueueId);
+    const res = await fetch('/queue/move', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(request)});
     let payload = null;
     try { payload = await res.json(); } catch(_) {}
     if (!res.ok) {
@@ -1496,7 +1521,7 @@ function renderStatus(st) {
         thumbEl.classList.toggle('hasThumb', !!tu);
       }
       const playBtn = document.getElementById('upNextPlayBtn');
-      if (playBtn) playBtn.onclick = () => qPlayNow(0);
+      if (playBtn) playBtn.onclick = () => qPlayNow(0, nextItem.queue_id);
     }
   }
 
@@ -1517,6 +1542,7 @@ function renderStatus(st) {
     li.className = 'qTile';
     if (item && item.available === false) li.classList.add('isUnavailable');
     li.dataset.index = String(idx);
+    li.dataset.queueId = String((item && item.queue_id) || '');
 
     // Contained 16:9 artwork (not a background: text stays on clean glass)
     const thumb = document.createElement('div');
@@ -1583,7 +1609,7 @@ function renderStatus(st) {
     del.textContent = '✕';
     del.title = 'Remove from queue';
     del.setAttribute('aria-label', 'Remove from queue');
-    del.onclick = () => qSoftRemove(idx);
+    del.onclick = () => qSoftRemove(idx, item && item.queue_id);
 
     // One indirection into the tile's actions keeps the tile clean; a button
     // per action would not scale and crams tap targets together.

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -1960,6 +1960,24 @@ function bindHeaderMenu(){
 }
 
 function _fmtTs(ts){
+  // Compact: time-only today, short date within the year, year beyond that.
+  // The verbose locale string used to eat the whole meta line and truncate
+  // the mode suffix ("auto ne…") it shares the row with.
+  try {
+    const d = new Date((ts||0)*1000);
+    if (isNaN(d.getTime())) return '';
+    const now = new Date();
+    if (d.toDateString() === now.toDateString()) {
+      return d.toLocaleTimeString([], {hour:'numeric', minute:'2-digit'});
+    }
+    if (d.getFullYear() === now.getFullYear()) {
+      return d.toLocaleString([], {month:'short', day:'numeric', hour:'numeric', minute:'2-digit'});
+    }
+    return d.toLocaleString([], {month:'short', day:'numeric', year:'numeric'});
+  } catch (_) { return ''; }
+}
+
+function _fmtTsFull(ts){
   try {
     const d = new Date((ts||0)*1000);
     if (isNaN(d.getTime())) return '';
@@ -2068,6 +2086,7 @@ async function renderHistory(){
     const when = document.createElement('div');
     when.className = 'histSub';
     when.textContent = `${_fmtTs(it.ts)} · ${String(it.mode || '').replace(/_/g, ' ')}`.replace(/ · $/, '');
+    when.title = _fmtTsFull(it.ts);
 
     const tags = document.createElement('div');
     tags.className = 'histTags';
@@ -2139,6 +2158,24 @@ function bindHistoryUi(){
   if (btn) btn.onclick = openHistory;
   if (closeBtn) closeBtn.onclick = closeHistory;
   if (clearBtn) clearBtn.onclick = async () => {
+    // Two-tap guard: wiping the whole history record deserves a beat.
+    if (clearBtn.dataset.armed !== '1') {
+      clearBtn.dataset.armed = '1';
+      clearBtn.dataset.label = clearBtn.textContent;
+      clearBtn.textContent = 'Clear all?';
+      clearBtn.classList.add('armed');
+      setTimeout(() => {
+        if (clearBtn.dataset.armed === '1') {
+          delete clearBtn.dataset.armed;
+          clearBtn.textContent = clearBtn.dataset.label || 'Clear';
+          clearBtn.classList.remove('armed');
+        }
+      }, 3500);
+      return;
+    }
+    delete clearBtn.dataset.armed;
+    clearBtn.textContent = clearBtn.dataset.label || 'Clear';
+    clearBtn.classList.remove('armed');
     await fetch('/history/clear', {method:'POST', headers:{'Content-Type':'application/json'}, body: '{}'});
     await renderHistory();
   };

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -2763,18 +2763,25 @@ function syncSeerrRequestModeUi(){
 }
 
 function syncJellyfinAuthModeUi(){
-  const modeSelect = document.getElementById('setJfAuthMode');
-  const mode = String(modeSelect?.value || 'user_login');
-  const sharedFields = document.getElementById('setJfSharedAuthFields');
-  const userFields = document.getElementById('setJfUserAuthFields');
+  const shared = !!document.getElementById('setJfSharedCastEnabled')?.checked;
   const hint = document.getElementById('setJfAuthModeHint');
-  if (sharedFields) sharedFields.classList.toggle('hidden', mode !== 'shared_api_key');
-  if (userFields) userFields.classList.toggle('hidden', mode !== 'user_login');
   if (hint) {
-    hint.textContent = mode === 'shared_api_key'
-      ? 'One administrator API identity advertises RelayTV to every user allowed to control shared devices.'
-      : 'The stored Jellyfin user owns the cast session and catalog; other users do not share this target identity.';
+    hint.textContent = shared
+      ? 'Requires a server API key. Client login remains active for browsing. Leave login empty for a cast-only setup.'
+      : 'Casting uses the client login’s session and server permissions. Any stored API key is retained but inactive.';
   }
+}
+
+function jellyfinCredentialsError({enabled, server, shared, apiKey, clearApiKey, apiKeyConfigured, user, password, clearPassword, passwordConfigured}){
+  if (!enabled) return '';
+  if (!server) return 'Server URL is required.';
+  const hasApiKey = !clearApiKey && (!!apiKey || apiKeyConfigured);
+  const hasPassword = !clearPassword && (!!password || passwordConfigured);
+  if (shared && !hasApiKey) return 'A server API key is required for the shared cast target.';
+  if ((!shared || user || hasPassword) && !(user && hasPassword)) {
+    return 'A username and password are required for client login. For casting only, clear the username and stored password, and enable the shared cast target.';
+  }
+  return '';
 }
 
 async function loadSettingsUi(){
@@ -2818,7 +2825,7 @@ async function loadSettingsUi(){
   const iptvEnabled = document.getElementById('setIptvEnabled');
   const jfEnabled = document.getElementById('setJfEnabled');
   const jfServerUrl = document.getElementById('setJfServerUrl');
-  const jfAuthMode = document.getElementById('setJfAuthMode');
+  const jfSharedCast = document.getElementById('setJfSharedCastEnabled');
   const jfApiKeyInput = document.getElementById('setJfApiKey');
   const jfClearApiKey = document.getElementById('setJfClearApiKey');
   const jfApiKeyState = document.getElementById('setJfApiKeyState');
@@ -2863,7 +2870,7 @@ async function loadSettingsUi(){
   );
   if (jfEnabled) jfEnabled.checked = !!cur.jellyfin_enabled;
   if (jfServerUrl) jfServerUrl.value = (cur.jellyfin_server_url || defaultJellyfinServerUrl());
-  if (jfAuthMode) jfAuthMode.value = (cur.jellyfin_auth_mode || (cur.jellyfin_api_key_configured ? 'shared_api_key' : 'user_login'));
+  if (jfSharedCast) jfSharedCast.checked = (cur.jellyfin_auth_mode || (cur.jellyfin_api_key_configured ? 'shared_api_key' : 'user_login')) === 'shared_api_key';
   syncJellyfinAuthModeUi();
   if (jfApiKeyInput) jfApiKeyInput.value = '';
   if (jfClearApiKey) jfClearApiKey.checked = false;
@@ -2883,6 +2890,22 @@ async function loadSettingsUi(){
     const hasPw = !!cur.jellyfin_password_configured;
     jfPwState.textContent = hasPw ? 'Password is stored.' : 'No password stored.';
     jfPwState.setAttribute('data-configured', hasPw ? '1' : '0');
+  }
+  const jfClientStatus = document.getElementById('setJfClientStatus');
+  const jfCastStatus = document.getElementById('setJfCastStatus');
+  if (jfClientStatus) {
+    jfClientStatus.textContent = !cur.jellyfin_enabled ? 'Client login: integration disabled.'
+      : !jfStatus ? 'Client login: status unavailable.'
+      : jfStatus.authenticated ? `Client login: connected as ${jfStatus.auth_user || cur.jellyfin_username || 'configured user'}.`
+      : jfStatus.last_auth_ok === false ? 'Client login: failed. Check the username and password.'
+      : cur.jellyfin_username ? 'Client login: waiting for sign-in.'
+      : 'Client login: not configured. Sign in above to use your personal library.';
+  }
+  if (jfCastStatus) {
+    jfCastStatus.textContent = !cur.jellyfin_enabled ? 'Cast target: integration disabled.'
+      : !jfStatus ? 'Cast target: status unavailable.'
+      : jfStatus.cast_target_ready ? `Cast target: ready (${jfStatus.cast_target_scope === 'shared' ? 'shared API key' : 'client login session'}).`
+      : 'Cast target: not ready.';
   }
   const jfBadge = document.getElementById('setJfStatus');
   if (jfBadge) {
@@ -3091,8 +3114,8 @@ function bindSettingsUi(){
   const jfApplyMsg = document.getElementById('setJfApplyResult');
   const jfCacheClearBtn = document.getElementById('setJfCacheClearBtn');
   const jfCacheClearMsg = document.getElementById('setJfCacheClearResult');
-  const jfAuthModeSelect = document.getElementById('setJfAuthMode');
-  if (jfAuthModeSelect) jfAuthModeSelect.onchange = syncJellyfinAuthModeUi;
+  const jfSharedCast = document.getElementById('setJfSharedCastEnabled');
+  if (jfSharedCast) jfSharedCast.onchange = syncJellyfinAuthModeUi;
   const seerrApplyBtn = document.getElementById('setSeerrApplyBtn');
   const seerrTestBtn = document.getElementById('setSeerrTestBtn');
   const seerrApplyMsg = document.getElementById('setSeerrApplyResult');
@@ -3194,7 +3217,7 @@ function bindSettingsUi(){
     }
     const jfEnabled = !!document.getElementById('setJfEnabled')?.checked;
     const jfServer = (document.getElementById('setJfServerUrl')?.value || '').trim();
-    const jfAuthMode = String(document.getElementById('setJfAuthMode')?.value || 'user_login');
+    const jfAuthMode = document.getElementById('setJfSharedCastEnabled')?.checked ? 'shared_api_key' : 'user_login';
     const jfApiKey = (document.getElementById('setJfApiKey')?.value || '').trim();
     const jfClearApiKey = !!document.getElementById('setJfClearApiKey')?.checked;
     const jfApiKeyConfigured = (document.getElementById('setJfApiKeyState')?.getAttribute('data-configured') || '') === '1';
@@ -3208,12 +3231,14 @@ function bindSettingsUi(){
     const jfPlaybackMode = (document.getElementById('setJfPlaybackMode')?.value || 'auto').trim().toLowerCase();
     const deviceName = (document.getElementById('setDeviceName')?.value || '').trim();
 
-    if (jfEnabled) {
-      if (!jfServer) { if (jfApplyMsg){ jfApplyMsg.classList.add('err'); jfApplyMsg.textContent='Server URL is required.'; } return; }
-      const hasApiKey = !!jfApiKey || (jfApiKeyConfigured && !jfClearApiKey);
-      const hasLogin = !!jfUser && (!!jfPass || (jfPwConfigured && !jfClearPw));
-      if (jfAuthMode === 'shared_api_key' && !hasApiKey) { if (jfApplyMsg){ jfApplyMsg.classList.add('err'); jfApplyMsg.textContent='A server API key is required for shared cast mode.'; } return; }
-      if (jfAuthMode === 'user_login' && !hasLogin) { if (jfApplyMsg){ jfApplyMsg.classList.add('err'); jfApplyMsg.textContent='A username and password is required for user-scoped mode.'; } return; }
+    const jfError = jellyfinCredentialsError({
+      enabled: jfEnabled, server: jfServer, shared: jfAuthMode === 'shared_api_key',
+      apiKey: jfApiKey, clearApiKey: jfClearApiKey, apiKeyConfigured: jfApiKeyConfigured,
+      user: jfUser, password: jfPass, clearPassword: jfClearPw, passwordConfigured: jfPwConfigured,
+    });
+    if (jfError) {
+      if (jfApplyMsg) { jfApplyMsg.classList.add('err'); jfApplyMsg.textContent = jfError; }
+      return;
     }
 
     const payload = {
@@ -3371,7 +3396,7 @@ function bindSettingsUi(){
     const uploadRetentionHours = Number(document.getElementById('setUploadRetentionHours')?.value || '24');
     const jfEnabled = !!document.getElementById('setJfEnabled')?.checked;
     const jfServer = (document.getElementById('setJfServerUrl')?.value || '').trim();
-    const jfAuthMode = String(document.getElementById('setJfAuthMode')?.value || 'user_login');
+    const jfAuthMode = document.getElementById('setJfSharedCastEnabled')?.checked ? 'shared_api_key' : 'user_login';
     const jfApiKey = (document.getElementById('setJfApiKey')?.value || '').trim();
     const jfClearApiKey = !!document.getElementById('setJfClearApiKey')?.checked;
     const jfApiKeyConfigured = (document.getElementById('setJfApiKeyState')?.getAttribute('data-configured') || '') === '1';
@@ -3401,13 +3426,12 @@ function bindSettingsUi(){
       alert('Invidious server URL is required when YouTube Invidious mode is enabled.');
       return;
     }
-    if (jfEnabled) {
-      if (!jfServer) { alert(`${jfBrandName()} server URL is required.`); return; }
-      const hasApiKey = !!jfApiKey || (jfApiKeyConfigured && !jfClearApiKey);
-      const hasLogin = !!jfUser && (!!jfPass || (jfPwConfigured && !jfClearPw));
-      if (jfAuthMode === 'shared_api_key' && !hasApiKey) { alert(`A ${jfBrandName()} server API key is required for shared cast mode.`); return; }
-      if (jfAuthMode === 'user_login' && !hasLogin) { alert(`A ${jfBrandName()} username and password is required for user-scoped mode.`); return; }
-    }
+    const jfError = jellyfinCredentialsError({
+      enabled: jfEnabled, server: jfServer, shared: jfAuthMode === 'shared_api_key',
+      apiKey: jfApiKey, clearApiKey: jfClearApiKey, apiKeyConfigured: jfApiKeyConfigured,
+      user: jfUser, password: jfPass, clearPassword: jfClearPw, passwordConfigured: jfPwConfigured,
+    });
+    if (jfError) { alert(jfError); return; }
     if (seerrEnabled && !seerrServerUrl) { alert('Seerr server URL is required.'); return; }
     if (seerrEnabled && seerrRequestMode !== 'caller_session' && !seerrApiKey && (!seerrApiKeyConfigured || seerrClearApiKey)) { alert('Seerr API key is required for shared browsing.'); return; }
 

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -744,6 +744,35 @@ function _looksLikeJellyfinMediaUrl(u){
   return false;
 }
 
+const __favBrandColors = {
+  'youtube.com': '#ff0033', 'youtu.be': '#ff0033',
+  'rumble.com': '#85c742',
+  'twitch.tv': '#9146ff',
+  'vimeo.com': '#17b3e8',
+  'odysee.com': '#ef1970',
+  'dailymotion.com': '#00aaff',
+  'peertube.tv': '#f1680d',
+  'bitchute.com': '#d2441c',
+  'x.com': '#000000', 'twitter.com': '#1d9bf0',
+};
+const __favPalette = ['#2b6ce7', '#7c3aed', '#0891b2', '#059669', '#d97706', '#dc2626', '#db2777', '#4f46e5'];
+
+/* Local-first provider badge: a letter tile rendered as an SVG data URI.
+   Deterministic per host, needs no network and leaks nothing to third
+   parties (the Google S2 favicon service used to see every queued domain). */
+function _letterFaviconDataUri(host){
+  const clean = String(host || '').replace(/^www\./, '');
+  const letter = (clean[0] || '?').toUpperCase();
+  let color = __favBrandColors[clean] || __favBrandColors[clean.split('.').slice(-2).join('.')] || '';
+  if (!color) {
+    let h = 0;
+    for (let i = 0; i < clean.length; i++) h = (h * 31 + clean.charCodeAt(i)) >>> 0;
+    color = __favPalette[h % __favPalette.length];
+  }
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect width='64' height='64' rx='14' fill='${color}'/><text x='32' y='43' font-family='system-ui,Segoe UI,sans-serif' font-size='32' font-weight='700' fill='#ffffff' text-anchor='middle'>${letter}</text></svg>`;
+  return 'data:image/svg+xml;utf8,' + encodeURIComponent(svg);
+}
+
 function faviconUrl(input){
   const obj = (input && typeof input === 'object') ? input : null;
   const u = obj ? String(obj.url || '') : String(input || '');
@@ -753,8 +782,7 @@ function faviconUrl(input){
   }
   const host = _safeUrlHost(u);
   if (!host) return '';
-  // Google S2 favicon service (works well without CORS headaches for <img>)
-  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=64`;
+  return _letterFaviconDataUri(host);
 }
 
 function displaySub(item){

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -646,6 +646,8 @@ function _isHiddenEl(el){
 
 function _uiRefreshInteractionLockActive(){
   if (__draggingQueue) return true;
+  if (__queueMenuEl) return true;
+  if (__pendingRemove) return true;
   const modalIds = ['addBackdrop', 'histBackdrop', 'aboutBackdrop', 'settingsBackdrop', 'langBackdrop', 'peersBackdrop'];
   for (const id of modalIds) {
     const el = document.getElementById(id);
@@ -664,6 +666,10 @@ function _uiPushLayer(){
 }
 
 function _uiCloseTopLayerFromNav(){
+  if (__queueMenuEl) {
+    closeQueueMenu();
+    return true;
+  }
   if (window.relaytvSeerr && window.relaytvSeerr.isDetailOpen()) {
     window.relaytvSeerr.closeDetail({fromNav:true});
     return true;
@@ -1099,6 +1105,155 @@ async function qRemove(index){
   await refresh();
 }
 
+async function qPlayNow(index){
+  try {
+    const res = await fetch('/queue/play', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({index})});
+    let payload = null;
+    try { payload = await res.json(); } catch(_) {}
+    if (!res.ok) {
+      console.warn('queue/play failed', res.status, payload);
+      _showToast((payload && payload.detail) ? String(payload.detail) : 'Could not play that item', {kind:'warn'});
+    } else {
+      _applyQueueSnapshot(payload);
+    }
+  } catch (e) {
+    console.warn('queue/play error', e);
+    _showToast('Could not play that item', {kind:'warn'});
+  }
+  await refresh();
+}
+
+/* ---- queue tile action menu (Play now / Send to device / Remove) ---- */
+let __queueMenuEl = null;
+let __queueMenuBackdrop = null;
+
+function _queueMenuKeyHandler(ev){
+  if (ev.key === 'Escape') {
+    ev.stopPropagation();
+    closeQueueMenu();
+  }
+}
+
+function closeQueueMenu(){
+  if (__queueMenuBackdrop) { __queueMenuBackdrop.remove(); __queueMenuBackdrop = null; }
+  if (__queueMenuEl) { __queueMenuEl.remove(); __queueMenuEl = null; }
+  document.removeEventListener('keydown', _queueMenuKeyHandler, true);
+}
+
+function _queueMenuItem(label, svgPath, onPick, cls){
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'qPopItem' + (cls ? ' ' + cls : '');
+  btn.innerHTML = `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="${svgPath}" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span></span>`;
+  btn.querySelector('span').textContent = label;
+  btn.onclick = () => { closeQueueMenu(); onPick(); };
+  return btn;
+}
+
+function openQueueMenu(index, item, anchor){
+  closeQueueMenu();
+  const backdrop = document.createElement('div');
+  backdrop.className = 'qPopBackdrop';
+  backdrop.addEventListener('pointerdown', (ev) => { ev.preventDefault(); closeQueueMenu(); });
+
+  const menu = document.createElement('div');
+  menu.className = 'qPopMenu';
+  menu.setAttribute('role', 'menu');
+  menu.setAttribute('aria-label', 'Queue item actions');
+  menu.appendChild(_queueMenuItem('Play now', 'M8 5.5v13l11-6.5z', () => qPlayNow(index)));
+  menu.appendChild(_queueMenuItem('Send to device', 'M4 12h13m0 0-4.5-4.5M17 12l-4.5 4.5M20 5v14', () => {
+    if (window.relaytvPeers) window.relaytvPeers.open({index, title: (item && (item.title || item.url)) || ''});
+  }));
+  menu.appendChild(_queueMenuItem('Remove', 'M5 7h14M10 7V5h4v2m-7 0 1 12h8l1-12', () => qSoftRemove(index), 'danger'));
+
+  document.body.appendChild(backdrop);
+  document.body.appendChild(menu);
+  __queueMenuBackdrop = backdrop;
+  __queueMenuEl = menu;
+  document.addEventListener('keydown', _queueMenuKeyHandler, true);
+
+  const r = anchor.getBoundingClientRect();
+  const mw = menu.offsetWidth;
+  const mh = menu.offsetHeight;
+  let left = Math.min(r.right - mw, window.innerWidth - mw - 8);
+  left = Math.max(8, left);
+  let top = r.bottom + 6;
+  if (top + mh > window.innerHeight - 8) top = Math.max(8, r.top - mh - 6);
+  menu.style.left = left + 'px';
+  menu.style.top = top + 'px';
+  const first = menu.querySelector('button');
+  if (first) first.focus({preventScroll: true});
+}
+
+/* ---- undo toast + soft remove ---- */
+let __toastEl = null;
+let __toastTimer = null;
+
+function _hideToast(){
+  if (__toastTimer) { clearTimeout(__toastTimer); __toastTimer = null; }
+  if (__toastEl) { __toastEl.remove(); __toastEl = null; }
+}
+
+function _showToast(label, {actionLabel = null, onAction = null, duration = 4000, kind = 'info'} = {}){
+  _hideToast();
+  const el = document.createElement('div');
+  el.className = 'qToast ' + kind;
+  el.setAttribute('role', 'status');
+  const span = document.createElement('span');
+  span.className = 'qToastLabel';
+  span.textContent = label;
+  el.appendChild(span);
+  if (actionLabel && onAction) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'qToastAction';
+    btn.textContent = actionLabel;
+    btn.onclick = () => { onAction(); };
+    el.appendChild(btn);
+  }
+  document.body.appendChild(el);
+  __toastEl = el;
+  if (duration > 0) __toastTimer = setTimeout(_hideToast, duration);
+  return el;
+}
+
+/* Soft remove: the tile collapses immediately but the server delete only
+   fires when the undo window closes. If the tab goes away first, the item
+   simply stays queued — the safer failure direction. */
+let __pendingRemove = null;
+
+function _flushPendingRemove(){
+  if (!__pendingRemove) return;
+  const pending = __pendingRemove;
+  __pendingRemove = null;
+  clearTimeout(pending.timer);
+  qRemove(pending.index);
+}
+
+function qSoftRemove(index){
+  _flushPendingRemove();
+  const tile = document.querySelector(`.qTile[data-index="${index}"]`);
+  if (tile) tile.classList.add('qPendingRemove');
+  const timer = setTimeout(() => {
+    const pending = __pendingRemove;
+    __pendingRemove = null;
+    _hideToast();
+    if (pending) qRemove(pending.index);
+  }, 6000);
+  __pendingRemove = { index, timer };
+  _showToast('Removed from queue', {
+    actionLabel: 'Undo',
+    duration: 6000,
+    onAction: () => {
+      if (__pendingRemove) clearTimeout(__pendingRemove.timer);
+      __pendingRemove = null;
+      _hideToast();
+      const t = document.querySelector(`.qTile[data-index="${index}"]`);
+      if (t) t.classList.remove('qPendingRemove');
+    },
+  });
+}
+
 async function qMove(from_index, to_index){
   try {
     const res = await fetch('/queue/move', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({from_index, to_index})});
@@ -1265,6 +1420,8 @@ function renderStatus(st) {
   }
 
   if (!__draggingQueue) {
+    // The re-render detaches the tile the menu was anchored to.
+    closeQueueMenu();
     ol.innerHTML = '';
     (st.queue || []).forEach((item, idx) => {
     const li = document.createElement('li');
@@ -1336,24 +1493,24 @@ function renderStatus(st) {
     del.className = 'qDelBtn';
     del.textContent = '✕';
     del.title = 'Remove from queue';
-    del.onclick = () => qRemove(idx);
+    del.setAttribute('aria-label', 'Remove from queue');
+    del.onclick = () => qSoftRemove(idx);
 
-    // Send just this item. One indirection into the device sheet keeps the tile
-    // clean; a device picker per tile would not scale.
-    const send = document.createElement('button');
-    send.className = 'qSendItemBtn';
-    send.type = 'button';
-    send.title = 'Send this item to another device';
-    send.setAttribute('aria-label', 'Send this item to another device');
-    send.textContent = '⋯';
-    send.onclick = () => {
-      if (window.relaytvPeers) window.relaytvPeers.open({index: idx, title: item.title || item.url || ''});
-    };
+    // One indirection into the tile's actions keeps the tile clean; a button
+    // per action would not scale and crams tap targets together.
+    const menuBtn = document.createElement('button');
+    menuBtn.className = 'qMenuBtn';
+    menuBtn.type = 'button';
+    menuBtn.title = 'Item actions';
+    menuBtn.setAttribute('aria-label', 'Item actions');
+    menuBtn.setAttribute('aria-haspopup', 'menu');
+    menuBtn.textContent = '⋯';
+    menuBtn.onclick = () => openQueueMenu(idx, item, menuBtn);
 
     li.appendChild(thumb);
     li.appendChild(body);
     li.appendChild(handle);
-    li.appendChild(send);
+    li.appendChild(menuBtn);
     li.appendChild(del);
     ol.appendChild(li);
   });

--- a/app/relaytv_app/static/ui/jellyfin.css
+++ b/app/relaytv_app/static/ui/jellyfin.css
@@ -1749,3 +1749,89 @@
     max-height: 220px;
   }
 }
+
+/* --- UX overhaul: search list, library chip, poster fallback, primary action --- */
+
+/* Search results read as a full list instead of a cut-off horizontal rail. */
+.jfSearchList{
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-x: visible;
+  padding-bottom: 0;
+}
+.jfSearchList .jfItem{
+  width: 100%;
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  padding: 10px;
+  grid-template-rows: none;
+}
+.jfSearchList .jfThumb{
+  flex: 0 0 auto;
+  width: 128px;
+  aspect-ratio: 16 / 9;
+  border-radius: 10px;
+}
+.jfSearchList .jfMeta{
+  flex: 1 1 auto;
+  min-width: 0;
+  justify-content: center;
+}
+.jfSearchList .jfQuickRow{ margin-top: 8px; }
+.jfSearchList .jfQuickBtn{
+  height: 36px;
+  padding: 0 14px;
+  font-size: 12px;
+}
+@media (max-width: 420px){
+  .jfSearchList .jfThumb{ width: 104px; }
+}
+
+/* Library hint chip: disambiguates same-title duplicates across libraries. */
+.jfLibChip{
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+  color: rgba(159, 208, 255, .85);
+  border: 1px solid rgba(96, 170, 255, .38);
+  background: rgba(43, 108, 231, .16);
+}
+
+/* Titled tile swapped in when a poster fails to load. */
+.jfThumbFallback{
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  padding: 8px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.3;
+  color: rgba(214, 231, 255, .82);
+  background:
+    radial-gradient(80% 80% at 30% 20%, rgba(43, 108, 231, .30), transparent 60%),
+    linear-gradient(150deg, rgba(20, 34, 66, .90), rgba(8, 14, 30, .95));
+}
+
+/* Primary detail action (Resume / Play Now). */
+.jfActionRow .btn.primary{
+  border: 1px solid rgba(125, 211, 252, .62);
+  background: linear-gradient(180deg, rgba(56, 189, 248, .85), rgba(37, 99, 235, .80));
+  color: #f0f9ff;
+  box-shadow: 0 4px 14px rgba(37, 99, 235, .32);
+}
+.jfActionRow .btn.primary:hover{
+  background: linear-gradient(180deg, rgba(94, 207, 255, .92), rgba(59, 130, 246, .86));
+}

--- a/app/relaytv_app/static/ui/jellyfin.js
+++ b/app/relaytv_app/static/ui/jellyfin.js
@@ -621,6 +621,16 @@ function _jfBindImageFallback(img){
   img.addEventListener('error', () => {
     if (img.dataset.jfFallback === '1') return;
     img.dataset.jfFallback = '1';
+    // A broken poster with no label is a dead end; swap in a titled tile.
+    const fallbackTitle = String(img.dataset.fallbackTitle || '').trim();
+    if (fallbackTitle && img.parentElement) {
+      const tile = document.createElement('span');
+      tile.className = 'jfThumbFallback';
+      tile.textContent = fallbackTitle;
+      img.parentElement.appendChild(tile);
+      img.remove();
+      return;
+    }
     img.classList.add('jfImageFallback');
     img.src = '/pwa/weather/not-available.svg';
   });
@@ -767,19 +777,25 @@ function _jfRenderDetail(item){
   const actions = document.createElement('div');
   actions.className = 'jfActionRow';
 
-  const mkBtn = (label, action) => {
+  const mkBtn = (label, action, cls) => {
     const b = document.createElement('button');
     b.type = 'button';
-    b.className = 'btn';
+    b.className = 'btn' + (cls ? ' ' + cls : '');
     b.textContent = label;
     b.onclick = () => jellyfinDetailAction(action);
     return b;
   };
 
-  actions.appendChild(mkBtn('Play Now', 'play_now'));
+  const resumeSec = Math.max(0, Number(item.resume_pos || 0));
+  if (resumeSec > 0) {
+    // With a resume point, "Play Now" vs "Resume" was ambiguous; spell both out.
+    actions.appendChild(mkBtn(`Resume ${_jfFmtSec(resumeSec)}`, 'resume', 'primary'));
+    actions.appendChild(mkBtn('Play from start', 'play_now'));
+  } else {
+    actions.appendChild(mkBtn('Play Now', 'play_now', 'primary'));
+  }
   actions.appendChild(mkBtn('Play Next', 'play_next'));
   actions.appendChild(mkBtn('Queue Last', 'play_last'));
-  actions.appendChild(mkBtn('Resume', 'resume'));
   host.appendChild(actions);
 
   const msg = document.createElement('div');
@@ -842,6 +858,7 @@ function _jfBuildRowItemCard(item, rowId){
   img.alt = '';
   img.loading = 'lazy';
   img.decoding = 'async';
+  img.dataset.fallbackTitle = itemType === 'episode' ? (subtitleText || titleText) : titleText;
   img.src = item.poster_local || item.poster || item.thumbnail_local || item.thumbnail || '/pwa/weather/not-available.svg';
   _jfBindImageFallback(img);
   tWrap.appendChild(img);
@@ -885,6 +902,14 @@ function _jfBuildRowItemCard(item, rowId){
   itSub.textContent = itemType === 'episode' ? titleText : subtitleText;
   meta.appendChild(itTitle);
   meta.appendChild(itSub);
+  // Library hint disambiguates same-title duplicates across libraries.
+  const libraryName = String(item.library_name || '').trim();
+  if (libraryName) {
+    const libChip = document.createElement('div');
+    libChip.className = 'jfLibChip';
+    libChip.textContent = libraryName;
+    meta.appendChild(libChip);
+  }
 
   const iType = itemType;
   if (__jfActiveTab === 'tv' && iType === 'series') {
@@ -1291,6 +1316,8 @@ function _jfRenderRows(rows){
     if (rowId === 'tv_series' || rowId === 'tv_episodes') scroller.classList.add('jfCatalogTv');
     if (rowId === 'tv_episodes') scroller.classList.add('jfCatalogEpisodes');
     if (rowId === 'tv_seasons') scroller.classList.add('jfSeasonWrap');
+    // Search reads better as a full list than a cut-off horizontal rail.
+    if (rowId === 'search') scroller.classList.add('jfSearchList');
 
     const items = Array.isArray(row.items) ? row.items : [];
     if (!items.length) {
@@ -1441,7 +1468,9 @@ async function loadJellyfinHome(force){
     const reason = String(j.last_error || '').trim();
     _jfSetConn(up, up ? 'Connected' : (reason ? `Unavailable · ${reason}` : 'Unavailable'));
     if (!up) _jfSetBrowseUnavailable(reason);
-    _jfSetStatus(j.connected ? 'Ready' : 'Ready (degraded)', j.connected ? 'ok' : '');
+    // A bare "Ready" under the search box read as a UI bug; only say something
+    // when the state actually needs attention.
+    _jfSetStatus(j.connected ? '' : 'Degraded — showing cached catalog', j.connected ? 'ok' : '');
   } catch (e) {
     if (_jfIsAbortError(e)) return;
     const msg = String(e?.message || e);
@@ -1477,7 +1506,7 @@ async function runJellyfinSearch(force){
     const reason = String(j.last_error || '').trim();
     _jfSetConn(up, up ? 'Connected' : (reason ? `Unavailable · ${reason}` : 'Unavailable'));
     if (!up) _jfSetBrowseUnavailable(reason);
-    _jfSetStatus(`${scopedItems.length} result(s)`, 'ok');
+    _jfSetStatus(`${scopedItems.length} ${scopedItems.length === 1 ? 'result' : 'results'}`, 'ok');
   } catch (e) {
     if (_jfIsAbortError(e)) return;
     _jfSetBrowseUnavailable(String(e?.message || e));

--- a/app/relaytv_app/static/ui/peers.css
+++ b/app/relaytv_app/static/ui/peers.css
@@ -385,8 +385,8 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  min-height: 0;
-  padding: 5px 12px;
+  min-height: 40px;
+  padding: 8px 16px;
   border-radius: 999px;
   font-size: 12px;
   font-weight: 700;
@@ -409,38 +409,6 @@
 .qSendBtn:active{ background: rgba(24,44,92,.70); transform: translateY(1px); }
 .qSendGlyph{ width: 15px; height: 15px; }
 
-/* Per-item send: same footprint as the queue tile's remove control, in the
-   neutral glass tone so removal stays the only red affordance. */
-.qSendItemBtn{
-  flex: 0 0 auto;
-  align-self: center;
-  min-height: 0;
-  padding: 0;
-  width: 28px;
-  height: 28px;
-  border-radius: 999px;
-  font-size: 15px;
-  font-weight: 800;
-  line-height: 1;
-  border: 1px solid rgba(140,190,255,.34);
-  background: rgba(20,26,40,.60);
-  color: rgba(210,228,255,.82);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  z-index: 2;
-  box-shadow: none;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-}
-.qSendItemBtn:hover{
-  color: #eaf3ff;
-  border-color: rgba(150,210,255,.60);
-  background: rgba(34,60,120,.70);
-  transform: none;
-}
-
 @media (max-width: 560px){
   .peersModal{ width: 100%; }
   .pmAddActions button{ flex: 1 1 auto; }
@@ -459,12 +427,6 @@
     box-shadow: inset 0 1px 0 rgba(255,255,255,.9), 0 0 0 2px rgba(56,140,248,.14);
   }
   .pmSub, .pmStatus, .pmMeta, .pmHelper{ color: rgba(23,52,120,.72); }
-  .qSendItemBtn{
-    color: rgba(23,52,120,.85);
-    border-color: rgba(37,99,235,.30);
-    background: rgba(219,232,255,.70);
-  }
-  .qSendItemBtn:hover{ color: #0c1f4d; border-color: rgba(37,99,235,.50); background: rgba(199,220,255,.90); }
   .pmModes{ border-color: rgba(37,99,235,.20); background: rgba(219,232,255,.45); }
   .pmMode{ color: rgba(23,52,120,.78); }
   .pmMode:hover{ color: #0c1f4d; background: rgba(199,220,255,.70); }

--- a/app/relaytv_app/static/ui/peers.js
+++ b/app/relaytv_app/static/ui/peers.js
@@ -88,6 +88,7 @@
     return {
       kind,
       index,
+      queueId: String(source.queue_id || ''),
       url,
       provider,
       title: String(source.title || source.name || url || 'Untitled'),
@@ -107,12 +108,12 @@
     if (playbackActive() && np && np.url) rows.push(itemRow(np, 'now', null));
     (Array.isArray(st.queue) ? st.queue : []).forEach((item, idx) => rows.push(itemRow(item, 'queue', idx)));
 
-    // Key by URL rather than position: auto-next advancing while the sheet is
-    // open shifts every index, and a selection must not slide onto a different
-    // item. The ordinal disambiguates the same URL queued twice.
+    // Queue instance ids survive reordering and distinguish duplicate URLs.
+    // The URL fallback keeps compatibility with an older server during a
+    // rolling upgrade.
     const seen = Object.create(null);
     rows.forEach((row) => {
-      const base = `${row.kind}:${row.url}`;
+      const base = row.queueId ? `${row.kind}:id:${row.queueId}` : `${row.kind}:${row.url}`;
       const n = (seen[base] = (seen[base] || 0) + 1);
       row.key = n === 1 ? base : `${base}#${n}`;
     });
@@ -135,6 +136,10 @@
 
   function selectedQueueIndexes(){
     return state.items.filter((row) => row.kind === 'queue' && isSelected(row)).map((row) => row.index);
+  }
+
+  function selectedQueueIds(){
+    return state.items.filter((row) => row.kind === 'queue' && isSelected(row) && row.queueId).map((row) => row.queueId);
   }
 
   function queueRowCount(){
@@ -507,10 +512,11 @@
     const id = encodeURIComponent(peer.id);
     const keepLocal = state.mode === 'copy';
     const indexes = selectedQueueIndexes();
+    const queueIds = selectedQueueIds();
     // Omitting the selection when it covers the whole queue means the server
     // reads the queue itself, which stays correct even if an item was added
     // between this render and the request.
-    const scoped = selectionCoversQueue() ? {} : {indexes};
+    const scoped = selectionCoversQueue() ? {} : (queueIds.length === indexes.length ? {queue_ids: queueIds} : {indexes});
     if (selectedNow()){
       // A session is in play, so this is the handoff payload either way; the
       // mode only decides whether this device tears down afterwards.
@@ -681,11 +687,12 @@
     state.deselected.clear();
     state.pickSignature = '';
     buildItems();
-    if (Number.isInteger(scope.index)){
+    if (Number.isInteger(scope.index) || scope.queueId){
       // Opened from one queue tile: that item is the whole point, so everything
       // else — including the session — starts excluded.
       state.items.forEach((row) => {
-        if (row.kind !== 'queue' || row.index !== scope.index) state.deselected.add(row.key);
+        const matches = scope.queueId ? row.queueId === String(scope.queueId) : row.index === scope.index;
+        if (row.kind !== 'queue' || !matches) state.deselected.add(row.key);
       });
     }
     state.lastFocus = document.activeElement;

--- a/app/relaytv_app/static/ui/peers.js
+++ b/app/relaytv_app/static/ui/peers.js
@@ -25,10 +25,10 @@
     adopting: '',
     mode: 'send',
     items: [],
-    // Only exclusions are tracked: everything is selected by default, so an
-    // item that arrives while the sheet is open joins the send rather than
-    // being silently left out.
+    // The whole-sheet view selects new arrivals by default. A tile-scoped
+    // selection (or None) instead keeps an explicit set of selected keys.
     deselected: new Set(),
+    scopedSelection: null,
     pickSignature: '',
     lastFocus: null,
   };
@@ -123,6 +123,11 @@
     Array.from(state.deselected).forEach((key) => {
       if (!keys.has(key)) state.deselected.delete(key);
     });
+    if (state.scopedSelection !== null) {
+      rows.forEach((row) => {
+        if (!state.scopedSelection.has(row.key)) state.deselected.add(row.key);
+      });
+    }
     state.items = rows;
   }
 
@@ -140,14 +145,6 @@
 
   function selectedQueueIds(){
     return state.items.filter((row) => row.kind === 'queue' && isSelected(row) && row.queueId).map((row) => row.queueId);
-  }
-
-  function queueRowCount(){
-    return state.items.filter((row) => row.kind === 'queue').length;
-  }
-
-  function selectionCoversQueue(){
-    return selectedQueueIndexes().length === queueRowCount();
   }
 
   function syncSubtitle(){
@@ -376,12 +373,17 @@
     if (!row.sendable) return;
     if (state.deselected.has(row.key)) state.deselected.delete(row.key);
     else state.deselected.add(row.key);
+    if (state.scopedSelection !== null) {
+      if (state.deselected.has(row.key)) state.scopedSelection.delete(row.key);
+      else state.scopedSelection.add(row.key);
+    }
     setStatus('');
     render();
   }
 
   function selectAll(on){
     state.deselected.clear();
+    state.scopedSelection = on ? null : new Set();
     if (!on) state.items.forEach((row) => { if (row.sendable) state.deselected.add(row.key); });
     setStatus('');
     render();
@@ -513,10 +515,9 @@
     const keepLocal = state.mode === 'copy';
     const indexes = selectedQueueIndexes();
     const queueIds = selectedQueueIds();
-    // Omitting the selection when it covers the whole queue means the server
-    // reads the queue itself, which stays correct even if an item was added
-    // between this render and the request.
-    const scoped = selectionCoversQueue() ? {} : (queueIds.length === indexes.length ? {queue_ids: queueIds} : {indexes});
+    // Submit the displayed selection even when it currently covers every
+    // item. Items arriving after this click were never selected for transfer.
+    const scoped = queueIds.length === indexes.length ? {queue_ids: queueIds} : {indexes};
     if (selectedNow()){
       // A session is in play, so this is the handoff payload either way; the
       // mode only decides whether this device tears down afterwards.
@@ -685,14 +686,17 @@
     const scope = opts && typeof opts === 'object' ? opts : {};
     state.mode = 'send';
     state.deselected.clear();
+    state.scopedSelection = null;
     state.pickSignature = '';
     buildItems();
     if (Number.isInteger(scope.index) || scope.queueId){
+      state.scopedSelection = new Set();
       // Opened from one queue tile: that item is the whole point, so everything
       // else — including the session — starts excluded.
       state.items.forEach((row) => {
         const matches = scope.queueId ? row.queueId === String(scope.queueId) : row.index === scope.index;
         if (row.kind !== 'queue' || !matches) state.deselected.add(row.key);
+        else state.scopedSelection.add(row.key);
       });
     }
     state.lastFocus = document.activeElement;

--- a/app/relaytv_app/static/ui/seerr.js
+++ b/app/relaytv_app/static/ui/seerr.js
@@ -177,7 +177,9 @@ function _seerrCard(item){
   meta.textContent = [item.year || '', mediaType === 'tv' ? 'Series' : 'Movie', item.rating ? `★ ${item.rating}` : ''].filter(Boolean).join(' · ');
   const state = document.createElement('span');
   state.className = 'seerrState';
-  state.textContent = String(item.status || item.media_status || 'unknown').replaceAll('_', ' ');
+  // Upstream's "unknown" means nobody asked for it; say so in human terms.
+  const rawStatus = String(item.status || item.media_status || 'unknown').replaceAll('_', ' ');
+  state.textContent = rawStatus === 'unknown' ? 'Not requested' : rawStatus;
   body.append(title, meta, state);
   button.appendChild(body);
   if (mediaId > 0 && (mediaType === 'movie' || mediaType === 'tv')) {
@@ -231,7 +233,13 @@ async function loadSeerrBrowse(options){
     __seerrPage = Number(payload.page || page) || page;
     __seerrTotalPages = Math.max(__seerrPage, Number(payload.total_pages || 1) || 1);
     _seerrRender();
-    _seerrSetStatus(`${Number(payload.total_results || __seerrItems.length)} result${Number(payload.total_results || __seerrItems.length) === 1 ? '' : 's'}`, false);
+    // The raw upstream total ("10000 results") is noise for browsed sections;
+    // counts only mean something for searches and the requests list.
+    const total = Number(payload.total_results || __seerrItems.length);
+    const statusText = __seerrQuery
+      ? `${total} result${total === 1 ? '' : 's'}`
+      : (__seerrSection === 'requests' ? `${total} request${total === 1 ? '' : 's'}` : '');
+    _seerrSetStatus(statusText, false);
   } catch (error) {
     if (error && error.name === 'AbortError') return;
     if (serial !== __seerrRequestSerial) return;

--- a/docs/API.md
+++ b/docs/API.md
@@ -427,6 +427,9 @@ Queue endpoints:
     consumed from the queue only when the play is accepted. A failed play is
     restored at its original position unless a newer queue mutation occurred;
     in that case the newer user decision wins
+  - if Stop/Close or another Play supersedes resolution, returns `409` rather
+    than reporting a successful play. The same guarded restoration applies;
+    a concurrent queue Clear still wins
 - `POST /queue/move`
   - preferred body: `{"queue_id": string, "to_queue_id": string}`; legacy
     `{"from_index": int, "to_index": int}` remains supported
@@ -546,6 +549,11 @@ Send:
   - without `keep_local` the local session is cleared, not closed: the session
     moved to the peer, so this device returns to idle with nothing to resume
     rather than showing the item it gave away
+  - local teardown is conditional on the captured playback generation still
+    being current. If another Play or Stop/Close intervenes, the peer keeps
+    what it received but the replacement local state is untouched and
+    `local_stopped` is `false`. Otherwise any remaining local queue entries
+    become eligible for normal autoplay after teardown
   - returns `{"playing", "resume_pos", "sent", "accepted", "rejected",
     "queue_length", "local_stopped", "local_queue_length", "kept_local", "peer"}`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -412,16 +412,22 @@ Queue endpoints:
 - `POST /v1/queue/add`
   - body: `{"url"}`
 - `GET /queue`
+  - queue items include an opaque `queue_id` that remains stable while the
+    item is reordered; use it for delayed or interactive mutations
 - `POST /queue/remove`
-  - body: `{"index": int}`
+  - preferred body: `{"queue_id": string}`; legacy `{"index": int}` remains
+    supported
 - `POST /queue/play`
-  - body: `{"index": int}`
+  - preferred body: `{"queue_id": string}`; legacy `{"index": int}` remains
+    supported
   - plays the queued item immediately, preserving current playback to the
     front of the queue (same semantics as `POST /history/play`); the item is
-    consumed from the queue only when the play is accepted, and restored at
-    its original position when it fails
+    consumed from the queue only when the play is accepted. A failed play is
+    restored at its original position unless a newer queue mutation occurred;
+    in that case the newer user decision wins
 - `POST /queue/move`
-  - body: `{"from_index": int, "to_index": int}`
+  - preferred body: `{"queue_id": string, "to_queue_id": string}`; legacy
+    `{"from_index": int, "to_index": int}` remains supported
 - `POST /queue/dedupe`
 - `POST /clear`
   - clears the queue
@@ -495,11 +501,14 @@ Registry:
 Send:
 
 - `POST /peers/{peer_id}/send`
-  - body: `{"mode": "append"|"replace"|"move", "index"?, "indexes"?}`
-  - omit both selectors to send the whole queue. `indexes` sends just those
+  - body: `{"mode": "append"|"replace"|"move", "queue_id"?, "queue_ids"?,
+    "index"?, "indexes"?}`
+  - omit all selectors to send the whole queue. `indexes` sends just those
     queue positions, in queue order; `index` is the older single-item form and
-    still works. An explicit empty `indexes` is a `400`, not a no-op, and any
-    out-of-range position is a `400` before anything is sent
+    still works. New clients should use the stable id forms so a selection
+    cannot move onto another item. An explicit empty selector list is a `400`,
+    not a no-op; an unknown id is a `409`, and an out-of-range position is a
+    `400` before anything is sent
   - `append` and `replace` are copies: the sending device keeps its queue.
     `move` gives up ownership — it imports as `append` on the peer and then
     drops the sent items locally, but only after the peer confirms the import,
@@ -517,10 +526,11 @@ Send:
   - IPTV items are reported in `rejected`, not sent: their stream URLs may
     carry credentials anywhere in the path, so no portable URL exists
 - `POST /peers/{peer_id}/handoff`
-  - body: `{"indexes"?, "keep_local"?}`; an empty body (or none) hands over the
-    current playback plus the whole queue and stops here
-  - `indexes` restricts which queue items travel with the session; the rest stay
-    here and this device advances into them instead of going idle
+  - body: `{"queue_ids"?, "indexes"?, "keep_local"?}`; an empty body (or none)
+    hands over the current playback plus the whole queue and stops here
+  - `queue_ids` (preferred) or `indexes` restrict which queue items travel with
+    the session; the rest stay here and this device advances into them instead
+    of going idle
   - `keep_local` sends exactly the same payload but skips every local teardown,
     so both devices play the same thing from the same position. This is the UI's
     **Copy**; it defaults to `false` so an unasked-for handoff still moves the

--- a/docs/API.md
+++ b/docs/API.md
@@ -413,7 +413,9 @@ Queue endpoints:
   - body: `{"url"}`
 - `GET /queue`
   - queue items include an opaque `queue_id` that remains stable while the
-    item is reordered; use it for delayed or interactive mutations
+    item is reordered; use it for delayed or interactive mutations. IDs are
+    assigned before insertion becomes visible; repeated entries have distinct
+    IDs even when their URLs match
 - `POST /queue/remove`
   - preferred body: `{"queue_id": string}`; legacy `{"index": int}` remains
     supported
@@ -514,14 +516,16 @@ Send:
     drops the sent items locally, but only after the peer confirms the import,
     so a transfer that fails in transit loses nothing. Unselected items stay.
     A `move` response adds `{"moved": true, "local_queue_length"}`
-  - `move` drops only what the peer **accepted**, matched against the queue as
-    it stands when the response arrives, never by the positions captured before
-    the request. Items the peer rejected, items that could not travel (IPTV),
-    and items that shifted position while the send was in flight are all left
-    alone — a send can take tens of seconds, and reusing a stale index would
-    delete whatever had moved into that slot. If a peer reports no per-item
+  - `move` drops only what the peer **accepted**, matched atomically by stable
+    queue ID when the response arrives, never by position or URL. Accepted
+    entries are removed even if reordered; already-removed entries are ignored.
+    Rejected items, items that could not travel (IPTV), and unsent entries
+    (including duplicates of a sent URL) stay local. If a peer reports no per-item
     results and its `accepted` count does not cover everything sent, nothing is
     dropped locally
+  - the browser always submits the displayed selection explicitly, including
+    when all displayed items are selected; additions after submission are not
+    included. Omitting selectors remains supported for other API clients
   - returns `{"sent", "accepted", "rejected", "queue_length", "peer", "mode"}`
   - IPTV items are reported in `rejected`, not sent: their stream URLs may
     carry credentials anywhere in the path, so no portable URL exists

--- a/docs/API.md
+++ b/docs/API.md
@@ -414,6 +414,12 @@ Queue endpoints:
 - `GET /queue`
 - `POST /queue/remove`
   - body: `{"index": int}`
+- `POST /queue/play`
+  - body: `{"index": int}`
+  - plays the queued item immediately, preserving current playback to the
+    front of the queue (same semantics as `POST /history/play`); the item is
+    consumed from the queue only when the play is accepted, and restored at
+    its original position when it fails
 - `POST /queue/move`
   - body: `{"from_index": int, "to_index": int}`
 - `POST /queue/dedupe`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,9 +26,14 @@ milestone logs live in git history.
   (play-now, queue, close, advance, resume, natural end, stop) — the
   only writer of playback session state outside `state.py`. Also owns the
   read-only handoff snapshot (what is playing, and where) that device transfer
-  sends to a peer.
+  sends to a peer, and generation-conditional handoff completion. Local teardown
+  holds the runtime lock before the playback-intent lock; peer I/O and media
+  resolution stay outside both. Remaining local entries advance through the
+  existing autoplay worker after teardown.
 - `app/relaytv_app/player.py`: playback process/runtime adapter (mpv
-  lifecycle, Qt shell, CEC, track/property control).
+  lifecycle, Qt shell, CEC, track/property control). Queue Play-now opts into an
+  explicit superseded exception so canceled resolution can use revision-guarded
+  queue rollback; legacy player callers retain their normal return contract.
 - `app/relaytv_app/postlive_relay.py`: local relay for still-processing
   YouTube replays (see `POSTLIVE_REPLAY.md`).
 - `app/relaytv_app/state.py`: persisted queue, history, session, and
@@ -58,7 +63,9 @@ milestone logs live in git history.
 - `app/relaytv_app/integrations/jellyfin_service.py`: Jellyfin/Emby
   product behavior — command ingress, stream selection and transcode
   policy, track preferences, metadata enrichment, stopped/progress
-  payloads.
+  payloads. Slow queue preference lookups publish field updates by stable
+  queue ID only while the captured URL is still current; they never replace
+  the live queue with their earlier snapshot.
 - `app/relaytv_app/integrations/jellyfin_receiver.py`: Jellyfin/Emby
   transport, auth, server-type detection, status, catalog cache, and
   progress/stopped calls.

--- a/docs/DEVICE_SYNC_OPERATIONS.md
+++ b/docs/DEVICE_SYNC_OPERATIONS.md
@@ -27,7 +27,10 @@ Leaving the now-playing row out turns either mode into a plain queue transfer:
 That is also what happens when nothing is playing here.
 
 A `⋯` on each queue tile opens the same sheet with only that item selected, so
-one thing can be sent without deselecting everything else by hand.
+one thing can be sent without deselecting everything else by hand. New arrivals
+stay unselected in this single-item view. The queue-header sheet includes new
+arrivals while open unless you choose **None**; either way, clicking a device
+sends only the selection displayed at that moment.
 
 Nothing is sent automatically. Every transfer is an explicit action, and the
 receiving device never forwards what it was sent.
@@ -131,9 +134,10 @@ Every destructive step waits for confirmation from the other device:
   fails in transit loses nothing and leaves you watching what you were watching.
 - **Send** gives up only what the other device actually accepted. Anything it
   rejected — an unconfigured provider, say — and anything that could not travel
-  at all stays here. The items are matched by identity, not by their position
-  in the queue, so a transfer that takes a while cannot delete something that
-  moved into a sent item's slot in the meantime.
+  at all stays here. Cleanup matches stable queue IDs in one locked operation,
+  never positions or URLs. An item removed during transfer stays removed;
+  another entry with the same URL is not deleted in its place. New arrivals
+  remain local unless they were included in the submitted selection.
 - **Copy** changes nothing locally at all, so there is nothing to undo.
 - On the receiving side, a handoff takes over playback *before* importing the
   queue. A device that cannot start playing does not end up holding the items

--- a/docs/DEVICE_SYNC_OPERATIONS.md
+++ b/docs/DEVICE_SYNC_OPERATIONS.md
@@ -139,6 +139,11 @@ Every destructive step waits for confirmation from the other device:
   another entry with the same URL is not deleted in its place. New arrivals
   remain local unless they were included in the submitted selection.
 - **Copy** changes nothing locally at all, so there is nothing to undo.
+- A delayed handoff cannot stop a newer local session or undo a subsequent
+  Stop/Close. Its response reports `local_stopped: false` when playback changed
+  during transfer. The peer still keeps the confirmed transfer. If the original
+  session is still current, it is cleared and the normal autoplay worker can
+  advance into any queue entries left here.
 - On the receiving side, a handoff takes over playback *before* importing the
   queue. A device that cannot start playing does not end up holding the items
   either.

--- a/docs/JELLYFIN_OPERATIONS.md
+++ b/docs/JELLYFIN_OPERATIONS.md
@@ -162,57 +162,55 @@ Shared URL behavior:
 
 ## Shared Cast Target Authentication
 
-RelayTV Settings requires an explicit **Cast target identity** choice:
+Settings separates **Client login** from **Shared cast target**:
 
-- **Shared cast target (server API key)** advertises one userless device to
-  every Jellyfin user whose policy allows shared-device control.
-- **User-scoped cast target (username and password)** owns the control session
-  and catalog as the one stored Jellyfin account.
+- **Client login** uses a username and password for RelayTV's media browser,
+  personal library, and resume points. It remains active when shared casting
+  is enabled. Leave the preferred user ID blank to use the signed-in account.
+- **Share this cast target using an API key** enables a userless cast device
+  for every Jellyfin user whose policy allows shared-device control. Create a
+  key in **Dashboard → Advanced → API Keys**, paste it, and apply. Name the key
+  **RelayTV** to label the cast target `<configured device name> - RelayTV`.
 
-For shared mode, create a key in the Jellyfin admin dashboard under
-**Advanced → API Keys**, select shared mode, paste the key, and apply. Name the
-key **RelayTV** if you want Jellyfin's cast menu to label the target as
-`<configured device name> - RelayTV`.
+Both credential sections remain visible. Use **Apply Jellyfin / Emby** or the
+main Settings **Apply** button to save both together. Blank password/key fields
+preserve stored secrets; the explicit clear switches remove them. Client login
+and cast-target status are shown separately, so failed login remains visible
+while shared casting is connected.
 
-The API key owns RelayTV's control plane:
+With shared casting enabled, the API key owns the cast websocket, capability
+registration, session readback, and playing/progress/stopped reports. Local client
+catalog/media requests use the login-session token when login is configured.
+Incoming server-socket casts resolve media with the cast API key, independently
+of the local login; their cached catalog results are kept separate from browser
+results.
 
-- cast websocket;
-- capability registration and session readback;
-- playing, progress, and stopped reports.
+The browsing login uses a separate device identity (`<device ID>-client`) so
+it does not attach a user to the shared cast device. A pending or failed login
+does not fall back to the administrator API key for catalog access.
 
-This registers RelayTV as a userless shared device. The same selected API key
-is used for control and catalog/media requests; stored username/password
-credentials are inactive while shared mode is selected. Jellyfin API keys are
-administrator-level credentials. RelayTV stores the value server-side, returns
-only `jellyfin_api_key_configured` to the Settings UI, and never includes the
-key in status responses or logs. Leaving the field blank preserves the stored
-key; use **Clear stored API key** to remove it explicitly.
+Existing API-key-only setups remain supported: leave username/password empty
+for casting only, or supply a preferred user ID for API-based catalog browsing.
+With shared casting off, the login session provides both browsing and the
+existing user-scoped cast target; a stored API key remains inactive. Other users
+can only control that session when their Jellyfin policies permit it. The
+existing `jellyfin_auth_mode` setting is retained for API compatibility and
+selects cast identity (`shared_api_key` or `user_login`).
 
-Jellyfin still applies its own user policy. The target is available to all
-users whose policy allows shared-device control; RelayTV cannot make it appear
-for a user whose Jellyfin **shared device control** permission is disabled.
+Jellyfin API keys are administrator-level credentials. RelayTV stores the key
+server-side and returns only `jellyfin_api_key_configured` to Settings. Keys and
+passwords are omitted from status responses and logs.
 
-Jellyfin Web reserves the cast menu's second row for an authenticated session
-user. A shared API-key target is intentionally userless, so its API-key name is
-shown as the client suffix on the first row instead. Assigning a user merely to
-populate that second row would make the target user-scoped again.
-
-In user-login mode, the login-session token is used for both control and
-catalog/media requests; a stored API key is inactive. Other users may not see
-or control that session unless their Jellyfin policies permit remote control
-of another user's session. Retaining inactive credentials makes switching
-modes reversible, but RelayTV never silently combines the two identities.
-
-An API-key-only configuration can run the shared cast target without a
-username or password. For catalog browsing in that mode, set a preferred user
-ID when user-specific catalog routes are required.
+Jellyfin still enforces shared-device control permissions. Its cast menu's
+second row is reserved for an authenticated session user; the shared target is
+userless, so the API-key name appears as the client suffix on the first row.
 
 ### Caller-specific watch state
 
 A command from another Jellyfin user reaches the shared target, including its
 `ControllingUserId`, but RelayTV does not yet use that identity to change the
 catalog profile or attribute playback reports. The on-device catalog continues
-to use the configured preferred user when one is set, and resume/played state
+to use the client login or configured preferred user, and resume/played state
 is not guaranteed to update for the person who initiated a remote cast.
 User-login mode is one fixed operator-configured account, not per-browser
 caller identity. Dynamically attributing shared casts to the initiating caller
@@ -229,16 +227,17 @@ Shared cast-target authentication:
   - Equivalent to the Server API key field in Settings.
   - Preferred for a Jellyfin target shared across permitted users.
   - An environment-provided API key implies shared mode for backward
-    compatibility; the explicit selector is persisted when configured in the UI.
+    compatibility; the shared cast toggle persists the explicit mode when configured in the UI.
 
-User-scoped cast-target authentication:
+Client login (also used for casting when shared casting is off):
 
 - `RELAYTV_JELLYFIN_AUTH_ENABLED=1` (default enabled)
 - `RELAYTV_JELLYFIN_USERNAME=<jellyfin-user>`
 - `RELAYTV_JELLYFIN_PASSWORD=<jellyfin-password>`
 
-- Select **User-scoped cast target** in Settings. Username/password without an
-  API key also defaults to user-login mode for backward compatibility.
+- Configure **Client login** in Settings. Username/password without an API key
+  defaults to user-login mode for backward compatibility. Enable the separate
+  shared cast toggle and add an API key to use both roles together.
 
 Optional identity:
 

--- a/docs/TRANSITION_INVENTORY.md
+++ b/docs/TRANSITION_INVENTORY.md
@@ -95,7 +95,7 @@ The five Phase 3 review scenarios and where they are guarded at phase start:
 | --- | --- |
 | `AUTO_NEXT_SUPPRESS_UNTIL` | `playback_service.py` (2) |
 | `NOW_PLAYING` | `playback_service.py` (9)<br>`player.py` (10)<br>`routes/__init__.py` (1) |
-| `QUEUE` | `integrations/jellyfin_service.py` (4)<br>`playback_service.py` (7)<br>`player.py` (5)<br>`routes/queue.py` (8)<br>`routes/uploads.py` (1)<br>`upload_store.py` (1) |
+| `QUEUE` | `integrations/jellyfin_service.py` (4)<br>`playback_service.py` (8)<br>`player.py` (5)<br>`routes/queue.py` (8)<br>`routes/uploads.py` (1)<br>`upload_store.py` (1) |
 | `SESSION_POSITION` | `playback_service.py` (8)<br>`player.py` (9) |
 | `SESSION_STATE` | `playback_service.py` (8)<br>`player.py` (12)<br>`routes/__init__.py` (4) |
 | `_TEMP_PLAYBACK_STACK` | `playback_service.py` (8)<br>`routes/__init__.py` (2)<br>`routes/playback.py` (2) |

--- a/docs/TRANSITION_INVENTORY.md
+++ b/docs/TRANSITION_INVENTORY.md
@@ -94,9 +94,9 @@ The five Phase 3 review scenarios and where they are guarded at phase start:
 | Transition global | Writers outside `state.py` (write sites) |
 | --- | --- |
 | `AUTO_NEXT_SUPPRESS_UNTIL` | `playback_service.py` (2) |
-| `NOW_PLAYING` | `playback_service.py` (9)<br>`player.py` (10)<br>`routes/__init__.py` (1) |
+| `NOW_PLAYING` | `playback_service.py` (10)<br>`player.py` (10)<br>`routes/__init__.py` (1) |
 | `QUEUE` | `integrations/jellyfin_service.py` (4)<br>`playback_service.py` (8)<br>`player.py` (5)<br>`routes/queue.py` (8)<br>`routes/uploads.py` (1)<br>`upload_store.py` (1) |
-| `SESSION_POSITION` | `playback_service.py` (8)<br>`player.py` (9) |
-| `SESSION_STATE` | `playback_service.py` (8)<br>`player.py` (12)<br>`routes/__init__.py` (4) |
+| `SESSION_POSITION` | `playback_service.py` (9)<br>`player.py` (9) |
+| `SESSION_STATE` | `playback_service.py` (9)<br>`player.py` (12)<br>`routes/__init__.py` (4) |
 | `_TEMP_PLAYBACK_STACK` | `playback_service.py` (8)<br>`routes/__init__.py` (2)<br>`routes/playback.py` (2) |
 <!-- END GENERATED TRANSITION TABLE -->

--- a/docs/TRANSITION_INVENTORY.md
+++ b/docs/TRANSITION_INVENTORY.md
@@ -95,7 +95,7 @@ The five Phase 3 review scenarios and where they are guarded at phase start:
 | --- | --- |
 | `AUTO_NEXT_SUPPRESS_UNTIL` | `playback_service.py` (2) |
 | `NOW_PLAYING` | `playback_service.py` (9)<br>`player.py` (10)<br>`routes/__init__.py` (1) |
-| `QUEUE` | `integrations/jellyfin_service.py` (4)<br>`playback_service.py` (7)<br>`player.py` (5)<br>`routes/queue.py` (6)<br>`routes/uploads.py` (1)<br>`upload_store.py` (1) |
+| `QUEUE` | `integrations/jellyfin_service.py` (4)<br>`playback_service.py` (7)<br>`player.py` (5)<br>`routes/queue.py` (8)<br>`routes/uploads.py` (1)<br>`upload_store.py` (1) |
 | `SESSION_POSITION` | `playback_service.py` (8)<br>`player.py` (9) |
 | `SESSION_STATE` | `playback_service.py` (8)<br>`player.py` (12)<br>`routes/__init__.py` (4) |
 | `_TEMP_PLAYBACK_STACK` | `playback_service.py` (8)<br>`routes/__init__.py` (2)<br>`routes/playback.py` (2) |

--- a/docs/release-highlights/0.11.0.md
+++ b/docs/release-highlights/0.11.0.md
@@ -1,0 +1,15 @@
+## A friendlier remote, end to end
+
+This release is a full UX pass over the surfaces you touch every day. The
+queue grew up: every item now has a real action menu (Play now, Send to
+device, Remove) with Play-now built on a new `POST /queue/play` endpoint,
+removals are undoable, and desktop tiles finally show full titles. When
+playback ends, the remote says so — an Ended card with your resume point and
+an Up-next strip one tap from playing on. Jellyfin search is a proper list
+with library hints for duplicate titles, episode pages spell out "Resume
+34:01" versus "Play from start", and the idle dashboard only says Now
+Playing when something actually is. Provider badges are now local letter
+tiles, so your queue no longer leaks its domains to a third-party favicon
+service.
+
+---

--- a/tests/js/jellyfin_settings.test.js
+++ b/tests/js/jellyfin_settings.test.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const source = fs.readFileSync(path.join(__dirname, '../../app/relaytv_app/static/ui/app.js'), 'utf8');
+
+function fixture(){
+  const elements = new Map();
+  function element(id){
+    if (!elements.has(id)) {
+      const classes = new Set();
+      const attributes = new Map();
+      elements.set(id, {
+        value: '', checked: false, textContent: '', disabled: false,
+        classList: {
+          add: (...names) => names.forEach(name => classes.add(name)),
+          remove: (...names) => names.forEach(name => classes.delete(name)),
+          contains: name => classes.has(name),
+          toggle: (name, on) => on ? classes.add(name) : classes.delete(name),
+        },
+        setAttribute: (name, value) => attributes.set(name, value),
+        getAttribute: name => attributes.get(name),
+        addEventListener(){},
+      });
+    }
+    return elements.get(id);
+  }
+  // Use only real IDs from the served settings markup, so removed selectors
+  // cannot quietly remain available to the event handlers under test.
+  const markup = fs.readFileSync(path.join(__dirname, '../../app/relaytv_app/routes/__init__.py'), 'utf8');
+  for (const match of markup.matchAll(/id="((?:set|settings)[^"]+)"/g)) element(match[1]);
+  const requests = [];
+  const alerts = [];
+  const context = vm.createContext({
+    document: {getElementById: id => elements.get(id) || null},
+    window: {addEventListener(){}},
+    openSettings(){}, closeSettings(){}, loadSettingsUi: async() => {},
+    syncSeerrRequestModeUi(){}, applyJfBranding(){}, jfBrandName: () => 'Jellyfin',
+    SETTINGS_TV_CONTROL_BASELINE: {}, WEATHER_LOCATION_STATE: {},
+    collectIdlePanelSettings: () => ({}),
+    alert: message => alerts.push(message),
+    fetch: async(url, options) => {
+      if (options) requests.push({url, body: JSON.parse(options.body)});
+      return {ok: true, json: async() => ({})};
+    },
+  });
+  const helpersStart = source.indexOf('function syncJellyfinAuthModeUi()');
+  vm.runInContext(source.slice(helpersStart, source.indexOf('async function loadSettingsUi()', helpersStart)), context);
+  const bindStart = source.indexOf('function bindSettingsUi()');
+  vm.runInContext(source.slice(bindStart, source.indexOf('// Consume the', bindStart)), context);
+  vm.runInContext('bindSettingsUi()', context);
+  element('setJfEnabled').checked = true;
+  element('setJfServerUrl').value = 'http://jf.example';
+  element('setJfSharedCastEnabled').checked = true;
+  element('setJfApiKey').value = 'cast-key';
+  element('setJfUsername').value = 'viewer';
+  element('setJfPassword').value = 'password';
+  return {element, requests, alerts, context};
+}
+
+for (const button of ['setJfApplyBtn', 'settingsSaveBtn']) {
+  test(`${button} saves client login alongside the shared cast key`, async() => {
+    const f = fixture();
+    await f.element(button).onclick();
+    assert.equal(f.requests.length, 1);
+    assert.equal(f.requests[0].body.jellyfin_auth_mode, 'shared_api_key');
+    assert.equal(f.requests[0].body.jellyfin_api_key, 'cast-key');
+    assert.equal(f.requests[0].body.jellyfin_username, 'viewer');
+    assert.equal(f.requests[0].body.jellyfin_password, 'password');
+  });
+
+  test(`${button} preserves blank secrets and switches casting without hiding login`, async() => {
+    const f = fixture();
+    f.element('setJfPassword').value = '';
+    f.element('setJfPasswordState').setAttribute('data-configured', '1');
+    f.element('setJfApiKey').value = '';
+    f.element('setJfApiKeyState').setAttribute('data-configured', '1');
+    for (const shared of [true, false]) {
+      f.element('setJfSharedCastEnabled').checked = shared;
+      f.element('setJfSharedCastEnabled').onchange();
+      assert.equal(f.element('setJfUserAuthFields').classList.contains('hidden'), false);
+      assert.equal(f.element('setJfSharedAuthFields').classList.contains('hidden'), false);
+      await f.element(button).onclick();
+      const {body} = f.requests.at(-1);
+      assert.equal(body.jellyfin_auth_mode, shared ? 'shared_api_key' : 'user_login');
+      assert.equal(Object.hasOwn(body, 'jellyfin_password'), false);
+      assert.equal(Object.hasOwn(body, 'jellyfin_api_key'), false);
+    }
+    assert.equal(f.requests.length, 2);
+  });
+
+  test(`${button} rejects incomplete client login even when casting is configured`, async() => {
+    const f = fixture();
+    f.element('setJfPassword').value = '';
+    await f.element(button).onclick();
+    assert.equal(f.requests.length, 0);
+    const error = button === 'settingsSaveBtn' ? f.alerts[0] : f.element('setJfApplyResult').textContent;
+    assert.match(error, /required for client login/);
+  });
+
+  test(`${button} honors explicit clear over a newly typed secret`, async() => {
+    const f = fixture();
+    f.element('setJfClearApiKey').checked = true;
+    await f.element(button).onclick();
+    assert.equal(f.requests.length, 0);
+    f.element('setJfClearApiKey').checked = false;
+    f.element('setJfClearPassword').checked = true;
+    await f.element(button).onclick();
+    assert.equal(f.requests.length, 0);
+    f.element('setJfUsername').value = '';
+    await f.element(button).onclick();
+    assert.equal(f.requests.length, 1);
+    assert.equal(f.requests[0].body.jellyfin_password, '');
+    assert.equal(f.requests[0].body.jellyfin_auth_mode, 'shared_api_key');
+  });
+}

--- a/tests/js/peer_selection.test.js
+++ b/tests/js/peer_selection.test.js
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-only
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const path = require('node:path');
+const source = fs.readFileSync(path.join(__dirname, '../../app/relaytv_app/static/ui/peers.js'), 'utf8');
+
+function extract(name){
+  const start = source.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, name);
+  let depth = 0;
+  for (let i = source.indexOf('{', start); i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}' && --depth === 0) return source.slice(start, i + 1);
+  }
+  throw Error(name);
+}
+
+function fixture(){
+  const status = {queue: [{url: 'https://example.com/a', title: 'A', queue_id: 'a'}]};
+  const state = {mode: 'send', items: [], deselected: new Set(), scopedSelection: null};
+  const backdrop = {classList: {remove(){}}};
+  const context = vm.createContext({
+    state, Set, encodeURIComponent, document: {activeElement: null},
+    lastStatus: () => status, playbackActive: () => false,
+    $: id => id === 'peersBackdrop' ? backdrop : null,
+    isOpen: () => false, setStatus(){}, setAddHelper(){}, toggleAddForm(){}, syncModes(){},
+    load: async() => {},
+  });
+  for (const name of ['itemRow', 'buildItems', 'isSelected', 'selectedNow', 'selectedQueueIndexes',
+    'selectedQueueIds', 'sendRequest', 'open']) {
+    vm.runInContext(extract(name), context);
+  }
+  // Allow the previous implementation to execute fully during revert proof.
+  for (const name of ['queueRowCount', 'selectionCoversQueue']) {
+    if (source.includes(`function ${name}(`)) vm.runInContext(extract(name), context);
+  }
+  return {status, state, context, request: () => JSON.parse(JSON.stringify(
+    vm.runInContext("sendRequest({id:'bedroom'})", context)
+  ))};
+}
+
+test('sending the only tile retains its explicit id in the request', () => {
+  const f = fixture();
+  vm.runInContext("open({index:0, queueId:'a'})", f.context);
+  assert.deepEqual(f.request().body, {mode: 'move', queue_ids: ['a']});
+});
+
+test('tile selection excludes items arriving while the sheet is open', () => {
+  const f = fixture();
+  vm.runInContext("open({index:0, queueId:'a'})", f.context);
+  f.status.queue.push({url: 'https://example.com/b', title: 'B', queue_id: 'b'});
+  vm.runInContext('buildItems()', f.context);
+  assert.deepEqual(f.request().body.queue_ids, ['a']);
+  // The selected tile disappears: its replacement must not become selected.
+  f.status.queue.shift();
+  vm.runInContext('buildItems()', f.context);
+  assert.deepEqual(f.request().body.queue_ids, []);
+});
+
+test('whole-sheet selection sends only the displayed snapshot', () => {
+  const f = fixture();
+  vm.runInContext('open({})', f.context);
+  const request = f.request();
+  f.status.queue.push({url: 'https://example.com/b', queue_id: 'b'});
+  assert.deepEqual(request.body.queue_ids, ['a']);
+});

--- a/tests/js/queue_soft_remove.test.js
+++ b/tests/js/queue_soft_remove.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+// Queue removals are index-based on the wire. When an undo window is committed,
+// a second index captured from the old rendering must not be sent after the
+// first request shifts the queue.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const APP_JS = fs.readFileSync(
+  path.join(__dirname, '../../app/relaytv_app/static/ui/app.js'),
+  'utf8',
+);
+
+function extractFunction(name){
+  for(const prefix of [`async function ${name}(`, `function ${name}(`]){
+    const start = APP_JS.indexOf(prefix);
+    if(start === -1) continue;
+    let depth = 0;
+    let seenBody = false;
+    for(let i = start; i < APP_JS.length; i++){
+      const ch = APP_JS[i];
+      if(ch === '{'){ depth++; seenBody = true; }
+      else if(ch === '}'){
+        depth--;
+        if(seenBody && depth === 0) return APP_JS.slice(start, i + 1);
+      }
+    }
+  }
+  throw new Error(`${name} not found in app.js`);
+}
+
+function fixture(){
+  const queue = ['A', 'B', 'C'];
+  const requests = [];
+  const toasts = [];
+  let completed = 0;
+  let releaseFirst;
+  const firstRequestGate = new Promise(resolve => { releaseFirst = resolve; });
+
+  const context = vm.createContext({
+    console,
+    JSON,
+    __pendingRemove: null,
+    __removeFlushPromise: null,
+    clearTimeout(){},
+    setTimeout(){ return 1; },
+    document: {
+      querySelector(){
+        return {classList: {add(){}, remove(){}}};
+      },
+    },
+    _showToast(message){ toasts.push(message); },
+    _hideToast(){},
+    _applyQueueSnapshot(){},
+    refresh: async() => { completed++; },
+    fetch: async(_url, options) => {
+      const {index} = JSON.parse(options.body);
+      requests.push(index);
+      if(requests.length === 1) await firstRequestGate;
+      queue.splice(index, 1);
+      return {
+        ok: true,
+        json: async() => ({queue: [...queue], queue_length: queue.length}),
+      };
+    },
+  });
+  const functions = ['qRemove', '_flushPendingRemove', 'qSoftRemove'];
+  if(APP_JS.includes('function _commitPendingRemove(')) functions.splice(1, 0, '_commitPendingRemove');
+  for(const name of functions){
+    vm.runInContext(extractFunction(name), context, {filename:'app.js'});
+  }
+  return {context, queue, requests, releaseFirst, toasts, completed: () => completed};
+}
+
+test('overlapping soft removals never reuse an index from the old queue', async() => {
+  const state = fixture();
+
+  vm.runInContext('qSoftRemove(0); qSoftRemove(1);', state.context);
+  const firstFlush = vm.runInContext('__removeFlushPromise', state.context);
+
+  assert.deepEqual(state.requests, [0]);
+  state.releaseFirst();
+  if(firstFlush) await firstFlush;
+  while(state.completed() < 1) await new Promise(setImmediate);
+  assert.deepEqual(state.queue, ['B', 'C']);
+
+  // The refreshed rendering now identifies B as index zero. A new action can
+  // safely commit that index without deleting C.
+  vm.runInContext('qSoftRemove(0)', state.context);
+  await vm.runInContext('_flushPendingRemove()', state.context);
+
+  assert.deepEqual(state.requests, [0, 0]);
+  assert.deepEqual(state.queue, ['C']);
+  assert.ok(state.toasts.some(message => /select Remove again/.test(message)));
+});

--- a/tests/js/queue_soft_remove.test.js
+++ b/tests/js/queue_soft_remove.test.js
@@ -1,8 +1,7 @@
 'use strict';
 
-// Queue removals are index-based on the wire. When an undo window is committed,
-// a second index captured from the old rendering must not be sent after the
-// first request shifts the queue.
+// Queue removals carry stable ids on the wire. Indexes remain as a compatibility
+// fallback, but a delayed undo-window commit must still name the same item.
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
@@ -34,10 +33,15 @@ function extractFunction(name){
 }
 
 function fixture(){
-  const queue = ['A', 'B', 'C'];
+  const queue = [
+    {id: 'id-a', title: 'A'},
+    {id: 'id-b', title: 'B'},
+    {id: 'id-c', title: 'C'},
+  ];
   const requests = [];
   const toasts = [];
   let completed = 0;
+  let rendered = 0;
   let releaseFirst;
   const firstRequestGate = new Promise(resolve => { releaseFirst = resolve; });
 
@@ -46,6 +50,7 @@ function fixture(){
     JSON,
     __pendingRemove: null,
     __removeFlushPromise: null,
+    __lastStatus: {queue: []},
     clearTimeout(){},
     setTimeout(){ return 1; },
     document: {
@@ -56,15 +61,20 @@ function fixture(){
     _showToast(message){ toasts.push(message); },
     _hideToast(){},
     _applyQueueSnapshot(){},
+    _uiRefreshInteractionLockActive(){
+      return !!context.__pendingRemove || !!context.__removeFlushPromise;
+    },
+    renderStatus(){ rendered++; },
     refresh: async() => { completed++; },
     fetch: async(_url, options) => {
-      const {index} = JSON.parse(options.body);
-      requests.push(index);
+      const {index, queue_id: queueId} = JSON.parse(options.body);
+      requests.push({index, queueId: queueId || ''});
       if(requests.length === 1) await firstRequestGate;
-      queue.splice(index, 1);
+      const liveIndex = queueId ? queue.findIndex(item => item.id === queueId) : index;
+      if(liveIndex >= 0) queue.splice(liveIndex, 1);
       return {
         ok: true,
-        json: async() => ({queue: [...queue], queue_length: queue.length}),
+        json: async() => ({queue: queue.map(item => ({title: item.title})), queue_length: queue.length}),
       };
     },
   });
@@ -73,27 +83,81 @@ function fixture(){
   for(const name of functions){
     vm.runInContext(extractFunction(name), context, {filename:'app.js'});
   }
-  return {context, queue, requests, releaseFirst, toasts, completed: () => completed};
+  return {
+    context,
+    queue,
+    requests,
+    releaseFirst,
+    toasts,
+    completed: () => completed,
+    rendered: () => rendered,
+  };
 }
 
 test('overlapping soft removals never reuse an index from the old queue', async() => {
   const state = fixture();
 
-  vm.runInContext('qSoftRemove(0); qSoftRemove(1);', state.context);
+  vm.runInContext("qSoftRemove(0, 'id-a'); qSoftRemove(1, 'id-b');", state.context);
   const firstFlush = vm.runInContext('__removeFlushPromise', state.context);
 
-  assert.deepEqual(state.requests, [0]);
+  assert.deepEqual(state.requests, [{index: 0, queueId: 'id-a'}]);
   state.releaseFirst();
   if(firstFlush) await firstFlush;
   while(state.completed() < 1) await new Promise(setImmediate);
-  assert.deepEqual(state.queue, ['B', 'C']);
+  assert.deepEqual(state.queue.map(item => item.title), ['B', 'C']);
 
   // The refreshed rendering now identifies B as index zero. A new action can
   // safely commit that index without deleting C.
-  vm.runInContext('qSoftRemove(0)', state.context);
+  vm.runInContext("qSoftRemove(0, 'id-b')", state.context);
   await vm.runInContext('_flushPendingRemove()', state.context);
 
-  assert.deepEqual(state.requests, [0, 0]);
-  assert.deepEqual(state.queue, ['C']);
+  assert.deepEqual(state.requests, [
+    {index: 0, queueId: 'id-a'},
+    {index: 0, queueId: 'id-b'},
+  ]);
+  assert.deepEqual(state.queue.map(item => item.title), ['C']);
   assert.ok(state.toasts.some(message => /select Remove again/.test(message)));
+  assert.equal(state.rendered(), 2);
+});
+
+test('external queue advancement cannot retarget a delayed removal', async() => {
+  const state = fixture();
+
+  vm.runInContext("qSoftRemove(1, 'id-b')", state.context);
+  state.queue.shift();
+  const flush = vm.runInContext('_flushPendingRemove()', state.context);
+  state.releaseFirst();
+  await flush;
+
+  assert.deepEqual(state.requests, [{index: 1, queueId: 'id-b'}]);
+  assert.deepEqual(state.queue.map(item => item.title), ['C']);
+  assert.equal(state.rendered(), 1);
+});
+
+test('play-now and drag requests carry stable queue targets', async() => {
+  const requests = [];
+  const context = vm.createContext({
+    console,
+    JSON,
+    _applyQueueSnapshot(){},
+    _showToast(){},
+    refresh: async() => {},
+    fetch: async(url, options) => {
+      requests.push({url, body: JSON.parse(options.body)});
+      return {ok: true, json: async() => ({queue: [], queue_length: 0})};
+    },
+  });
+  vm.runInContext(extractFunction('qPlayNow'), context, {filename: 'app.js'});
+  vm.runInContext(extractFunction('qMove'), context, {filename: 'app.js'});
+
+  await vm.runInContext("qPlayNow(2, 'id-c')", context);
+  await vm.runInContext("qMove(2, 0, 'id-c', 'id-a')", context);
+
+  assert.deepEqual(requests, [
+    {url: '/queue/play', body: {index: 2, queue_id: 'id-c'}},
+    {
+      url: '/queue/move',
+      body: {from_index: 2, to_index: 0, queue_id: 'id-c', to_queue_id: 'id-a'},
+    },
+  ]);
 });

--- a/tests/test_jellyfin_client_auth.py
+++ b/tests/test_jellyfin_client_auth.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Client login and shared casting must work at the same time."""
+import json
+
+import pytest
+
+from relaytv_app import state
+from relaytv_app.config import runtime_config
+from relaytv_app.integrations import jellyfin_receiver as receiver
+
+
+@pytest.fixture
+def shared_client(monkeypatch):
+    monkeypatch.setattr(receiver, "_STATUS", {
+        **receiver._STATUS,
+        "enabled": True, "running": True, "connected": True,
+        "server_url": "http://jf.example", "device_id": "tv-device",
+        "auth_mode": "shared_api_key", "api_key_configured": True,
+        "auth_user_configured": True, "authenticated": False,
+        "auth_user_id": "", "last_auth_ok": None,
+        "last_register_ok": True,
+    })
+    for name, value in {
+        "_AUTH_MODE": "shared_api_key", "_API_KEY": "cast-key",
+        "_AUTH_USERNAME": "viewer", "_AUTH_PASSWORD": "password",
+        "_ACCESS_TOKEN": "", "_AUTH_USER_ID": "", "_AUTH_SESSION_ID": "",
+    }.items():
+        monkeypatch.setattr(receiver, name, value)
+    monkeypatch.setattr(state, "get_settings", lambda: {})
+    monkeypatch.setattr(receiver, "_preferred_catalog_user_id", lambda: "")
+    monkeypatch.setattr(receiver, "_control_socket_status", lambda: {})
+    runtime_config.set_value("RELAYTV_JELLYFIN_AUTH_ENABLED", "1")
+    receiver._catalog_cache_clear()
+    requests = []
+
+    class Response:
+        def __init__(self, body):
+            self.body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps(self.body).encode()
+
+    def urlopen(req, timeout=5):
+        requests.append(req)
+        if req.full_url.endswith("AuthenticateByName"):
+            assert json.loads(req.data) == {"Username": "viewer", "Pw": "password"}
+            return Response({"AccessToken": "client-token", "User": {"Id": "viewer-id"}})
+        return Response({"Id": "movie", "Name": "Movie", "Type": "Movie"})
+
+    monkeypatch.setattr(receiver._urlrequest, "urlopen", urlopen)
+    yield requests
+    receiver._catalog_cache_clear()
+
+
+def test_shared_cast_authenticates_client_and_keeps_request_roles_separate(shared_client):
+    receiver._ensure_authentication()
+    assert receiver.status()["authenticated"] is True
+    assert receiver.status()["catalog_auth_source"] == "user_session"
+    assert receiver.status()["cast_target_scope"] == "shared"
+    assert receiver.status()["catalog_user_id"] == "viewer-id"
+    assert receiver.control_token() == "cast-key"
+    assert receiver.catalog_token() == "client-token"
+    assert 'DeviceId="tv-device-client"' in shared_client[0].get_header("X-emby-authorization")
+
+    assert receiver.get_item_metadata("movie")["title"] == "Movie"
+    metadata = shared_client[-1]
+    assert metadata.full_url == "http://jf.example/Users/viewer-id/Items/movie"
+    assert metadata.get_header("X-emby-token") == "client-token"
+    assert 'DeviceId="tv-device-client"' in metadata.get_header("X-emby-authorization")
+    # Catalog detail/playback-info share this HTTP helper.
+    receiver._get_json("http://jf.example/Users/viewer-id/Items", token="client-token")
+    assert 'DeviceId="tv-device-client"' in shared_client[-1].get_header("X-emby-authorization")
+
+    assert receiver.send_playback_start_once({"ItemId": "movie"})["ok"] is True
+    control = shared_client[-1]
+    assert control.get_header("X-emby-token") == "cast-key"
+    assert 'DeviceId="tv-device"' in control.get_header("X-emby-authorization")
+
+
+def test_pending_and_failed_client_login_never_fall_back_to_admin_key(shared_client, monkeypatch):
+    assert receiver.catalog_token() == ""
+    assert receiver._request_context().catalog_token == ""
+    assert receiver.status()["catalog_ready"] is False
+
+    # An explicit retry that fails must also retire an earlier login token.
+    receiver._ensure_authentication()
+    receiver.get_item_metadata("movie")
+    assert receiver._CATALOG_CACHE
+    monkeypatch.setattr(receiver._urlrequest, "urlopen", lambda *a, **kw: (_ for _ in ()).throw(OSError("login rejected")))
+    assert receiver.authenticate_once()["reason"] == "auth_failed"
+    assert receiver.catalog_token() == ""
+    assert receiver.session_token() == ""
+    assert not receiver._CATALOG_CACHE
+    assert receiver.status()["catalog_ready"] is False
+    assert receiver.status()["control_auth_source"] == "api_key"
+    assert receiver.control_token() == "cast-key"
+    assert receiver.status()["sync_health"] == "ok"
+
+
+def test_api_key_only_setup_remains_functional(shared_client, monkeypatch):
+    monkeypatch.setattr(receiver, "_AUTH_USERNAME", "")
+    monkeypatch.setattr(receiver, "_AUTH_PASSWORD", "")
+    monkeypatch.setitem(receiver._STATUS, "auth_user_configured", False)
+    receiver._ensure_authentication()
+    assert shared_client == []
+    assert receiver.catalog_token() == "cast-key"
+    assert receiver._request_context().catalog_token == "cast-key"
+    assert receiver.status()["catalog_auth_source"] == "api_key"
+    assert receiver.status()["catalog_ready"] is True
+
+
+def test_shared_cast_media_is_independent_of_concurrent_client_browsing(shared_client, monkeypatch):
+    import threading
+
+    receiver._ensure_authentication()
+    entered = threading.Event()
+    release = threading.Event()
+    original_open = receiver._urlrequest.urlopen
+    failures = []
+
+    def urlopen(req, timeout=5):
+        if req.get_header("X-emby-token") == "cast-key":
+            entered.set()
+            assert release.wait(5), "test did not release the cast lookup"
+        return original_open(req, timeout=timeout)
+
+    def sink(action, payload, *, guard=None):
+        assert receiver.catalog_token() == "cast-key"
+        return receiver.get_item_detail("movie", user_id_override=payload["ControllingUserId"])
+
+    monkeypatch.setattr(receiver._urlrequest, "urlopen", urlopen)
+    monkeypatch.setattr(receiver, "_COMMAND_SINK", sink)
+
+    def cast():
+        try:
+            assert receiver.dispatch_command("play", {"ControllingUserId": "viewer-id"})["title"] == "Movie"
+            assert receiver.catalog_token() == "client-token"
+        except BaseException as exc:
+            failures.append(exc)
+
+    thread = threading.Thread(target=cast)
+    thread.start()
+    try:
+        assert entered.wait(5), "cast lookup never reached HTTP"
+        assert receiver.catalog_token() == "client-token"
+        assert receiver.get_item_detail("movie")["title"] == "Movie"
+        assert shared_client[-1].get_header("X-emby-token") == "client-token"
+    finally:
+        release.set()
+        thread.join(5)
+    assert not thread.is_alive()
+    assert not failures
+    assert shared_client[-1].get_header("X-emby-token") == "cast-key"
+    assert 'DeviceId="tv-device"' in shared_client[-1].get_header("X-emby-authorization")
+    # Cache hits in either role must retain that role's media/image credential.
+    client_detail = receiver.get_item_detail("movie")
+    cast_detail = receiver.dispatch_command("play", {"ControllingUserId": "viewer-id"})
+    assert "client-token" in client_detail["thumbnail"]
+    assert "cast-key" in cast_detail["thumbnail"]
+
+
+def test_cast_credential_scope_is_reset_on_failure(shared_client, monkeypatch):
+    receiver._ensure_authentication()
+
+    def fail(*args, **kwargs):
+        assert receiver.catalog_token() == "cast-key"
+        raise RuntimeError("command failed")
+
+    monkeypatch.setattr(receiver, "_COMMAND_SINK", fail)
+    with pytest.raises(RuntimeError, match="command failed"):
+        receiver.dispatch_command("play", {})
+    assert receiver.catalog_token() == "client-token"
+    assert receiver._request_context().catalog_token == "client-token"

--- a/tests/test_jellyfin_service.py
+++ b/tests/test_jellyfin_service.py
@@ -6,6 +6,7 @@ and player adapters — no FastAPI route context. Route-level contract tests
 for the same behavior live in tests/test_jellyfin_routes.py.
 """
 import pytest
+import threading
 
 from relaytv_app import playback_service, player, state, video_profile
 from relaytv_app.integrations import jellyfin_receiver, jellyfin_service
@@ -35,6 +36,58 @@ def test_catalog_token_uses_receiver_selected_identity(monkeypatch) -> None:
     monkeypatch.setattr(jellyfin_receiver, "catalog_token", lambda: "selected-token")
 
     assert jellyfin_service.catalog_token() == "selected-token"
+
+
+@pytest.mark.parametrize("mutation", ["replace", "reorder", "retarget"])
+def test_preference_lookup_preserves_newer_queue_decisions(monkeypatch, mutation):
+    old = {"url": "http://jellyfin.local/Videos/old/stream", "provider": "jellyfin",
+           "jellyfin_item_id": "old", "title": "Old"}
+    monkeypatch.setattr(state, "QUEUE", state._RevisionedQueue([old]))
+    old_id = state.queue_item_id(old)
+    monkeypatch.setattr(state, "persist_queue", lambda: True)
+    monkeypatch.setattr(player, "prime_mpv_up_next_from_queue", lambda **kw: None)
+    entered, release = threading.Event(), threading.Event()
+
+    def lookup(item_id):
+        entered.set()
+        assert release.wait(5)
+        return "1", ""
+
+    monkeypatch.setattr(jellyfin_service, "preferred_stream_indices", lookup)
+    results = []
+    worker = threading.Thread(target=lambda: results.append(
+        jellyfin_service.retarget_queue_stream_preferences()
+    ), daemon=True)
+    worker.start()
+    try:
+        assert entered.wait(5)
+        with state.QUEUE_LOCK:
+            if mutation == "replace":
+                state.QUEUE.clear()
+            elif mutation == "retarget":
+                state.QUEUE[0]["url"] += "?AudioStreamIndex=2"
+            else:
+                state.QUEUE[0]["thumbnail"] = "https://example.com/new-art.jpg"
+            state.QUEUE.insert(0, {"url": "https://example.com/new", "title": "New"})
+        new_id = state.queue_item_id(state.QUEUE[0])
+    finally:
+        release.set()
+        worker.join(5)
+    assert not worker.is_alive()
+    assert state.queue_item_id(state.QUEUE[0]) == new_id
+    if mutation == "replace":
+        assert [item["title"] for item in state.QUEUE] == ["New"]
+        assert results == [0]
+    else:
+        assert [item["title"] for item in state.QUEUE] == ["New", "Old"]
+        assert state.queue_item_id(state.QUEUE[1]) == old_id
+        if mutation == "retarget":
+            assert "AudioStreamIndex=2" in state.QUEUE[1]["url"]
+            assert results == [0]
+        else:
+            assert "audioStreamIndex=1" in state.QUEUE[1]["url"]
+            assert state.QUEUE[1]["thumbnail"] == "https://example.com/new-art.jpg"
+            assert results == [1]
 
 
 # --- command normalization -------------------------------------------------

--- a/tests/test_jellyfin_service.py
+++ b/tests/test_jellyfin_service.py
@@ -688,6 +688,44 @@ def test_normalize_catalog_item_exposes_image_roles_and_progress(monkeypatch) ->
     assert "provider_ids" not in item
 
 
+def test_normalize_catalog_item_derives_library_hint_from_path(monkeypatch) -> None:
+    monkeypatch.setattr(jellyfin_receiver, "_attach_thumb", lambda item: item)
+
+    item = jellyfin_receiver._normalize_catalog_item(
+        {
+            "Id": "series-1",
+            "Name": "Silo",
+            "Type": "Series",
+            "ProductionYear": 2023,
+            "Path": "/mnt/media/TV Shows 4K/Silo",
+        },
+        base="http://media.local",
+        token="",
+    )
+
+    assert item["library_name"] == "TV Shows 4K"
+    assert "Path" not in item
+
+
+def test_library_label_from_path_variants() -> None:
+    label = jellyfin_receiver._library_label_from_path
+
+    # Series folder directly under the library root.
+    assert label("/mnt/media/TV Shows/Silo", title="Silo") == "TV Shows"
+    # Windows separators and a year-suffixed folder still resolve.
+    assert label("D:\\media\\TV 4K\\Silo (2023)", title="Silo") == "TV 4K"
+    # Episodes resolve through the series folder.
+    assert (
+        label("/mnt/media/TV Shows/Silo/Season 1/ep.mkv", title="Machines", series_name="Silo")
+        == "TV Shows"
+    )
+    # Movie files fall back to the parent directory.
+    assert label("/mnt/media/Movies/Silo (2023).mkv", title="Silo") == "Movies"
+    # Junk stays quiet.
+    assert label("", title="Silo") == ""
+    assert label("movie.mkv", title="Movie") == ""
+
+
 def test_item_detail_requests_tmdb_provider_identity(monkeypatch) -> None:
     urls = []
     monkeypatch.setattr(

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -350,7 +350,7 @@ def test_receiver_status_reports_shared_control_and_catalog_sources(monkeypatch)
     assert st["control_auth_source"] == "api_key"
     assert st["cast_target_scope"] == "shared"
     assert st["cast_target_ready"] is True
-    assert st["catalog_auth_source"] == "api_key"
+    assert st["catalog_auth_source"] == "user_session"
     assert st["catalog_ready"] is True
 
 
@@ -1203,7 +1203,7 @@ def test_authentication_captures_its_inputs_with_its_generation(monkeypatch) -> 
     assert jellyfin_receiver._request_context().generation != before
 
 
-def test_shared_mode_uses_only_api_key_even_when_login_token_exists(monkeypatch) -> None:
+def test_shared_mode_keeps_cast_key_separate_from_client_login(monkeypatch) -> None:
     monkeypatch.setattr(jellyfin_receiver, "_AUTH_MODE", "shared_api_key")
     monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "shared-api-key")
     monkeypatch.setattr(jellyfin_receiver, "_ACCESS_TOKEN", "catalog-user-token")
@@ -1211,9 +1211,9 @@ def test_shared_mode_uses_only_api_key_even_when_login_token_exists(monkeypatch)
     context = jellyfin_receiver._request_context()
 
     assert context.control_token == "shared-api-key"
-    assert context.catalog_token == "shared-api-key"
+    assert context.catalog_token == "catalog-user-token"
     assert jellyfin_receiver.control_token() == "shared-api-key"
-    assert jellyfin_receiver.catalog_token() == "shared-api-key"
+    assert jellyfin_receiver.catalog_token() == "catalog-user-token"
 
 
 def test_user_login_mode_uses_only_session_even_when_api_key_is_stored(monkeypatch) -> None:

--- a/tests/test_peers.py
+++ b/tests/test_peers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 import time
 
 import pytest
@@ -579,7 +580,7 @@ def test_handoff_requires_playback_and_stops_locally_after_success(
 
     monkeypatch.setattr(peers, "_request", _request)
     calls: list[str] = []
-    monkeypatch.setattr(peers_routes, "_clear_local_queue", lambda: calls.append("clear_queue") or 0)
+    monkeypatch.setattr(peers_routes, "_remove_local_queue_items", lambda items: calls.append("clear_queue") or 0)
     monkeypatch.setattr(
         "relaytv_app.routes.playback.clear_now_playing",
         lambda: calls.append("clear_now_playing") or {"status": "cleared"},
@@ -635,7 +636,7 @@ def test_handoff_failure_leaves_local_playback_alone(client, peers_file, stub_id
         lambda: stopped.append(True) or {"status": "cleared"},
     )
     cleared: list[bool] = []
-    monkeypatch.setattr(peers_routes, "_clear_local_queue", lambda: cleared.append(True) or 0)
+    monkeypatch.setattr(peers_routes, "_remove_local_queue_items", lambda items: cleared.append(True) or 0)
 
     response = client.post(f"/peers/{peer['id']}/handoff", json={})
     assert response.status_code == 502
@@ -762,6 +763,47 @@ def _seed_queue(*titles: str) -> None:
             state.QUEUE.append({"url": f"https://example.com/{title.lower()}", "title": title})
 
 
+@pytest.mark.parametrize("replacement", ["duplicate", "new_item"])
+def test_transfer_cleanup_preserves_unsent_instances(client, stub_identity, monkeypatch, replacement):
+    from relaytv_app import routes, player
+
+    peer = peers.add_peer(base_url="http://tv.local:8787", name="Bedroom")
+    monkeypatch.setattr(state, "QUEUE", state._RevisionedQueue())
+    monkeypatch.setattr(state, "persist_queue", lambda: None)
+    monkeypatch.setattr(state, "persist_queue_payload", lambda payload: None)
+    monkeypatch.setattr(player, "prime_mpv_up_next_from_queue", lambda **kw: None)
+    monkeypatch.setattr(routes, "_ui_event_push_queue", lambda *a, **kw: None)
+    _seed_queue("Sent")
+    selected_id = state.queue_item_id(state.QUEUE[0])
+    entered, release = threading.Event(), threading.Event()
+    responses = []
+
+    def _blocked_request(*args, **kwargs):
+        entered.set()
+        assert release.wait(5)
+        return {"accepted": 1, "queue_length": 1, "results": []}
+
+    monkeypatch.setattr(peers, "_request", _blocked_request)
+    worker = threading.Thread(target=lambda: responses.append(client.post(
+        f"/peers/{peer['id']}/send", json={"mode": "move", "queue_ids": [selected_id]}
+    )), daemon=True)
+    worker.start()
+    try:
+        assert entered.wait(5)
+        if replacement == "duplicate":
+            assert client.post("/queue/remove", json={"queue_id": selected_id}).status_code == 200
+        with state.QUEUE_LOCK:
+            state.QUEUE.append({"url": "https://example.com/sent", "title": "Unsent"})
+        unsent_id = state.queue_item_id(state.QUEUE[-1])
+    finally:
+        release.set()
+        worker.join(5)
+    assert not worker.is_alive()
+    assert responses and responses[0].status_code == 200
+    assert _queue_titles() == ["Unsent"]
+    assert state.queue_item_id(state.QUEUE[0]) == unsent_id
+
+
 def _queue_titles() -> list[str]:
     with state.QUEUE_LOCK:
         return [str(item.get("title") or "") for item in state.QUEUE]
@@ -836,7 +878,7 @@ def test_copy_sends_the_session_but_keeps_playing_here(client, peers_file, stub_
         "relaytv_app.routes.playback.clear_now_playing",
         lambda: stopped.append(True) or {"status": "cleared"},
     )
-    monkeypatch.setattr(peers_routes, "_clear_local_queue", lambda: cleared.append(True) or 0)
+    monkeypatch.setattr(peers_routes, "_remove_local_queue_items", lambda items: cleared.append(True) or 0)
     _seed_queue("Next up")
 
     response = client.post(f"/peers/{peer['id']}/handoff", json={"keep_local": True})

--- a/tests/test_peers.py
+++ b/tests/test_peers.py
@@ -582,8 +582,8 @@ def test_handoff_requires_playback_and_stops_locally_after_success(
     calls: list[str] = []
     monkeypatch.setattr(peers_routes, "_remove_local_queue_items", lambda items: calls.append("clear_queue") or 0)
     monkeypatch.setattr(
-        "relaytv_app.routes.playback.clear_now_playing",
-        lambda: calls.append("clear_now_playing") or {"status": "cleared"},
+        "relaytv_app.playback_service.complete_peer_handoff",
+        lambda snapshot, **kw: calls.append("clear_now_playing") or True,
     )
 
     with state.QUEUE_LOCK:
@@ -632,8 +632,8 @@ def test_handoff_failure_leaves_local_playback_alone(client, peers_file, stub_id
     monkeypatch.setattr(peers, "_request", _fail)
     stopped: list[bool] = []
     monkeypatch.setattr(
-        "relaytv_app.routes.playback.clear_now_playing",
-        lambda: stopped.append(True) or {"status": "cleared"},
+        "relaytv_app.playback_service.complete_peer_handoff",
+        lambda snapshot, **kw: stopped.append(True) or True,
     )
     cleared: list[bool] = []
     monkeypatch.setattr(peers_routes, "_remove_local_queue_items", lambda items: cleared.append(True) or 0)
@@ -809,6 +809,70 @@ def _queue_titles() -> list[str]:
         return [str(item.get("title") or "") for item in state.QUEUE]
 
 
+@pytest.mark.parametrize("replacement", [False, True])
+def test_handoff_completion_owns_only_the_captured_playback(client, stub_identity, monkeypatch, replacement):
+    from relaytv_app import playback_service, player
+    from relaytv_app.routes import playback as playback_routes
+
+    peer = peers.add_peer(base_url="http://tv.local:8787", name="Bedroom")
+    monkeypatch.setattr(state, "QUEUE", state._RevisionedQueue([
+        {"url": "https://example.com/remaining", "title": "Remaining"},
+    ]))
+    monkeypatch.setattr(state, "NOW_PLAYING", {"url": "https://example.com/a", "title": "A"})
+    monkeypatch.setattr(state, "SESSION_STATE", "playing")
+    monkeypatch.setattr(state, "AUTO_NEXT_SUPPRESS_UNTIL", 12345678900.0)
+    monkeypatch.setattr(state, "_persist_session_payload", lambda *a: True)
+    monkeypatch.setattr(state, "persist_queue", lambda: True)
+    monkeypatch.setattr(player, "is_playing", lambda: True)
+    monkeypatch.setattr(player, "mpv_get", lambda prop: 10)
+    monkeypatch.setattr(playback_routes, "_idle_visual_surface_enabled_for_player", lambda: False)
+    stopped = []
+    monkeypatch.setattr(player, "stop_mpv", lambda **kw: stopped.append(state.NOW_PLAYING["title"]))
+    entered, release = threading.Event(), threading.Event()
+    payloads = []
+
+    def request(*args, payload=None, **kwargs):
+        payloads.append(payload)
+        entered.set()
+        assert release.wait(5)
+        return {"playing": True, "accepted": 0, "results": [], "queue_length": 0}
+
+    monkeypatch.setattr(peers, "_request", request)
+    responses = []
+    worker = threading.Thread(target=lambda: responses.append(client.post(
+        f"/peers/{peer['id']}/handoff", json={"queue_ids": []},
+    )), daemon=True)
+    worker.start()
+    try:
+        assert entered.wait(5)
+        if replacement:
+            player.claim_playback_intent()
+            state.NOW_PLAYING = {"url": "https://example.com/b", "title": "B"}
+    finally:
+        release.set()
+        worker.join(5)
+    assert not worker.is_alive()
+    assert responses and responses[0].status_code == 200
+    assert payloads[0]["now_playing"]["title"] == "A"
+    assert "playback_intent" not in payloads[0]
+    assert responses[0].json()["local_stopped"] is not replacement
+    assert _queue_titles() == ["Remaining"]
+    if replacement:
+        assert stopped == []
+        assert state.NOW_PLAYING["title"] == "B"
+        assert state.AUTO_NEXT_SUPPRESS_UNTIL == 12345678900.0
+    else:
+        assert stopped == ["A"]
+        assert state.NOW_PLAYING is None
+        assert state.SESSION_STATE == "idle"
+        assert state.AUTO_NEXT_SUPPRESS_UNTIL == 0
+        # Remaining items are eligible for the existing autoplay worker.
+        advances = []
+        monkeypatch.setattr(playback_service, "advance_queue", lambda **kw: advances.append(kw) or {})
+        playback_service.natural_end()
+        assert len(advances) == 1
+
+
 def test_move_of_a_selection_removes_only_the_sent_items(client, peers_file, stub_identity, monkeypatch) -> None:
     peer = peers.add_peer(base_url="http://tv.local:8787", name="Bedroom")
     captured: dict[str, object] = {}
@@ -875,8 +939,8 @@ def test_copy_sends_the_session_but_keeps_playing_here(client, peers_file, stub_
     stopped: list[bool] = []
     cleared: list[bool] = []
     monkeypatch.setattr(
-        "relaytv_app.routes.playback.clear_now_playing",
-        lambda: stopped.append(True) or {"status": "cleared"},
+        "relaytv_app.playback_service.complete_peer_handoff",
+        lambda snapshot, **kw: stopped.append(True) or True,
     )
     monkeypatch.setattr(peers_routes, "_remove_local_queue_items", lambda items: cleared.append(True) or 0)
     _seed_queue("Next up")
@@ -1015,8 +1079,8 @@ def test_handoff_of_a_selection_leaves_the_unselected_items_here(
 
     monkeypatch.setattr(peers, "_request", _request)
     monkeypatch.setattr(
-        "relaytv_app.routes.playback.clear_now_playing",
-        lambda: {"status": "cleared"},
+        "relaytv_app.playback_service.complete_peer_handoff",
+        lambda snapshot, **kw: True,
     )
     _seed_queue("Keep me", "Take me")
 

--- a/tests/test_peers.py
+++ b/tests/test_peers.py
@@ -725,6 +725,36 @@ def test_send_single_index_and_unreachable_peer(client, peers_file, stub_identit
         state.QUEUE.clear()
 
 
+def test_send_single_queue_id_survives_index_shift(client, peers_file, stub_identity, monkeypatch) -> None:
+    peer = peers.add_peer(base_url="http://tv.local:8787", name="Bedroom")
+    captured: dict[str, object] = {}
+
+    def _request(base_url, path, *, token="", payload=None, timeout=0.0):
+        captured["payload"] = payload
+        return {"accepted": 1, "queue_length": 1, "results": []}
+
+    monkeypatch.setattr(peers, "_request", _request)
+    with state.QUEUE_LOCK:
+        state.QUEUE.clear()
+        state.QUEUE.extend(
+            [
+                {"url": "https://example.com/a", "title": "First"},
+                {"url": "https://example.com/b", "title": "Second"},
+                {"url": "https://example.com/c", "title": "Third"},
+            ]
+        )
+        state.ensure_queue_item_ids(state.QUEUE)
+        selected_id = state.queue_item_id(state.QUEUE[1])
+        state.QUEUE.pop(0)
+
+    response = client.post(f"/peers/{peer['id']}/send", json={"index": 1, "queue_id": selected_id})
+
+    assert response.status_code == 200
+    assert [entry["title"] for entry in captured["payload"]["items"]] == ["Second"]
+    with state.QUEUE_LOCK:
+        state.QUEUE.clear()
+
+
 def _seed_queue(*titles: str) -> None:
     with state.QUEUE_LOCK:
         state.QUEUE.clear()

--- a/tests/test_playback_intent.py
+++ b/tests/test_playback_intent.py
@@ -11,8 +11,11 @@ import inspect
 import threading
 
 import pytest
+from fastapi.testclient import TestClient
 
 from relaytv_app import player, state
+from relaytv_app import routes
+from relaytv_app.main import create_app
 
 
 @pytest.fixture(autouse=True)
@@ -99,6 +102,114 @@ def _play_in_thread(url, results, errors):
 
 
 # --- the primitives ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("clear_queue", [False, True])
+def test_queue_play_superseded_during_resolution(harness, monkeypatch, clear_queue):
+    monkeypatch.setattr(state, "QUEUE", state._RevisionedQueue([
+        {"url": "https://youtu.be/slow", "title": "Selected"},
+    ]))
+    selected_id = state.queue_item_id(state.QUEUE[0])
+    monkeypatch.setattr(state, "persist_queue_payload", lambda payload: True)
+    monkeypatch.setattr(player, "is_playing", lambda: False)
+    monkeypatch.setattr(player, "stop_mpv", lambda **kw: None)
+    monkeypatch.setattr(player, "prime_mpv_up_next_from_queue", lambda **kw: None)
+    monkeypatch.setattr(routes, "_ensure_notification_surface", lambda **kw: None)
+    monkeypatch.setattr(routes, "_push_overlay_toast", lambda **kw: None)
+    monkeypatch.setattr(routes, "_ui_event_push_queue", lambda *a, **kw: None)
+    client = TestClient(create_app(testing=True))
+    responses = []
+    worker = threading.Thread(target=lambda: responses.append(client.post(
+        "/queue/play", json={"queue_id": selected_id},
+    )), daemon=True)
+    worker.start()
+    try:
+        assert harness["resolving"].wait(5)
+        assert client.post("/close").status_code == 200
+        if clear_queue:
+            assert client.post("/clear").status_code == 200
+    finally:
+        harness["gate"].set()
+        worker.join(5)
+    assert not worker.is_alive()
+    assert responses and responses[0].status_code == 409
+    assert "superseded" in responses[0].json()["detail"]
+    assert harness["loaded"] == []
+    assert [state.queue_item_id(item) for item in state.QUEUE] == ([] if clear_queue else [selected_id])
+
+
+def test_strict_play_still_loads_when_not_superseded(harness):
+    harness["gate"].set()
+    result = player.play_item(
+        {"url": "https://youtu.be/normal"}, use_resolver=True, cec=False,
+        clear_queue=False, mode="queue_play", raise_on_superseded=True,
+    )
+    assert result["url"] == "https://youtu.be/normal"
+    assert len(harness["loaded"]) == 1
+
+
+def test_handoff_teardown_serializes_with_a_new_play_claim(monkeypatch):
+    from relaytv_app import playback_service
+
+    monkeypatch.setattr(state, "NOW_PLAYING", {"url": "https://example.com/a"})
+    intent = player.claim_playback_intent()
+    entered, release, claiming, claimed = (threading.Event() for _ in range(4))
+    results = []
+
+    def stop(**kwargs):
+        entered.set()
+        assert release.wait(5)
+
+    def claim():
+        claiming.set()
+        player.claim_playback_intent()
+        claimed.set()
+
+    monkeypatch.setattr(player, "stop_mpv", stop)
+    finisher = threading.Thread(target=lambda: results.append(playback_service.complete_peer_handoff(
+        {"playback_intent": intent}, idle_surface_enabled=False,
+    )), daemon=True)
+    newcomer = threading.Thread(target=claim, daemon=True)
+    finisher.start()
+    try:
+        assert entered.wait(5)
+        newcomer.start()
+        assert claiming.wait(5)
+        assert not claimed.wait(0.05), "new playback claimed ownership during old-session teardown"
+    finally:
+        release.set()
+        finisher.join(5)
+        if newcomer.ident is not None:
+            newcomer.join(5)
+    assert not finisher.is_alive() and not newcomer.is_alive()
+    assert results == [True]
+    assert claimed.is_set()
+
+
+def test_handoff_snapshot_rejects_generation_change_during_position_read(monkeypatch):
+    from relaytv_app import playback_service
+
+    monkeypatch.setattr(state, "NOW_PLAYING", {"url": "https://example.com/a"})
+    monkeypatch.setattr(player, "is_playing", lambda: True)
+    entered, release = threading.Event(), threading.Event()
+
+    def get(prop):
+        entered.set()
+        assert release.wait(5)
+        return 10
+
+    monkeypatch.setattr(player, "mpv_get", get)
+    results = []
+    worker = threading.Thread(target=lambda: results.append(playback_service.handoff_snapshot()), daemon=True)
+    worker.start()
+    try:
+        assert entered.wait(5)
+        player.claim_playback_intent()
+    finally:
+        release.set()
+        worker.join(5)
+    assert not worker.is_alive()
+    assert results == [None]
 
 
 def test_claiming_supersedes_the_previous_intent() -> None:

--- a/tests/test_public_media.py
+++ b/tests/test_public_media.py
@@ -105,7 +105,10 @@ def test_status_payload_redacts_runtime_media_without_mutating_state(monkeypatch
         "title": "Movie",
         "url": "https://media.example/Videos/123/stream?static=true",
     }
-    assert payload["queue"] == [payload["now_playing"]]
+    queued = dict(payload["queue"][0])
+    queue_id = queued.pop("queue_id")
+    assert len(queue_id) == 32
+    assert queued == payload["now_playing"]
     assert item["url"].endswith("api_key=secret&static=true")
     assert item["_resolved_stream"].endswith("token=secret")
 
@@ -182,7 +185,9 @@ def test_queue_remove_response_redacts_items_without_mutating_state(monkeypatch)
     assert response.status_code == 200
     body = response.json()
     assert body["removed"] == _SAFE_ITEM
-    assert body["queue"] == [_SAFE_ITEM]
+    queued = dict(body["queue"][0])
+    assert len(queued.pop("queue_id")) == 32
+    assert queued == _SAFE_ITEM
     assert "secret" not in json.dumps(body)
     assert routes.state.QUEUE[0]["_resolved_stream"].endswith("token=secret")
 

--- a/tests/test_queue_history_routes.py
+++ b/tests/test_queue_history_routes.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-only
+import threading
+
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
@@ -10,7 +12,7 @@ def _client_with_queue_patches(monkeypatch):
     events: list[dict[str, object]] = []
     prime_calls: list[bool] = []
 
-    monkeypatch.setattr(routes.state, "QUEUE", [], raising=False)
+    monkeypatch.setattr(routes.state, "QUEUE", routes.state._RevisionedQueue(), raising=False)
     monkeypatch.setattr(routes.state, "HISTORY", [], raising=False)
     monkeypatch.setattr(routes.state, "NOW_PLAYING", None, raising=False)
     monkeypatch.setattr(routes.state, "persist_queue", lambda: None)
@@ -120,7 +122,10 @@ def test_queue_and_history_read_shapes(monkeypatch) -> None:
 
     queue_response = client.get("/queue")
     assert queue_response.status_code == 200
-    assert queue_response.json() == {
+    queue_body = queue_response.json()
+    queue_id = queue_body["queue"][0].pop("queue_id")
+    assert len(queue_id) == 32
+    assert queue_body == {
         "now_playing": {"url": "https://example.com/now.mp4", "title": "Now"},
         "queue": [{"url": "https://example.com/queued.mp4", "title": "Queued"}],
         "queue_length": 1,
@@ -132,6 +137,94 @@ def test_queue_and_history_read_shapes(monkeypatch) -> None:
     assert history_body["history"] == [{"url": "https://example.com/history.mp4", "title": "History"}]
     assert history_body["history_length"] == 1
     assert history_body["limit"] == routes.state.HISTORY_LIMIT
+
+
+def test_stable_queue_id_prevents_delayed_remove_from_sliding(monkeypatch) -> None:
+    client, _, _ = _client_with_queue_patches(monkeypatch)
+    routes.state.QUEUE.extend(
+        [
+            {"url": "https://example.com/a.mp4", "title": "A"},
+            {"url": "https://example.com/b.mp4", "title": "B"},
+            {"url": "https://example.com/c.mp4", "title": "C"},
+        ]
+    )
+    queue = client.get("/queue").json()["queue"]
+    target_id = queue[1]["queue_id"]
+
+    # Model auto-next or another client changing the queue during the undo
+    # window. The stale index now points at C, but the id still names B.
+    with routes.state.QUEUE_LOCK:
+        routes.state.QUEUE.pop(0)
+    response = client.post("/queue/remove", json={"index": 1, "queue_id": target_id})
+
+    assert response.status_code == 200
+    assert response.json()["removed"]["title"] == "B"
+    assert [item["title"] for item in routes.state.QUEUE] == ["C"]
+
+
+def test_queue_id_survives_persistence_normalization() -> None:
+    item = {"url": "https://example.com/a.mp4", "title": "A"}
+    queue_id = routes.state.queue_item_id(item, create=True)
+
+    persisted = routes.state._persistable_queue_item(item)
+    loaded = routes.state._load_persisted_queue_item(persisted)
+
+    assert routes.state.queue_item_id(loaded) == queue_id
+    assert routes.state.QUEUE_ITEM_ID_KEY not in routes.state._persistable_history_item(item)
+
+
+def test_duplicate_queue_instances_receive_distinct_ids() -> None:
+    item = {"url": "https://example.com/a.mp4", "title": "A"}
+    items = [item, item]
+
+    routes.state.ensure_queue_item_ids(items)
+
+    assert items[0] is not items[1]
+    assert routes.state.queue_item_id(items[0]) != routes.state.queue_item_id(items[1])
+
+
+def test_unknown_queue_id_fails_closed_instead_of_using_stale_index(monkeypatch) -> None:
+    client, _, _ = _client_with_queue_patches(monkeypatch)
+    routes.state.QUEUE.extend(
+        [
+            {"url": "https://example.com/a.mp4", "title": "A"},
+            {"url": "https://example.com/b.mp4", "title": "B"},
+        ]
+    )
+
+    response = client.post("/queue/play", json={"index": 0, "queue_id": "0" * 32})
+
+    assert response.status_code == 409
+    assert [item["title"] for item in routes.state.QUEUE] == ["A", "B"]
+
+
+def test_stable_queue_ids_keep_drag_targets_after_external_insert(monkeypatch) -> None:
+    client, _, _ = _client_with_queue_patches(monkeypatch)
+    routes.state.QUEUE.extend(
+        [
+            {"url": "https://example.com/a.mp4", "title": "A"},
+            {"url": "https://example.com/b.mp4", "title": "B"},
+            {"url": "https://example.com/c.mp4", "title": "C"},
+        ]
+    )
+    queue = client.get("/queue").json()["queue"]
+    source_id = queue[2]["queue_id"]
+    target_id = queue[1]["queue_id"]
+    with routes.state.QUEUE_LOCK:
+        routes.state.QUEUE.insert(0, {"url": "https://example.com/x.mp4", "title": "X"})
+
+    response = client.post(
+        "/queue/move",
+        json={
+            "from_index": 2,
+            "to_index": 1,
+            "queue_id": source_id,
+            "to_queue_id": target_id,
+        },
+    )
+
+    assert response.status_code == 200
+    assert [item["title"] for item in routes.state.QUEUE] == ["X", "A", "C", "B"]
 
 
 def test_history_clear_and_play_delegate_to_play_now(monkeypatch) -> None:
@@ -270,7 +363,8 @@ def test_queue_play_preserves_opaque_provider_metadata(monkeypatch) -> None:
     response = client.post("/queue/play", json={"index": 0})
 
     assert response.status_code == 200
-    assert played == [queued]
+    assert played == [{key: value for key, value in queued.items() if key != routes.state.QUEUE_ITEM_ID_KEY}]
+    assert len(routes.state.queue_item_id(queued)) == 32
     assert played[0]["provider"] == "iptv"
     assert played[0]["iptv_source_id"] == "source-1"
     assert played[0]["iptv_channel_id"] == "channel-1"
@@ -300,6 +394,58 @@ def test_queue_play_restores_item_when_play_fails(monkeypatch) -> None:
     assert events[0]["queue_length"] == 3
 
 
+def test_failed_queue_play_allows_its_own_preserve_rollback(monkeypatch) -> None:
+    client, events, _ = _client_with_queue_patches(monkeypatch)
+    routes.state.QUEUE.append({"url": "https://example.com/selected.mp4", "title": "Selected"})
+
+    def _failing_play_now(_item, **_kwargs):
+        preserved = {"url": "https://example.com/current.mp4", "title": "Current"}
+        with routes.state.QUEUE_LOCK:
+            routes.state.QUEUE.insert(0, preserved)
+            routes.state.QUEUE.pop(0)
+        raise HTTPException(status_code=400, detail="cannot resolve media")
+
+    monkeypatch.setattr(routes, "_play_now_item", _failing_play_now)
+
+    response = client.post("/queue/play", json={"index": 0})
+
+    assert response.status_code == 400
+    assert [item["title"] for item in routes.state.QUEUE] == ["Selected"]
+    assert [event["action"] for event in events] == ["add"]
+
+
+def test_failed_queue_play_does_not_undo_newer_clear(monkeypatch) -> None:
+    client, events, _ = _client_with_queue_patches(monkeypatch)
+    routes.state.QUEUE.append({"url": "https://example.com/a.mp4", "title": "A"})
+    play_entered = threading.Event()
+    release_play = threading.Event()
+    result: list[object] = []
+
+    def _failing_play_now(_item, **_kwargs):
+        play_entered.set()
+        assert release_play.wait(2.0)
+        raise HTTPException(status_code=400, detail="cannot resolve media")
+
+    monkeypatch.setattr(routes, "_play_now_item", _failing_play_now)
+
+    worker = threading.Thread(
+        target=lambda: result.append(client.post("/queue/play", json={"index": 0})),
+        daemon=True,
+    )
+    worker.start()
+    assert play_entered.wait(2.0)
+
+    cleared = client.post("/clear")
+    release_play.set()
+    worker.join(2.0)
+
+    assert not worker.is_alive()
+    assert cleared.status_code == 200
+    assert result and result[0].status_code == 400
+    assert routes.state.QUEUE == []
+    assert [event["action"] for event in events] == ["clear"]
+
+
 def test_queue_play_validates_index_and_item(monkeypatch) -> None:
     client, events, _ = _client_with_queue_patches(monkeypatch)
     routes.state.QUEUE[:] = [
@@ -314,6 +460,7 @@ def test_queue_play_validates_index_and_item(monkeypatch) -> None:
     assert missing_url.json()["detail"] == "queue item missing url"
     # A rejected item must stay where it was.
     assert len(routes.state.QUEUE) == 2
-    assert routes.state.QUEUE[1] == {"title": "no url"}
+    assert routes.state.QUEUE[1]["title"] == "no url"
+    assert len(routes.state.queue_item_id(routes.state.QUEUE[1])) == 32
     assert events == []
     assert routes.state.HISTORY == []

--- a/tests/test_queue_history_routes.py
+++ b/tests/test_queue_history_routes.py
@@ -334,6 +334,7 @@ def test_queue_play_delegates_and_consumes_item(monkeypatch) -> None:
         "reason": "queue_play",
         "title_hint": "B",
         "resume_pos": 8.5,
+        "raise_on_superseded": True,
     }
     assert [event["action"] for event in events] == ["remove"]
     assert events[0]["queue_length"] == 2

--- a/tests/test_queue_history_routes.py
+++ b/tests/test_queue_history_routes.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from relaytv_app import routes
@@ -175,4 +176,105 @@ def test_history_clear_and_play_delegate_to_play_now(monkeypatch) -> None:
     cleared = client.post("/history/clear")
     assert cleared.status_code == 200
     assert cleared.json() == {"status": "cleared"}
+
+
+def _seed_playable_queue() -> list[dict[str, object]]:
+    items: list[dict[str, object]] = [
+        {"url": "https://example.com/a.mp4", "title": "A"},
+        {
+            "url": "https://example.com/b.mp4",
+            "title": "B",
+            "thumbnail": "https://example.com/b.jpg",
+            "resume_pos": 8.5,
+            "history_id": "hist-b",
+            "_resolved_source_url": "https://example.com/watch-b",
+            "_resolved_stream": "https://cdn.example.com/b.mp4",
+            "_resolved_audio": "https://cdn.example.com/b.m4a",
+            "_resolved_at": 99.5,
+        },
+        {"url": "https://example.com/c.mp4", "title": "C"},
+    ]
+    routes.state.QUEUE[:] = items
+    return items
+
+
+def test_queue_play_delegates_and_consumes_item(monkeypatch) -> None:
+    client, events, _ = _client_with_queue_patches(monkeypatch)
+    _seed_playable_queue()
+    play_now_requests: list[object] = []
+    monkeypatch.setattr(
+        routes,
+        "play_now",
+        lambda req: play_now_requests.append(req) or {"ok": True, "action": "played", "url": req.url},
+    )
+
+    played = client.post("/queue/play", json={"index": 1})
+
+    assert played.status_code == 200
+    assert played.json()["ok"] is True
+    assert [item["url"] for item in played.json()["queue"]] == [
+        "https://example.com/a.mp4",
+        "https://example.com/c.mp4",
+    ]
+    assert played.json()["queue_length"] == 2
+    assert [item["url"] for item in routes.state.QUEUE] == [
+        "https://example.com/a.mp4",
+        "https://example.com/c.mp4",
+    ]
+    assert len(play_now_requests) == 1
+    req = play_now_requests[0]
+    assert req.url == "https://example.com/b.mp4"
+    assert req.preserve_current is True
+    assert req.reason == "queue_play"
+    assert req.title == "B"
+    assert req.thumbnail == "https://example.com/b.jpg"
+    assert req.resume_pos == 8.5
+    assert req.history_id == "hist-b"
+    assert req.resolved_source_url == "https://example.com/watch-b"
+    assert req.resolved_stream == "https://cdn.example.com/b.mp4"
+    assert req.resolved_audio == "https://cdn.example.com/b.m4a"
+    assert req.resolved_at == 99.5
+    assert [event["action"] for event in events] == ["remove"]
+    assert events[0]["queue_length"] == 2
+
+
+def test_queue_play_restores_item_when_play_fails(monkeypatch) -> None:
+    client, events, _ = _client_with_queue_patches(monkeypatch)
+    _seed_playable_queue()
+
+    def _failing_play_now(req):
+        raise HTTPException(status_code=400, detail="cannot resolve media")
+
+    monkeypatch.setattr(routes, "play_now", _failing_play_now)
+
+    response = client.post("/queue/play", json={"index": 1})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "cannot resolve media"
+    # The failed play must not consume the item: original order is restored.
+    assert [item["url"] for item in routes.state.QUEUE] == [
+        "https://example.com/a.mp4",
+        "https://example.com/b.mp4",
+        "https://example.com/c.mp4",
+    ]
+    assert [event["action"] for event in events] == ["add"]
+    assert events[0]["queue_length"] == 3
+
+
+def test_queue_play_validates_index_and_item(monkeypatch) -> None:
+    client, events, _ = _client_with_queue_patches(monkeypatch)
+    routes.state.QUEUE[:] = [
+        {"url": "https://example.com/a.mp4", "title": "A"},
+        {"title": "no url"},
+    ]
+
+    assert client.post("/queue/play", json={"index": 5}).status_code == 400
+    assert client.post("/queue/play", json={"index": -1}).status_code == 400
+    missing_url = client.post("/queue/play", json={"index": 1})
+    assert missing_url.status_code == 400
+    assert missing_url.json()["detail"] == "queue item missing url"
+    # A rejected item must stay where it was.
+    assert len(routes.state.QUEUE) == 2
+    assert routes.state.QUEUE[1] == {"title": "no url"}
+    assert events == []
     assert routes.state.HISTORY == []

--- a/tests/test_queue_history_routes.py
+++ b/tests/test_queue_history_routes.py
@@ -201,11 +201,12 @@ def _seed_playable_queue() -> list[dict[str, object]]:
 def test_queue_play_delegates_and_consumes_item(monkeypatch) -> None:
     client, events, _ = _client_with_queue_patches(monkeypatch)
     _seed_playable_queue()
-    play_now_requests: list[object] = []
+    play_now_calls: list[tuple[dict[str, object], dict[str, object]]] = []
     monkeypatch.setattr(
         routes,
-        "play_now",
-        lambda req: play_now_requests.append(req) or {"ok": True, "action": "played", "url": req.url},
+        "_play_now_item",
+        lambda item, **kwargs: play_now_calls.append((item, kwargs))
+        or {"ok": True, "action": "played", "url": item["url"]},
     )
 
     played = client.post("/queue/play", json={"index": 1})
@@ -221,31 +222,69 @@ def test_queue_play_delegates_and_consumes_item(monkeypatch) -> None:
         "https://example.com/a.mp4",
         "https://example.com/c.mp4",
     ]
-    assert len(play_now_requests) == 1
-    req = play_now_requests[0]
-    assert req.url == "https://example.com/b.mp4"
-    assert req.preserve_current is True
-    assert req.reason == "queue_play"
-    assert req.title == "B"
-    assert req.thumbnail == "https://example.com/b.jpg"
-    assert req.resume_pos == 8.5
-    assert req.history_id == "hist-b"
-    assert req.resolved_source_url == "https://example.com/watch-b"
-    assert req.resolved_stream == "https://cdn.example.com/b.mp4"
-    assert req.resolved_audio == "https://cdn.example.com/b.m4a"
-    assert req.resolved_at == 99.5
+    assert len(play_now_calls) == 1
+    item, kwargs = play_now_calls[0]
+    assert item == {
+        "url": "https://example.com/b.mp4",
+        "title": "B",
+        "thumbnail": "https://example.com/b.jpg",
+        "resume_pos": 8.5,
+        "history_id": "hist-b",
+        "_resolved_source_url": "https://example.com/watch-b",
+        "_resolved_stream": "https://cdn.example.com/b.mp4",
+        "_resolved_audio": "https://cdn.example.com/b.m4a",
+        "_resolved_at": 99.5,
+    }
+    assert kwargs == {
+        "request_url": "https://example.com/b.mp4",
+        "preserve_current": True,
+        "reason": "queue_play",
+        "title_hint": "B",
+        "resume_pos": 8.5,
+    }
     assert [event["action"] for event in events] == ["remove"]
     assert events[0]["queue_length"] == 2
+
+
+def test_queue_play_preserves_opaque_provider_metadata(monkeypatch) -> None:
+    client, _, _ = _client_with_queue_patches(monkeypatch)
+    queued = {
+        "url": "https://iptv.invalid/source-1/channel-1",
+        "title": "News",
+        "provider": "iptv",
+        "iptv_source_id": "source-1",
+        "iptv_channel_id": "channel-1",
+    }
+    routes.state.QUEUE[:] = [queued]
+    played: list[dict[str, object]] = []
+
+    monkeypatch.setattr(routes.playback_service, "suppress_auto_next", lambda _seconds: None)
+    monkeypatch.setattr(routes.playback_service, "preserve_current_to_queue_front", lambda: None)
+    monkeypatch.setattr(
+        routes.playback_service,
+        "play_now",
+        lambda item, **_kwargs: played.append(item) or {"url": item["url"], "title": item["title"]},
+    )
+    monkeypatch.setattr(routes, "_push_overlay_toast", lambda **_kwargs: None)
+
+    response = client.post("/queue/play", json={"index": 0})
+
+    assert response.status_code == 200
+    assert played == [queued]
+    assert played[0]["provider"] == "iptv"
+    assert played[0]["iptv_source_id"] == "source-1"
+    assert played[0]["iptv_channel_id"] == "channel-1"
+    assert routes.state.QUEUE == []
 
 
 def test_queue_play_restores_item_when_play_fails(monkeypatch) -> None:
     client, events, _ = _client_with_queue_patches(monkeypatch)
     _seed_playable_queue()
 
-    def _failing_play_now(req):
+    def _failing_play_now(_item, **_kwargs):
         raise HTTPException(status_code=400, detail="cannot resolve media")
 
-    monkeypatch.setattr(routes, "play_now", _failing_play_now)
+    monkeypatch.setattr(routes, "_play_now_item", _failing_play_now)
 
     response = client.post("/queue/play", json={"index": 1})
 

--- a/tests/test_queue_identity.py
+++ b/tests/test_queue_identity.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Queue identity must be assigned before concurrent readers can see entries."""
+import threading
+
+from relaytv_app import playback_service, player, routes, state
+
+
+def test_enqueue_publishes_identity_before_persistence(monkeypatch):
+    monkeypatch.setattr(state, "QUEUE", state._RevisionedQueue())
+    monkeypatch.setattr(player, "prefetch_queue_item_stream", lambda item: None)
+    monkeypatch.setattr(player, "prime_mpv_up_next_from_queue", lambda **kw: None)
+    entered, release = threading.Event(), threading.Event()
+    events = []
+    monkeypatch.setattr(routes, "_ui_event_push", lambda name, payload: events.append(payload))
+
+    def blocked_persist():
+        entered.set()
+        assert release.wait(5)
+
+    monkeypatch.setattr(state, "persist_queue", blocked_persist)
+    worker = threading.Thread(target=lambda: playback_service.queue_item(
+        {"url": "https://example.com/selected", "title": "Selected"}
+    ), daemon=True)
+    worker.start()
+    try:
+        assert entered.wait(5)
+        with state.QUEUE_LOCK:
+            snapshot = list(state.QUEUE)
+            before = state.queue_item_id(snapshot[0])
+        assert before, "An entry became visible before its id was assigned"
+        routes._ui_event_push_queue("add", queue=snapshot)
+        assert events[0]["queue"][0]["queue_id"] == before
+        assert state.queue_item_id(state.QUEUE[0]) == before
+    finally:
+        release.set()
+        worker.join(5)
+    assert not worker.is_alive()
+
+
+def test_event_serialization_never_assigns_ids_to_shared_items(monkeypatch):
+    item = {"url": "https://example.com/legacy", "title": "Legacy"}
+    original = dict(item)
+    events = []
+    monkeypatch.setattr(routes, "_ui_event_push", lambda name, payload: events.append(payload))
+    routes._ui_event_push_queue("add", queue=[item])
+    assert item == original
+    assert events and events[0]["queue"][0]["title"] == "Legacy"
+
+
+def test_inserting_duplicate_ahead_preserves_original_identity():
+    item = {"url": "https://example.com/same"}
+    queue = state._RevisionedQueue([item])
+    original_id = state.queue_item_id(item)
+    queue.insert(0, item)
+    assert queue[1] is item
+    assert state.queue_item_id(queue[1]) == original_id
+    assert state.queue_item_id(queue[0]) != original_id

--- a/tests/test_route_inventory.py
+++ b/tests/test_route_inventory.py
@@ -123,6 +123,7 @@ EXPECTED_ROUTES = {
     ("POST", "/queue/handoff", "queue_handoff"),
     ("POST", "/queue/import", "queue_import"),
     ("POST", "/queue/move", "queue_move"),
+    ("POST", "/queue/play", "queue_play"),
     ("POST", "/queue/remove", "queue_remove"),
     ("POST", "/resume", "resume"),
     ("POST", "/resume/clear", "clear_resumable_session"),

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -200,9 +200,9 @@ def test_ui_smoke() -> None:
     assert 'id="setYtUseInvidious"' in response.text
     assert 'id="setIdleQrEnabled"' in response.text
     assert 'id="setJfEnabled"' in response.text
-    assert 'id="setJfAuthMode"' in response.text
-    assert 'value="shared_api_key"' in response.text
-    assert 'value="user_login"' in response.text
+    assert 'id="setJfSharedCastEnabled"' in response.text
+    assert 'id="setJfClientHeading"' in response.text
+    assert 'id="setJfCastHeading"' in response.text
     assert 'id="setJfApiKey"' in response.text
     assert 'id="setJfClearApiKey"' in response.text
     assert js.count("payload.jellyfin_api_key = jfClearApiKey ? '' : jfApiKey;") == 2

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -208,6 +208,8 @@ def test_ui_smoke() -> None:
     assert js.count("payload.jellyfin_api_key = jfClearApiKey ? '' : jfApiKey;") == 2
     assert js.count("jellyfin_auth_mode: jfAuthMode") == 2
     assert 'id="setJfClearPassword"' in response.text
+    assert "menu.appendChild(_queueMenuItem('Remove'" in js
+    assert "qDelBtn" not in js
     assert 'id="setJfStatus" class="sectionStatus unknown">Disabled</span>' in response.text
     assert "castScope === 'shared' ? 'Shared Cast' : 'Cast Ready'" in js
     assert 'class="toggleSwitch"' in response.text

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -176,7 +176,10 @@ def test_ui_smoke() -> None:
     assert 'id="nHeroArt"' in response.text
     assert 'id="nowStateDot"' in response.text
     assert 'function _isNowPlayingLive(np)' in js
-    assert "const posTxt = liveNow ? 'LIVE' : fmtTime(st.position);" in js
+    assert "const posTxt = liveNow ? 'LIVE' : fmtTime((ended && st.position == null && resumePos != null) ? resumePos : st.position);" in js
+    assert 'id="nowUpNext"' in response.text
+    assert 'id="upNextPlayBtn"' in response.text
+    assert ".nowCard.isIdle .nIdleMsg{ display: block; }" in css
     assert ".nowCard.isLive .progress{ display: none; }" in css
     assert 'id="langBackdrop"' in response.text
     assert 'id="subLangBackdrop"' in response.text


### PR DESCRIPTION
## Summary

A full UX pass over the Web UI, reviewed live with headless Chromium against the running container (phone 390×844, desktop 1440×900, TV 1920×1080, dark + light) with the initial UX milestones and subsequent correctness fixes:

1. **Queue item action menu + `POST /queue/play`** — the tile ⋯ was a send-only shortcut; it is now a real menu (Play now / Send to device / Remove). Play-now uses a new stable-ID `/queue/play` route (legacy indexes remain supported) with the same preserve-current semantics as `/history/play`: the item is consumed only when the play is accepted and restored at its original position when it fails, unless a newer queue mutation superseded it.
2. **Undo remove + roomier queue rows** — Remove stays in the item action menu and goes through a 6s undo toast before hitting the server (no metadata loss, no new routes). The standalone red × is gone so titles and metadata get more room; remaining compact controls (queue item menu 28px, queue Send/Clear 26px, header chips 36px, volume slider 8px) move to 40px targets.
3. **Ended/idle now-playing states** — the card no longer sits with a stale thumbnail, dead `--:--` times, and live-looking controls after playback closes. It shows an Ended tag, the resume position on the times and progress bar, a Resume label on the play tile, and an Up-next strip with the queue head and a direct Play action. The idle card gets the same strip.
4. **Desktop queue + phone header** — wrap widens to 1080px with a 300px floor on the queue column; tile actions overlay on hover/focus instead of squeezing titles to 3 characters. On phones the Jellyfin/IPTV launchers collapse to the same icon-only chip Seerr used, giving the device name its space back.
5. **Local favicon letter tiles** — provider badges no longer come from `google.com/s2/favicons`; queued domains stay on the LAN. Brand colors for common providers, deterministic palette otherwise.
6. **Jellyfin, history, Seerr, idle dashboard** — search results are a vertical list with library hints (path-derived) so same-title duplicates are distinguishable; broken posters swap to titled tiles; episode details spell out "Resume 34:01" vs "Play from start"; the stray "Ready" text only speaks when degraded; history timestamps compact so the mode suffix survives (+ two-tap guard on Clear-all); Seerr "unknown" reads "Not requested" and the raw 10000-result count only shows for searches/requests; the idle dashboard footer says "Ended"/"Idle" instead of a stale "Now Playing" and ellipsizes clear of the QR card.
7. **Review follow-ups: provider metadata** — queue Play now carries the original server-built item into playback so persisted IPTV catalog references retain all provider metadata.
8. **Stable queue actions and race-safe rollback** — queued instances now receive persisted opaque IDs. Remove, Play now, drag reorder, and Send to device bind to those IDs instead of mutable positions while legacy index callers remain supported. A failed Play-now restores its item only when no newer queue action landed; a concurrent Clear, remove, move, add, or auto-next decision wins.
9. **Transfer completion and publication safety** — accepted queue IDs are removed together under the queue lock, with no URL fallback or check-then-clear shortcut. The send sheet submits explicit snapshot selectors and retains tile-specific scope as items arrive. Queue insertion assigns IDs before readers see entries; supplied event snapshots are read-only.
10. **Latest-action ownership** — canceled queue Play-now returns `409` and uses guarded restoration instead of losing the item. Peer handoff completion atomically checks playback generation before local teardown. Jellyfin preference lookups patch only still-current queue IDs/URLs, preserving concurrent queue and metadata edits. The latter two close pre-existing adjacent races found during follow-up review.
11. **Separate Jellyfin client login and shared casting** — Settings now exposes independent Client login and Shared cast target sections instead of an API-key-versus-login selector. Both credentials can be saved together. Local browsing uses the client session; incoming shared casts retain API-key media access. Separate device identities, request scopes, and catalog caches keep the two roles independent, including concurrent browsing and casting. Each section reports its own connection status.

## User impact

- Every finding from the UX review (#1–#12) is addressed: ended-state clarity, queue actions, undo, touch targets, desktop readability, header identity, favicon privacy, Jellyfin search/detail, history, Seerr, TV dashboard.
- Follow-up review fixes keep persisted IPTV entries playable, prevent delayed actions from sliding onto another queue item, stop failed playback from undoing a newer queue decision, and prevent transfer completion from deleting an unsent duplicate or widening a tile selection.
- Stop/Close during queued resolution no longer silently loses an unplayed item. Delayed handoffs leave replacement local playback untouched; audio/subtitle preference updates cannot restore an obsolete queue.
- Jellyfin login remains active while shared casting is enabled. Both Apply actions preserve blank stored secrets, validate incomplete login and missing cast keys, and honor explicit credential clearing. Existing login-only and API-only setups remain supported.
- New API: `POST /queue/play` (documented in `docs/API.md`, pinned in the route inventory).

## Operator/deployment impact

- No new config keys or env variables and no manual migration. Existing queue entries receive an opaque ID automatically on load/insertion; the queue JSON schema change is additive. The Google favicon dependency disappears (one less external call on the UI).
- When both Jellyfin credentials are stored, the previously inactive username/password now signs in for local browsing while the API key serves shared casting. A failed client login does not fall back to administrator catalog access. API-only catalog access remains available when login credentials are empty. `jellyfin_auth_mode` and the existing settings API remain compatible. The client login uses a separate `<device ID>-client` session while shared casting is enabled.

## Breaking changes

None.

## Tests run

- `ruff check app tests`
- `PYTHONPATH=app pytest -q` — 1,001 passed (includes real event-controlled `/queue/play` versus `/clear` interleaving, owned preserve/rollback, stable remove/move/send selection, ID persistence/uniqueness, provider-metadata passthrough, and legacy index compatibility)
- `node --test tests/js/*.test.js` — 38 passed (includes deferred-fetch interleavings proving delayed removal, Play-now, and drag requests publish stable queue targets)
- `node --check` on `app.js`, `peers.js`, `realtime_transport.js`, the x11 overlay inline script, plus the idle page inline script
- `git diff --check`
- Route inventory, transition inventory (regenerated `docs/TRANSITION_INVENTORY.md`), smoke pins updated
- All review regressions are revert-proven: flattening the queue item drops IPTV identifiers; removing client/server ID publication retargets B to C; removing ID persistence changes identity after reload; removing revision or conditional-rollback guards resurrects an item after Clear; and rejecting owned mutations prevents an ordinary failed Play-now from restoring its selected item
- New transfer/publication regressions are revert-proven: old cleanup deletes an unsent duplicate after a real blocked peer request; dropping insertion-time assignment exposes an idless entry; restoring event-time assignment mutates shared snapshot entries; omitting explicit selectors broadens the request; and removing tile scope selects a newly arrived item. The transfer test also covers additions while the accepted item remains queued.
- Latest-action regressions: real `/queue/play` resolution versus `/close` (with and without `/clear`); successful strict playback; blocked peer handoff with unchanged/replaced session; snapshot capture during generation change; teardown versus a new playback claim; and Jellyfin preference lookup versus queue replacement, reordering/metadata updates, and a newer URL. Reverting the strict outcome, generation guards, lock coverage, stale queue publish, and URL guard makes their tests fail.
- Live validation from earlier milestones on the running container (branch bind-mounted per `AGENTS.md`): real `/queue/play` playback with preserve-to-front, menu/Escape/outside-click, undo + timer remove, ended/idle states, desktop hover tiles, Jellyfin search list + library chips + poster fallback (with and without resume), history meta + clear guard, Seerr badges, idle dashboard states — zero console errors throughout
- Jellyfin settings regressions cover both Apply handlers, saved-secret preservation, explicit clear precedence, concurrent cast/client HTTP lookups, credential and cache isolation, and cleanup after failed authentication or command execution. Reintroducing exclusive auth, API fallback, shared login/catalog device IDs, stale tokens, unscoped cast lookups, shared caches, or missing scope cleanup makes the regression tests fail.
- Full Python suite and Ruff ran in a fresh `.[dev]` environment (Python 3.13, FastAPI 0.141.1). Headless Chromium checked the new settings at 390×844 and 1440×900 using current HTML/JS and mocked API responses: both sections remain visible, toggle/apply/reload preserves credentials and selection, no horizontal overflow or page errors.
- Latest follow-ups were validated locally with automated tests; they have not been redeployed or device-soaked in this pass. Handoff teardown now leaves remaining queue entries to the normal autoplay worker; local runtime teardown is protected by the playback-intent lock, but peer I/O and media resolution are not.

## Release highlight

Yes — this squash includes `docs/release-highlights/0.11.0.md`; release PR #89 renames it to `docs/release-highlights/0.10.3.md` so the patch release publishes it. The Jellyfin settings fix does not warrant an additional highlight heading.


BEGIN_COMMIT_OVERRIDE
fix: improve remote, queue, Jellyfin, and idle surfaces (#88)
END_COMMIT_OVERRIDE