### PR TITLE
fix: harden integration settings and playback

### DIFF
--- a/app/relaytv_app/integrations/jellyfin_receiver.py
+++ b/app/relaytv_app/integrations/jellyfin_receiver.py
@@ -1086,19 +1086,15 @@ def control_socket_identity_headers(status_snapshot: dict[str, object] | None = 
     """Identify the cast device during the websocket HTTP handshake.
 
     The socket URL carries the credential as ``?api_key=``, while this header
-    gives Jellyfin the configured display name. For a shared API-key session
-    this header stays token-free on purpose: Jellyfin deliberately owns that
-    session's client label (the API key name) and keeps it userless, and
-    including the token here would duplicate the secret and take that back.
+    gives Jellyfin the configured display name and the same credential.
 
     Some Jellyfin builds don't accept the query-string credential at all for
     ``/socket`` ("Token is required", even though the same token works fine
     on every REST endpoint) and only read it from this header's ``Token``
     component - the same header-only quirk already worked around for login
-    and catalog requests elsewhere in this module. A user-login session has
-    no shared label to protect, so it carries the token here to survive that
-    server behavior; a shared API-key session keeps relying on the query
-    string alone, preserving its existing anonymous-session behavior.
+    and catalog requests elsewhere in this module. Both supported auth modes
+    carry their selected control credential here so the cast target works on
+    those builds as well as servers that accept the query string.
     """
     st = status_snapshot if isinstance(status_snapshot, dict) else status()
 
@@ -1118,10 +1114,11 @@ def control_socket_identity_headers(status_snapshot: dict[str, object] | None = 
         f'DeviceId="{device_id}", '
         f'Version="{client_version}"'
     )
-    if str(st.get("auth_mode") or "").strip().lower() == "user_login":
-        token = str(_ACCESS_TOKEN or "").strip()
-        if token:
-            auth = f'{auth}, Token="{token}"'
+    auth_mode = str(st.get("auth_mode") or "").strip().lower()
+    with _LOCK:
+        token = str(_API_KEY if auth_mode == "shared_api_key" else _ACCESS_TOKEN).strip()
+    if token:
+        auth = f'{auth}, Token="{token}"'
     return {"Authorization": auth}
 
 

--- a/app/relaytv_app/player.py
+++ b/app/relaytv_app/player.py
@@ -4699,7 +4699,20 @@ def advance_queue_playback(
                     and isinstance(next_item, dict)
                     and str(next_item.get("provider") or "").strip().lower() == "iptv"
                 )
-                skip_unplayable = bot_check or post_live_processing or iptv_stale or (
+                plex_stale = False
+                if (
+                    isinstance(next_item, dict)
+                    and str(next_item.get("provider") or "").strip().lower() == "plex"
+                ):
+                    try:
+                        from .integrations.plex_client import PlexError
+
+                        plex_stale = isinstance(exc, PlexError) and int(
+                            getattr(exc, "status_code", 0) or 0
+                        ) == 404
+                    except Exception:
+                        plex_stale = False
+                skip_unplayable = bot_check or post_live_processing or iptv_stale or plex_stale or (
                     allow_skip_unplayable
                     and isinstance(exc, HTTPException)
                     and int(getattr(exc, "status_code", 0) or 0) == 400
@@ -6974,10 +6987,34 @@ def restart_current(apply_mode: str | None = None) -> dict | None:
             return None
         if not state.NOW_PLAYING:
             return None
-        inp = (state.NOW_PLAYING.get("input") or state.NOW_PLAYING.get("url") or "").strip()
+        current = dict(state.NOW_PLAYING)
+        inp = (current.get("input") or current.get("url") or "").strip()
         if not inp:
             return None
         target: object = inp
+        provider = str(current.get("provider") or "").strip().lower()
+        plex_restart = provider == "plex" and bool(
+            str(current.get("plex_item_id") or "").strip()
+        )
+        if plex_restart:
+            # Plex's loopback stream URL belongs to the current direct relay or
+            # transcode session. Replaying it after stop_mpv either loses the
+            # Plex identity or races the old response's cleanup and returns a
+            # 404. Keep the durable encrypted catalog references and let
+            # play_item resolve a fresh stream before replacing the old one.
+            target = current
+            target["input"] = "https://plex.invalid/item"
+            target["url"] = "https://plex.invalid/item"
+            for key in (
+                "stream",
+                "audio",
+                "http_headers",
+                "_resolved_source_url",
+                "_resolved_stream",
+                "_resolved_audio",
+                "_resolved_at",
+            ):
+                target.pop(key, None)
         if is_youtube_url(inp):
             # Resolve before stopping anything: a failed resolve (e.g. a
             # YouTube bot check right after cookies were removed) must leave
@@ -7030,7 +7067,8 @@ def restart_current(apply_mode: str | None = None) -> dict | None:
                 pos = mpv_get("time-pos")
         except Exception:
             pos = None
-        stop_mpv()
+        if not plex_restart:
+            stop_mpv()
         # Use settings-driven video mode by default; apply_mode can force x11/drm.
         if apply_mode:
             runtime_config.set_value("RELAYTV_VIDEO_MODE", apply_mode)

--- a/app/relaytv_app/routes/plex.py
+++ b/app/relaytv_app/routes/plex.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict
 
+from .. import state
 from ..integrations import plex_auth, plex_service
 from ..integrations.plex_client import PlexError
 
@@ -283,8 +284,28 @@ def plex_item_action(req: PlexItemActionReq, response: Response):
 @router.post("/integrations/plex/server")
 def plex_server_select(req: PlexServerSelectReq, response: Response):
     _no_store(response)
+    requested = str(req.machine_id or "").strip()
     try:
-        return {"server": plex_auth.auth_manager.select_server(req.machine_id)}
+        status = plex_auth.auth_manager.status()
+        selected = status.get("server") if isinstance(status.get("server"), dict) else {}
+        selected_machine_id = str(selected.get("machine_id") or "").strip()
+        active_plex = (
+            str(getattr(state, "SESSION_STATE", "idle") or "").strip().lower()
+            in {"playing", "paused"}
+            and isinstance(getattr(state, "NOW_PLAYING", None), dict)
+            and str(state.NOW_PLAYING.get("provider") or "").strip().lower() == "plex"
+        )
+        if active_plex:
+            if requested and requested == selected_machine_id:
+                return {"server": selected}
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "plex_playback_active",
+                    "message": "Stop Plex playback before changing the selected server",
+                },
+            )
+        return {"server": plex_auth.auth_manager.select_server(requested)}
     except PlexError as exc:
         raise _http_error(exc) from None
 

--- a/app/relaytv_app/routes/settings.py
+++ b/app/relaytv_app/routes/settings.py
@@ -5,7 +5,7 @@ import re
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from .. import player, state, upload_store, ytdlp_update
+from .. import player, public_media, state, upload_store, ytdlp_update
 from ..config import (
     SEERR_REQUEST_MODES,
     normalize_seerr_request_mode,
@@ -595,7 +595,7 @@ def update_settings(req: SettingsReq):
         "apply_performed": apply_performed,
         "apply_succeeded": apply_succeeded,
         "settings": _settings_for_client(updated),
-        "now_playing": now,
+        "now_playing": public_media.public_media_item(upload_store.annotate_item(now)),
         "live_applied": live_applied,
         "live_apply_failed": live_apply_failed,
         "restart_sensitive_pending": restart_sensitive_pending,

--- a/app/relaytv_app/routes/uploads.py
+++ b/app/relaytv_app/routes/uploads.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse
 from starlette.concurrency import run_in_threadpool
 
-from .. import player, playback_service, state, upload_store
+from .. import player, playback_service, public_media, state, upload_store
 from ..debug import get_logger
 
 
@@ -149,7 +149,14 @@ def _enqueue_uploaded_media_url(url: str) -> dict:
     except Exception:
         pass
     _ui_event_push_queue("add", queue=queue_snapshot, queue_length=qlen, source="ingest_media_enqueue")
-    return {"status": "queued", "item": item, "queue_length": qlen, "now_playing": state.NOW_PLAYING}
+    return {
+        "status": "queued",
+        "item": public_media.public_media_item(upload_store.annotate_item(item)),
+        "queue_length": qlen,
+        "now_playing": public_media.public_media_item(
+            upload_store.annotate_item(state.NOW_PLAYING)
+        ),
+    }
 
 
 @router.post("/ingest/media")

--- a/app/relaytv_app/static/ui/app.js
+++ b/app/relaytv_app/static/ui/app.js
@@ -2905,7 +2905,9 @@ function _renderPlexSettings(cur, plexStatus, plexServers){
       option.textContent = `${server.name || 'Plex Media Server'}${local ? ' · local' : ''}${server.owned ? ' · owned' : ''}`;
       serverSelect.appendChild(option);
     }
-    serverSelect.value = String((selected && selected.machine_id) || cur.plex_server_machine_id || '');
+    const selectedMachineId = String((selected && selected.machine_id) || cur.plex_server_machine_id || '');
+    serverSelect.value = selectedMachineId;
+    serverSelect.setAttribute('data-selected-machine-id', selectedMachineId);
   }
   const testBtn = document.getElementById('setPlexTestBtn');
   if (testBtn) testBtn.disabled = !selected;
@@ -3463,6 +3465,21 @@ function bindSettingsUi(){
     plexApplyMsg.textContent = text || '';
   }
 
+  async function selectPlexServerIfChanged(machineId){
+    const serverSelect = document.getElementById('setPlexServer');
+    const selectedMachineId = String(serverSelect?.getAttribute('data-selected-machine-id') || '').trim();
+    if (!machineId || machineId === selectedMachineId) return false;
+    const response = await fetch('/integrations/plex/server', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({machine_id:machineId}),
+    });
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(_plexErrorMessage(body, response.status));
+    if (serverSelect) serverSelect.setAttribute('data-selected-machine-id', machineId);
+    return true;
+  }
+
   async function applyPlexOnly(){
     const enabled = !!document.getElementById('setPlexEnabled')?.checked;
     const machineId = String(document.getElementById('setPlexServer')?.value || '').trim();
@@ -3472,6 +3489,7 @@ function bindSettingsUi(){
     if (plexTestBtn) plexTestBtn.disabled = true;
     setPlexMessage('Applying Plex settings…');
     try {
+      await selectPlexServerIfChanged(machineId);
       const settingsResponse = await fetch('/settings', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
@@ -3484,15 +3502,6 @@ function bindSettingsUi(){
       });
       const settingsBody = await settingsResponse.json().catch(() => ({}));
       if (!settingsResponse.ok) throw new Error(_plexErrorMessage(settingsBody, settingsResponse.status));
-      if (machineId) {
-        const serverResponse = await fetch('/integrations/plex/server', {
-          method:'POST',
-          headers:{'Content-Type':'application/json'},
-          body:JSON.stringify({machine_id:machineId}),
-        });
-        const serverBody = await serverResponse.json().catch(() => ({}));
-        if (!serverResponse.ok) throw new Error(_plexErrorMessage(serverBody, serverResponse.status));
-      }
       await loadSettingsUi();
       setPlexMessage(enabled ? 'Plex settings applied.' : 'Plex disabled.', 'ok');
       return true;
@@ -3732,6 +3741,7 @@ function bindSettingsUi(){
     const jfSubLang = (document.getElementById('setJfSubLang')?.value || '').trim().toLowerCase();
     const jfPlaybackMode = (document.getElementById('setJfPlaybackMode')?.value || 'auto').trim().toLowerCase();
     const plexEnabled = !!document.getElementById('setPlexEnabled')?.checked;
+    const plexMachineId = String(document.getElementById('setPlexServer')?.value || '').trim();
     const plexPlaybackMode = String(document.getElementById('setPlexPlaybackMode')?.value || 'auto').trim().toLowerCase();
     const plexMaxBitrate = Number(document.getElementById('setPlexMaxBitrate')?.value || '0');
     const seerrEnabled = !!document.getElementById('setSeerrEnabled')?.checked;
@@ -3818,6 +3828,12 @@ function bindSettingsUi(){
     if (jfPass || jfClearPw) payload.jellyfin_password = jfClearPw ? '' : jfPass;
     if (seerrApiKey) payload.seerr_api_key = seerrApiKey;
     if (seerrClearApiKey) payload.seerr_api_key_clear = true;
+    try {
+      await selectPlexServerIfChanged(plexMachineId);
+    } catch (error) {
+      alert(error && error.message ? error.message : 'Failed to select Plex server');
+      return;
+    }
     const r = await fetch('/settings', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
     if (!r.ok) {
       alert('Failed to save settings');

--- a/tests/js/plex_settings.test.js
+++ b/tests/js/plex_settings.test.js
@@ -52,6 +52,7 @@ function fixture(){
     window: {addEventListener(){}, relaytvSeerr:null},
     openSettings(){}, closeSettings(){}, loadSettingsUi: async() => {},
     syncJellyfinAuthModeUi(){}, syncSeerrRequestModeUi(){},
+    jellyfinCredentialsError: () => '',
     SETTINGS_TV_CONTROL_BASELINE: {}, WEATHER_LOCATION_STATE: {},
     collectIdlePanelSettings: () => ({}),
     alert(){},
@@ -87,7 +88,7 @@ test('Plex link start exposes the official authorization URL and polls its flow'
   assert.match(f.element('setPlexApplyResult').textContent, /account linked/i);
 });
 
-test('Apply Plex saves the enable switch and selected server separately', async() => {
+test('Apply Plex selects the server before applying restart-sensitive settings', async() => {
   const f = fixture();
   f.element('setPlexEnabled').checked = true;
   f.element('setPlexServer').value = 'server-1';
@@ -98,8 +99,28 @@ test('Apply Plex saves the enable switch and selected server separately', async(
 
   assert.equal(result, true);
   assert.deepEqual(f.requests, [
-    {url:'/settings', body:{plex_enabled:true, plex_playback_mode:'transcode', plex_max_bitrate:8000, apply_now:true}},
     {url:'/integrations/plex/server', body:{machine_id:'server-1'}},
+    {url:'/settings', body:{plex_enabled:true, plex_playback_mode:'transcode', plex_max_bitrate:8000, apply_now:true}},
   ]);
   assert.match(f.element('setPlexApplyResult').textContent, /settings applied/i);
+});
+
+test('main Settings save applies a changed Plex server selection', async() => {
+  const f = fixture();
+  f.element('setPlexEnabled').checked = true;
+  f.element('setPlexServer').setAttribute('data-selected-machine-id', 'server-old');
+  f.element('setPlexServer').value = 'server-new';
+  f.element('setPlexPlaybackMode').value = 'direct';
+  f.element('setPlexMaxBitrate').value = '12000';
+
+  await f.element('settingsSaveBtn').onclick();
+
+  assert.deepEqual(f.requests[0], {
+    url:'/integrations/plex/server',
+    body:{machine_id:'server-new'},
+  });
+  assert.equal(f.requests[1].url, '/settings');
+  assert.equal(f.requests[1].body.plex_enabled, true);
+  assert.equal(f.requests[1].body.plex_playback_mode, 'direct');
+  assert.equal(f.requests[1].body.plex_max_bitrate, 12000);
 });

--- a/tests/test_jellyfin_ws.py
+++ b/tests/test_jellyfin_ws.py
@@ -257,8 +257,8 @@ def test_socket_url_carries_the_token_and_device() -> None:
     assert jellyfin_ws.socket_url(server_url="http://jf.lan:8096", token="", device_id="d") == ""
 
 
-def test_socket_handshake_identifies_the_display_device_without_repeating_the_token(monkeypatch) -> None:
-    """API-key sockets otherwise inherit the server name and opaque DeviceId."""
+def test_socket_handshake_identifies_device_and_sends_shared_key_header(monkeypatch) -> None:
+    """Some Jellyfin servers accept websocket credentials only in the header."""
     seen: dict[str, object] = {}
 
     class _Conn:
@@ -286,8 +286,10 @@ def test_socket_handshake_identifies_the_display_device_without_repeating_the_to
             "device_name": "Living Room",
             "client_name": "RelayTV",
             "client_version": "1.0",
+            "auth_mode": "shared_api_key",
         },
     )
+    monkeypatch.setattr(jellyfin_receiver, "_API_KEY", "shared-api-key")
     monkeypatch.setattr(jellyfin_receiver, "control_token", lambda: "shared-api-key")
     monkeypatch.setattr(jellyfin_receiver, "invalidate_registration", lambda reason="": None)
 
@@ -303,10 +305,9 @@ def test_socket_handshake_identifies_the_display_device_without_repeating_the_to
     assert headers == {
         "Authorization": (
             'MediaBrowser Client="RelayTV", Device="Living%20Room", '
-            'DeviceId="relaytv-stable", Version="1.0"'
+            'DeviceId="relaytv-stable", Version="1.0", Token="shared-api-key"'
         )
     }
-    assert "shared-api-key" not in str(headers)
 
 
 def test_the_access_token_never_reaches_status_or_logs(caplog) -> None:

--- a/tests/test_plex_routes.py
+++ b/tests/test_plex_routes.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 from fastapi.testclient import TestClient
 
+from relaytv_app import state
 from relaytv_app.integrations import plex_auth, plex_service
 from relaytv_app.integrations.plex_client import PlexBinaryResponse, PlexStreamResponse
 from relaytv_app.main import create_app
@@ -88,6 +89,43 @@ def test_plex_errors_keep_upstream_secrets_out_of_route_response(monkeypatch) ->
         "message": "Plex authentication has expired; link the account again",
     }
     assert "498" not in response.text
+
+
+def test_plex_server_change_is_blocked_during_active_plex_playback(monkeypatch) -> None:
+    select_calls: list[str] = []
+    monkeypatch.setattr(
+        plex_auth.auth_manager,
+        "status",
+        lambda: {"server": {"machine_id": "server-1", "name": "Living Room"}},
+    )
+    monkeypatch.setattr(
+        plex_auth.auth_manager,
+        "select_server",
+        lambda machine_id: select_calls.append(machine_id) or {},
+    )
+    monkeypatch.setattr(state, "SESSION_STATE", "playing", raising=False)
+    monkeypatch.setattr(
+        state,
+        "NOW_PLAYING",
+        {"provider": "plex", "plex_item_id": "opaque-item"},
+        raising=False,
+    )
+    client = TestClient(create_app(testing=True))
+
+    unchanged = client.post(
+        "/integrations/plex/server",
+        json={"machine_id": "server-1"},
+    )
+    changed = client.post(
+        "/integrations/plex/server",
+        json={"machine_id": "server-2"},
+    )
+
+    assert unchanged.status_code == 200
+    assert unchanged.json()["server"]["machine_id"] == "server-1"
+    assert changed.status_code == 409
+    assert changed.json()["detail"]["code"] == "plex_playback_active"
+    assert select_calls == []
 
 
 def test_plex_catalog_routes_are_bounded_and_non_cacheable(monkeypatch) -> None:

--- a/tests/test_settings_routes.py
+++ b/tests/test_settings_routes.py
@@ -44,6 +44,43 @@ def test_get_settings_route_sanitizes_secret_values(monkeypatch, tmp_path) -> No
     assert body["idle_notifications_enabled"] is True
 
 
+def test_settings_apply_response_sanitizes_restarted_media(monkeypatch) -> None:
+    current = {"volume": 50}
+    restarted = {
+        "url": "https://jellyfin.example/Videos/item?api_key=now-secret",
+        "provider": "jellyfin",
+        "title": "Movie",
+        "_resolved_stream": "https://jellyfin.example/stream?api_key=stream-secret",
+        "http_headers": {"X-Emby-Token": "header-secret"},
+    }
+
+    def update(patch):
+        current.update(patch)
+        return dict(current)
+
+    monkeypatch.setattr(routes.state, "SESSION_STATE", "playing", raising=False)
+    monkeypatch.setattr(routes.state, "NOW_PLAYING", dict(restarted), raising=False)
+    monkeypatch.setattr(routes.state, "get_settings", lambda: dict(current))
+    monkeypatch.setattr(routes.state, "update_settings", update)
+    monkeypatch.setattr(routes.player, "is_playing", lambda: True)
+    monkeypatch.setattr(routes.player, "restart_current", lambda: dict(restarted))
+
+    response = TestClient(create_app(testing=True)).post(
+        "/settings",
+        json={"volume": 60, "apply_now": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["now_playing"] == {
+        "url": "https://jellyfin.example/Videos/item",
+        "provider": "jellyfin",
+        "title": "Movie",
+    }
+    assert "now-secret" not in response.text
+    assert "stream-secret" not in response.text
+    assert "header-secret" not in response.text
+
+
 def test_seerr_api_key_is_write_only_and_requires_explicit_clear(monkeypatch) -> None:
     current = {
         "seerr_enabled": True,

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4196,6 +4196,52 @@ def test_restart_current_non_youtube_does_not_preresolve(monkeypatch: pytest.Mon
     assert played == ['https://example.com/movie.mp4']
 
 
+def test_restart_current_reresolves_plex_from_durable_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    played: list[dict[str, object]] = []
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'playing', raising=False)
+    monkeypatch.setattr(
+        player.state,
+        'NOW_PLAYING',
+        {
+            'input': 'http://127.0.0.1:8787/plex/stream/old-session',
+            'url': 'http://127.0.0.1:8787/plex/stream/old-session',
+            'title': 'Plex Movie',
+            'provider': 'plex',
+            'plex_item_id': 'opaque-item-ref',
+            'plex_part_id': 'opaque-part-ref',
+            '_resolved_stream': 'http://127.0.0.1:8787/plex/stream/old-session',
+            'http_headers': {'X-Plex-Token': 'secret'},
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(player, 'is_playing', lambda: True)
+    monkeypatch.setattr(player, 'mpv_get', lambda prop: 42.5)
+    monkeypatch.setattr(
+        player,
+        'stop_mpv',
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError('Plex must resolve its replacement before stopping')
+        ),
+    )
+
+    def fake_play(item, **kwargs):
+        played.append({'item': dict(item), **kwargs})
+        return {'provider': 'plex', 'plex_item_id': item['plex_item_id']}
+
+    monkeypatch.setattr(player, 'play_item', fake_play)
+
+    result = player.restart_current()
+
+    assert result == {'provider': 'plex', 'plex_item_id': 'opaque-item-ref'}
+    assert played[0]['item']['provider'] == 'plex'
+    assert played[0]['item']['plex_item_id'] == 'opaque-item-ref'
+    assert played[0]['item']['plex_part_id'] == 'opaque-part-ref'
+    assert played[0]['item']['url'] == 'https://plex.invalid/item'
+    assert '_resolved_stream' not in played[0]['item']
+    assert 'http_headers' not in played[0]['item']
+    assert played[0]['start_pos'] == 42.5
+
+
 def _patch_resolver_ytdlp_env(monkeypatch: pytest.MonkeyPatch, stdout: str) -> list[list[str]]:
     calls: list[list[str]] = []
 
@@ -6459,6 +6505,51 @@ def test_auto_next_skips_stale_iptv_channel_instead_of_blocking(monkeypatch: pyt
     result = player.advance_queue_playback(mode='auto_next', prefer_playlist_next=False)
 
     # The stale IPTV item is skipped (not re-queued) so autoplay is not blocked.
+    assert result['status'] == 'playing_next'
+    assert result['skipped_unplayable'] == 1
+    assert play_calls == [good_item]
+    assert player.state.QUEUE == []
+
+
+@pytest.mark.parametrize('mode', ['auto_next', 'next'])
+def test_queue_advance_skips_stale_plex_item_in_every_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+) -> None:
+    from relaytv_app.integrations.plex_client import PlexError
+
+    play_calls: list[dict] = []
+    stale_plex = {
+        'url': 'https://plex.invalid/item',
+        'title': 'Deleted Plex title',
+        'provider': 'plex',
+        'plex_item_id': 'opaque-deleted-ref',
+    }
+    good_item = {'url': 'https://example.com/good.mp4', 'title': 'Good'}
+
+    monkeypatch.setattr(player.state, 'NOW_PLAYING', None, raising=False)
+    monkeypatch.setattr(player.state, 'QUEUE', [stale_plex, good_item], raising=False)
+    monkeypatch.setattr(player.state, 'SESSION_STATE', 'playing', raising=False)
+    monkeypatch.setattr(player.state, 'AUTO_NEXT_SUPPRESS_UNTIL', 0.0, raising=False)
+    monkeypatch.setattr(player.state, 'persist_queue_payload', lambda payload: None)
+    monkeypatch.setattr(player, 'update_history_progress', lambda *args, **kwargs: None)
+    monkeypatch.setattr(player, '_emit_jellyfin_stopped_from_now', lambda now: None)
+    monkeypatch.setattr(player, '_emit_plex_timeline_from_now', lambda now, state_name: None)
+
+    def fake_play(item, **kwargs):
+        if item is stale_plex:
+            raise PlexError(
+                'plex_item_not_found',
+                'The Plex item is no longer available',
+                status_code=404,
+            )
+        play_calls.append(dict(item))
+        return {'url': item['url']}
+
+    monkeypatch.setattr(player, 'play_item', fake_play)
+
+    result = player.advance_queue_playback(mode=mode, prefer_playlist_next=False)
+
     assert result['status'] == 'playing_next'
     assert result['skipped_unplayable'] == 1
     assert play_calls == [good_item]

--- a/tests/test_upload_routes.py
+++ b/tests/test_upload_routes.py
@@ -17,7 +17,17 @@ def test_ingest_media_enqueue_route_uploads_and_queues(monkeypatch, tmp_path) ->
     monkeypatch.setenv("RELAYTV_UPLOADS_DIR", str(uploads_dir))
     monkeypatch.setattr(upload_store, "_UPLOADS_ROOT", str(uploads_dir), raising=False)
     monkeypatch.setattr(routes.state, "QUEUE", [], raising=False)
-    monkeypatch.setattr(routes.state, "NOW_PLAYING", {"url": "https://example.com/current.mp4"}, raising=False)
+    monkeypatch.setattr(
+        routes.state,
+        "NOW_PLAYING",
+        {
+            "url": "https://jellyfin.example/Videos/current?api_key=now-secret",
+            "provider": "jellyfin",
+            "_resolved_stream": "https://jellyfin.example/stream?api_key=stream-secret",
+            "http_headers": {"X-Emby-Token": "header-secret"},
+        },
+        raising=False,
+    )
     monkeypatch.setattr(routes.state, "persist_queue", lambda: persist_calls.append(True))
     monkeypatch.setattr(routes.player, "prefetch_queue_item_stream", lambda item: prefetch_calls.append(dict(item)))
     monkeypatch.setattr(routes.player, "prime_mpv_up_next_from_queue", lambda force=False: prime_calls.append(bool(force)))
@@ -37,6 +47,10 @@ def test_ingest_media_enqueue_route_uploads_and_queues(monkeypatch, tmp_path) ->
     assert body["item"]["provider"] == "upload"
     assert body["result"]["status"] == "queued"
     assert body["result"]["queue_length"] == 1
+    assert body["result"]["now_playing"]["url"] == "https://jellyfin.example/Videos/current"
+    assert "now-secret" not in response.text
+    assert "stream-secret" not in response.text
+    assert "header-secret" not in response.text
     assert routes.state.QUEUE[0]["provider"] == "upload"
     assert persist_calls == [True]
     assert prefetch_calls[0]["provider"] == "upload"


### PR DESCRIPTION
Integration settings could restart Plex from an expired loopback stream, the main Save action ignored a changed Plex server, and deleted Plex items could block queue advancement. Shared-key Jellyfin cast sockets also depended on query-string authentication, while two response paths could expose private media fields.

## User impact

- Settings restarts now re-resolve Plex playback from its durable catalog identity while keeping the current stream alive until the replacement is ready.
- Both Plex Apply and the main Settings Save apply a changed server selection. Server changes are rejected while Plex is actively playing so an in-flight stream is not invalidated.
- Deleted Plex items are skipped during automatic and manual queue advancement.
- Shared API-key Jellyfin cast targets send the credential in the websocket authorization header for header-only servers.
- Settings apply and upload enqueue responses now use the standard public-media redaction boundary.

## Operator/deployment impact

None. No configuration or migration is required.

## Breaking changes

None.

## Tests run

- `ruff check app tests`
- `PYTHONPATH=app pytest -q` (1,134 passed)
- `git diff --check`
- `node --check app/relaytv_app/static/ui/app.js`
- `node --check app/relaytv_app/static/ui/realtime_transport.js`
- extracted X11 overlay script through `node --check -`
- `node --test tests/js/*.test.js` (54 passed)
- Revert-proof checks for each lifecycle and response/authentication boundary regression

## Release highlight

No dedicated highlight file. This is a correctness and response-hardening fix suited to the generated changelog entry.
