### PR TITLE
docs: add 0.11.0 release highlight

### DIFF
--- a/docs/release-highlights/0.11.0.md
+++ b/docs/release-highlights/0.11.0.md
@@ -1,0 +1,10 @@
+## 🎬 New: browse and play Plex libraries
+
+RelayTV can now securely link your Plex account, connect to a library server,
+and bring Plex Home, movie and TV libraries, search, seasons, and episodes into
+the same phone remote. Choose a version, audio track, and subtitles, then play
+from the beginning, resume, or add it to the queue with Automatic, Direct play,
+and Always transcode modes; setup and troubleshooting are covered in
+[Plex operations](https://github.com/mcgeezy/relaytv/blob/main/docs/PLEX_OPERATIONS.md).
+
+---


### PR DESCRIPTION
The planned `0.11.0` release introduces Plex integration but currently has no release highlight, so the public GitHub Release would jump directly from the hero image to generated changelog bullets. This adds the required short Plex lead-in at `docs/release-highlights/0.11.0.md` for the release workflow to prepend when `v0.11.0` is published.

## User impact

The public `0.11.0` release notes will introduce Plex account linking, library browsing, search, version and track selection, resume, queueing, and playback modes before the generated feature and fix list.

## Operator/deployment impact

None.

## Breaking changes

None.

## Tests run

- `ruff check app tests`
- `PYTHONPATH=app pytest -q` (1,134 passed)
- `git diff --check`
- `node --check app/relaytv_app/static/ui/app.js`
- `node --check app/relaytv_app/static/ui/realtime_transport.js`
- extracted X11 overlay script through `node --check -`
- `node --test tests/js/*.test.js` (54 passed)

## Release highlight

Yes. This PR adds the missing `0.11.0` highlight itself.
